### PR TITLE
Rebuilds side pane UI to fix underlaps, etc.

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -3,14 +3,6 @@
 @tailwind utilities;
 
 @layer components {
-	.scroll-hidden {
-		-ms-overflow-style: none; /* Internet Explorer 10+ */
-		scrollbar-width: none; /* Firefox */
-	}
-	.scroll-hidden::-webkit-scrollbar {
-		display: none; /* Safari and Chrome */
-	}
-
 	.h1 {
 		@apply mb-4 text-2xl font-semibold text-gray-900 dark:text-gray-300;
 	}
@@ -21,5 +13,9 @@
 
 	.h3 {
 		@apply mb-2 text-lg font-semibold dark:text-white;
+	}
+
+	.modal-pane {
+		@apply rounded-lg border-gray-500 bg-white/90 px-4 shadow-lg dark:bg-black dark:text-white dark:shadow-lg dark:shadow-gray-200/10;
 	}
 }

--- a/src/assets/styles/leaflet-map.css
+++ b/src/assets/styles/leaflet-map.css
@@ -1,9 +1,9 @@
 .leaflet-touch {
 	.leaflet-bar {
 		position: absolute;
-		bottom: 6px;
+		bottom: 64px;
 		padding: 0px;
-		right: 0px;
+		right: -1px;
 
 		.leaflet-control-zoom-in,
 		.leaflet-control-zoom-out {

--- a/src/components/navigation/ModalPane.svelte
+++ b/src/components/navigation/ModalPane.svelte
@@ -6,8 +6,6 @@
 	import { createEventDispatcher } from 'svelte';
 	import { pushState } from '$app/navigation';
 
-	export let stop = null;
-
 	const dispatch = createEventDispatcher();
 
 	function closePane() {
@@ -17,8 +15,7 @@
 </script>
 
 <div
-	class="modal-pane scroll-hidden"
-	style={stop ? 'z-index: 40' : 'z-index: 20'}
+	class="modal-pane pointer-events-auto rounded-b-none px-4"
 	in:fly={{ y: 200, duration: 500 }}
 	out:fly={{ y: 200, duration: 500 }}
 >
@@ -40,15 +37,6 @@
 </div>
 
 <style lang="postcss">
-	.modal-pane {
-		@apply absolute bottom-0 left-0 max-h-[40rem] w-[25em] overflow-y-scroll bg-transparent px-2 shadow-lg md:w-full md:max-w-prose lg:w-full;
-		@apply rounded-lg border-b-[1px] border-[#C6C6C8] bg-[#F3F2F8] dark:border-[1px] dark:border-[#C6C6C8] dark:border-opacity-15 dark:bg-neutral-800;
-	}
-
-	.modal-content {
-		max-height: calc(100vh - 6.6em);
-	}
-
 	.close-button {
 		@apply rounded px-4 py-2;
 		@apply transition duration-300 ease-in-out hover:bg-neutral-200 dark:hover:bg-neutral-200/50;

--- a/src/components/navigation/ViewAllRoutesModal.svelte
+++ b/src/components/navigation/ViewAllRoutesModal.svelte
@@ -75,7 +75,7 @@
 			<h1 class="mb-6 text-center text-2xl font-bold text-white">{$t('search.all_routes')}</h1>
 		</div>
 
-		<div class="p-4">
+		<div class="mt-4">
 			<div class="relative mb-4">
 				<input
 					type="text"

--- a/src/components/search/SearchPane.svelte
+++ b/src/components/search/SearchPane.svelte
@@ -11,6 +11,8 @@
 
 	const dispatch = createEventDispatcher();
 
+	export let cssClasses = '';
+
 	let routes = null;
 	let stops = null;
 	let location = null;
@@ -105,9 +107,7 @@
 	});
 </script>
 
-<div
-	class="bg-blur-sm flex w-96 justify-between rounded-lg border-gray-500 bg-white/90 px-4 shadow-lg dark:bg-black dark:text-white dark:shadow-lg dark:shadow-gray-200/10"
->
+<div class={`modal-pane flex w-96 justify-between ${cssClasses}`}>
 	<div class="flex w-full flex-col gap-y-2 py-4">
 		<SearchField value={query} on:searchResults={handleSearchResults} />
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,11 +7,9 @@
 	config.autoAddCss = false; // Tell Font Awesome to skip adding the CSS automatically since it's being imported above
 </script>
 
-<div class="relative h-dvh w-full">
-	<div class="fixed w-full">
-		<Header />
-	</div>
-	<div class="h-[100vh] overflow-hidden">
+<div class="flex h-dvh w-full flex-col">
+	<Header />
+	<div class="relative flex-1 overflow-hidden">
 		<slot></slot>
 	</div>
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,5 @@
 <script>
 	import { pushState } from '$app/navigation';
-	import Header from '$components/navigation/Header.svelte';
 	import SearchPane from '$components/search/SearchPane.svelte';
 	import ModalPane from '$components/navigation/ModalPane.svelte';
 	import StopPane from '$components/oba/StopPane.svelte';
@@ -113,42 +112,42 @@
 {#if $isLoading}
 	<p>Loading...</p>
 {:else}
-	<div class="absolute left-0 right-0 top-0 z-40">
-		<Header />
-
-		<div class="ml-4 mt-4 md:w-64">
+	<div class="pointer-events-none absolute bottom-0 left-0 right-0 top-0 z-40">
+		<div class="ml-4 mt-4 flex h-full w-full flex-col md:w-96">
 			<SearchPane
 				{mapProvider}
+				cssClasses="pointer-events-auto"
 				on:routeSelected={handleRouteSelected}
 				on:clearResults={clearPolylines}
 				on:viewAllRoutes={handleShowAllRoutes}
 			/>
+			<div class="mt-2">
+				{#if stop}
+					<ModalPane on:close={closePane}>
+						<StopPane
+							{showAllStops}
+							{stop}
+							on:tripSelected={tripSelected}
+							on:updateRouteMap={handleUpdateRouteMap}
+							on:showAllStops={handleShowAllStops}
+						/>
+					</ModalPane>
+				{/if}
+
+				{#if showRouteModal}
+					<ModalPane on:close={closePane}>
+						<RouteModal {mapProvider} {stops} {selectedRoute} />
+					</ModalPane>
+				{/if}
+
+				{#if showAllRoutesModal}
+					<ModalPane on:close={closePane}>
+						<ViewAllRoutesModal on:routeSelected={handleRouteSelectedFromModal} />
+					</ModalPane>
+				{/if}
+			</div>
 		</div>
 	</div>
-
-	{#if stop}
-		<ModalPane on:close={closePane} {stop}>
-			<StopPane
-				{showAllStops}
-				{stop}
-				on:tripSelected={tripSelected}
-				on:updateRouteMap={handleUpdateRouteMap}
-				on:showAllStops={handleShowAllStops}
-			/>
-		</ModalPane>
-	{/if}
-
-	{#if showRouteModal}
-		<ModalPane on:close={closePane}>
-			<RouteModal {mapProvider} {stops} {selectedRoute} />
-		</ModalPane>
-	{/if}
-
-	{#if showAllRoutesModal}
-		<ModalPane on:close={closePane}>
-			<ViewAllRoutesModal on:routeSelected={handleRouteSelectedFromModal} />
-		</ModalPane>
-	{/if}
 
 	<MapContainer
 		{selectedTrip}


### PR DESCRIPTION
Fixes #71

The modal pane was feeling a bit wide, and looked a bit strange with its margins not lining up with the search box. This change reconsiders how we render the search box and modals to make them 'physically' smaller and feel more connected to the rest of the UI.

* Get rid of an extra header element on the map — now we only have the single header on the layout page
* Judiciously use `.pointer-events-none` to make large swaths of our UI clickable that had not been before
* Unify/DRY up our modal pane styling so that the search pane and modal panes look similar