### PR TITLE
Disable top-level await to fix the site in Safari

### DIFF
--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -1,21 +1,24 @@
-import { init, register, getLocaleFromNavigator } from 'svelte-i18n';
+import { init, addMessages, getLocaleFromNavigator } from 'svelte-i18n';
 
-async function setup() {
-	register('en', () => import('./../locales/en.json')); // English
-	register('es', () => import('./../locales/es.json')); // Spanish
-	register('pl', () => import('./../locales/pl.json')); // Polish
-	register('vi', () => import('./../locales/vi.json')); // Vietnamese
-	register('tl', () => import('./../locales/tl.json')); // Tagalog
-	register('so', () => import('./../locales/so.json')); // Somali
-	register('am', () => import('./../locales/am.json')); // Amharic
-	register('ar', () => import('./../locales/ar.json')); // Arabic
+import amharic from '../locales/am.json';
+import arabic from '../locales/ar.json';
+import english from '../locales/en.json';
+import spanish from '../locales/es.json';
+import polish from '../locales/pl.json';
+import somali from '../locales/so.json';
+import tagalog from '../locales/tl.json';
+import vietnamese from '../locales/vi.json';
 
-	return await Promise.allSettled([
-		init({
-			fallbackLocale: 'en',
-			initialLocale: getLocaleFromNavigator()
-		})
-	]);
-}
+addMessages('am', amharic);
+addMessages('ar', arabic);
+addMessages('en', english);
+addMessages('es', spanish);
+addMessages('pl', polish);
+addMessages('so', somali);
+addMessages('tl', tagalog);
+addMessages('vi', vietnamese);
 
-await setup();
+init({
+	fallbackLocale: 'en',
+	initialLocale: getLocaleFromNavigator()
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,10 +5,5 @@ export default defineConfig({
 	plugins: [sveltekit()],
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}']
-	},
-	esbuild: {
-		supported: {
-			'top-level-await': true
-		}
 	}
 });


### PR DESCRIPTION
Fixes #150

* I'm not sure why this is necessary, as this feature is supposed to work in Safari, but... it doesn't. So, I'm disabling it for now.
* Move back to synchronous loading of locales in i18n.js to unbreak the standalone schedule and stop pages.