### PR TITLE
Fix Dark mode styling for /stop/[stopid]

### DIFF
--- a/src/components/schedule-for-stop/RouteScheduleTable.svelte
+++ b/src/components/schedule-for-stop/RouteScheduleTable.svelte
@@ -27,34 +27,43 @@
 	}
 </script>
 
-<div class="overflow-x-auto">
-	<table class="mt-4 w-full table-auto rounded-lg border border-gray-200 shadow-lg">
-		<thead class="bg-gray-100 text-gray-800">
+<div class="overflow-x-auto dark:bg-black">
+	<table
+		class="mt-4 w-full table-auto rounded-lg border border-gray-200 shadow-lg dark:border-gray-700 dark:bg-black"
+	>
+		<thead class="bg-gray-100 text-gray-800 dark:bg-gray-900">
 			<tr>
-				<th class="cursor-pointer px-6 py-3 text-left">{$t('schedule_for_stop.hour')}</th>
-				<th class="cursor-pointer px-6 py-3 text-left">{$t('schedule_for_stop.minutes')}</th>
+				<th class="cursor-pointer px-6 py-3 text-left dark:text-white"
+					>{$t('schedule_for_stop.hour')}</th
+				>
+				<th class="cursor-pointer px-6 py-3 text-left dark:text-white"
+					>{$t('schedule_for_stop.minutes')}</th
+				>
 			</tr>
 		</thead>
 		<tbody>
-			<tr class="bg-gray-50 hover:bg-gray-100">
-				<td colspan="2" class="px-6 py-3 font-semibold text-gray-700">AM</td>
+			<tr class="bg-gray-50 hover:bg-gray-100 dark:hover:bg-gray-600">
+				<td
+					colspan="2"
+					class="px-6 py-3 font-semibold text-gray-700 dark:bg-gray-800 dark:text-white">AM</td
+				>
 			</tr>
 			{#if renderScheduleTable(schedule).amTimes.length === 0}
 				<tr>
-					<td colspan="2" class="border px-6 py-3 text-center text-gray-500">
+					<td colspan="2" class="border px-6 py-3 text-center text-gray-500 dark:border-gray-700">
 						{$t('schedule_for_stop.no_am_schedules_available')}
 					</td>
 				</tr>
 			{:else}
 				{#each renderScheduleTable(schedule).amTimes as [hour, times]}
-					<tr class="hover:bg-gray-100">
+					<tr class="hover:bg-gray-100 dark:hover:bg-gray-900">
 						<td
-							class="border px-6 py-3 text-center text-lg font-semibold"
+							class="border px-6 py-3 text-center text-lg font-semibold dark:border-gray-700 dark:text-white"
 							title="Full Time: {hour}:{extractMinutes(times[0].arrivalTime)}"
 						>
-							{formatHour(hour)} <span class="text-sm text-gray-600">AM</span>
+							{formatHour(hour)} <span class="text-sm text-gray-600 dark:text-gray-100">AM</span>
 						</td>
-						<td class="border px-6 py-3 text-lg">
+						<td class="border px-6 py-3 text-lg dark:border-gray-700 dark:text-white">
 							{#each times as stopTime, index (index)}
 								<span>
 									{extractMinutes(stopTime.arrivalTime)}
@@ -66,8 +75,11 @@
 				{/each}
 			{/if}
 
-			<tr class="bg-gray-50 hover:bg-gray-100">
-				<td colspan="2" class="px-6 py-3 font-semibold text-gray-700">PM</td>
+			<tr class="bg-gray-50 hover:bg-gray-100 dark:hover:bg-gray-900">
+				<td
+					colspan="2"
+					class="px-6 py-3 font-semibold text-gray-700 dark:bg-gray-800 dark:text-white">PM</td
+				>
 			</tr>
 			{#if renderScheduleTable(schedule).pmTimes.length === 0}
 				<tr>
@@ -77,14 +89,14 @@
 				</tr>
 			{:else}
 				{#each renderScheduleTable(schedule).pmTimes as [hour, times]}
-					<tr class="hover:bg-gray-100">
+					<tr class="hover:bg-gray-100 dark:hover:bg-gray-800">
 						<td
-							class="border px-6 py-3 text-center text-lg font-semibold"
+							class="border px-6 py-3 text-center text-lg font-semibold dark:border-gray-700 dark:text-white"
 							title="Full Time: {hour}:{extractMinutes(times[0].arrivalTime)}"
 						>
-							{formatHour(hour)} <span class="text-sm text-gray-600">PM</span>
+							{formatHour(hour)} <span class="text-sm text-gray-600 dark:text-gray-100">PM</span>
 						</td>
-						<td class="border px-6 py-3 text-lg">
+						<td class="border px-6 py-3 text-lg dark:border-gray-700 dark:text-white">
 							{#each times as stopTime, index (index)}
 								<span>
 									{extractMinutes(stopTime.arrivalTime)}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -28,7 +28,7 @@
 
 <div class="flex h-dvh w-full flex-col">
 	<Header />
-	<div class="relative flex-1 overflow-hidden">
+	<div class="relative flex-1 overflow-hidden dark:bg-black">
 		{@render children?.()}
 	</div>
 </div>

--- a/src/routes/stops/[stopID]/schedule/+page.svelte
+++ b/src/routes/stops/[stopID]/schedule/+page.svelte
@@ -157,9 +157,11 @@
 					</div>
 				</div>
 
-				<div class="flex-1 rounded-lg border border-gray-200 bg-white p-6">
+				<div
+					class="flex-1 rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-black"
+				>
 					{#if emptySchedules}
-						<p class="text-center text-gray-700">
+						<p class="text-center text-gray-700 dark:text-gray-400">
 							{$t('schedule_for_stop.no_schedules_available')}
 						</p>
 					{:else}


### PR DESCRIPTION
This addresses the following issues: #145, #146, #147 
Dark mode was not being rendered correctly when enabled. This adds TailwindCSS styling.

The shades of gray and white are not very formulaic but I went with what "looked right". Might be worth discussing some pre-defined colors for both light and dark so we don't continue to choose from every color option available.

<img width="1362" alt="Screenshot 2025-01-07 at 20 25 18" src="https://github.com/user-attachments/assets/0bca22d8-cf71-46bd-9784-fa8cd2458f3d" />

<img width="1318" alt="Screenshot 2025-01-07 at 20 42 00" src="https://github.com/user-attachments/assets/ec0fbe96-b0eb-4090-bd05-141cf6a074c3" />


