### PR TITLE
Open stop information on click in route modal, add button to open stop modal

### DIFF
--- a/src/components/MapContainer.svelte
+++ b/src/components/MapContainer.svelte
@@ -9,12 +9,12 @@
 	import { onMount } from 'svelte';
 	import { MapSource } from './../config/mapSource.js';
 
-	let apiKey = env.GOOGLE_MAPS_API_KEY;
+	let apiKey = env.PUBLIC_OBA_GOOGLE_MAPS_API_KEY;
 	let { handleStopMarkerSelect, mapProvider = $bindable(), ...restProps } = $props();
 
 	onMount(() => {
 		if (PUBLIC_OBA_MAP_PROVIDER === MapSource.Google) {
-			mapProvider = new GoogleMapProvider(apiKey);
+			mapProvider = new GoogleMapProvider(apiKey, handleStopMarkerSelect);
 		} else if (PUBLIC_OBA_MAP_PROVIDER === MapSource.OpenStreetMap) {
 			mapProvider = new OpenStreetMapProvider(handleStopMarkerSelect);
 		} else {

--- a/src/components/MapContainer.svelte
+++ b/src/components/MapContainer.svelte
@@ -16,7 +16,7 @@
 		if (PUBLIC_OBA_MAP_PROVIDER === MapSource.Google) {
 			mapProvider = new GoogleMapProvider(apiKey);
 		} else if (PUBLIC_OBA_MAP_PROVIDER === MapSource.OpenStreetMap) {
-			mapProvider = new OpenStreetMapProvider(apiKey);
+			mapProvider = new OpenStreetMapProvider(handleStopMarkerSelect);
 		} else {
 			console.error('Unknown map provider:');
 		}

--- a/src/components/map/PopupContent.svelte
+++ b/src/components/map/PopupContent.svelte
@@ -7,16 +7,17 @@
 	<p class="mt-2 flex items-center text-gray-700">
 		<span class="mr-2 rounded-md bg-purple-600 px-2 py-1 text-white">Arrival time:</span>
 		<span
-		>{new Date(arrivalTime * 1000).toLocaleTimeString([], {
-			hour: '2-digit',
-			minute: '2-digit'
-		})}</span>
+			>{new Date(arrivalTime * 1000).toLocaleTimeString([], {
+				hour: '2-digit',
+				minute: '2-digit'
+			})}</span
+		>
 	</p>
 	<div class="mt-auto flex justify-end">
 		<button
-				type="button"
-				class="inline-block rounded-lg border border-brand bg-brand px-3 py-1 text-sm font-medium text-white shadow-md transition duration-200 ease-in-out hover:bg-brand-secondary"
-				onclick={handleStopMarkerSelect}
+			type="button"
+			class="inline-block rounded-lg border border-brand bg-brand px-3 py-1 text-sm font-medium text-white shadow-md transition duration-200 ease-in-out hover:bg-brand-secondary"
+			onclick={handleStopMarkerSelect}
 		>
 			{'view stop'}
 		</button>

--- a/src/components/map/PopupContent.svelte
+++ b/src/components/map/PopupContent.svelte
@@ -1,5 +1,5 @@
 <script>
-	let { stopName, arrivalTime } = $props();
+	let { stopName, arrivalTime, handleStopMarkerSelect } = $props();
 </script>
 
 <div class="transform rounded-lg bg-white p-4 shadow-lg">
@@ -7,10 +7,18 @@
 	<p class="mt-2 flex items-center text-gray-700">
 		<span class="mr-2 rounded-md bg-purple-600 px-2 py-1 text-white">Arrival time:</span>
 		<span
-			>{new Date(arrivalTime * 1000).toLocaleTimeString([], {
-				hour: '2-digit',
-				minute: '2-digit'
-			})}</span
-		>
+		>{new Date(arrivalTime * 1000).toLocaleTimeString([], {
+			hour: '2-digit',
+			minute: '2-digit'
+		})}</span>
 	</p>
+	<div class="mt-auto flex justify-end">
+		<button
+				type="button"
+				class="inline-block rounded-lg border border-brand bg-brand px-3 py-1 text-sm font-medium text-white shadow-md transition duration-200 ease-in-out hover:bg-brand-secondary"
+				onclick={handleStopMarkerSelect}
+		>
+			{'view stop'}
+		</button>
+	</div>
 </div>

--- a/src/components/map/PopupContent.svelte
+++ b/src/components/map/PopupContent.svelte
@@ -5,7 +5,7 @@
 
 <div class="transform rounded-lg bg-white p-4 shadow-lg">
 	<h3 class="text-xl font-bold text-gray-900">{stopName}</h3>
-	<p class="mt-2 flex items-center text-gray-700">
+	<p class="my-4 flex items-center text-gray-700">
 		<span class="mr-2 rounded-md bg-purple-600 px-2 py-1 text-white">Arrival time:</span>
 		<span
 			>{new Date(arrivalTime * 1000).toLocaleTimeString([], {

--- a/src/components/map/PopupContent.svelte
+++ b/src/components/map/PopupContent.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { t } from 'svelte-i18n';
 	let { stopName, arrivalTime, handleStopMarkerSelect } = $props();
 </script>
 
@@ -13,13 +14,13 @@
 			})}</span
 		>
 	</p>
-	<div class="mt-auto flex justify-end">
+	<div class="mt-auto flex justify-center">
 		<button
 			type="button"
 			class="inline-block rounded-lg border border-brand bg-brand px-3 py-1 text-sm font-medium text-white shadow-md transition duration-200 ease-in-out hover:bg-brand-secondary"
 			onclick={handleStopMarkerSelect}
 		>
-			{'view stop'}
+			{$t('view_stop_information')}
 		</button>
 	</div>
 </div>

--- a/src/components/routes/RouteModal.svelte
+++ b/src/components/routes/RouteModal.svelte
@@ -1,12 +1,13 @@
 <script>
 	import StopItem from '$components/StopItem.svelte';
 	import ModalPane from '$components/navigation/ModalPane.svelte';
-	import { t } from 'svelte-i18n';
+	import {t} from 'svelte-i18n';
 
-	let { selectedRoute, stops, mapProvider, closePane } = $props();
+	let {selectedRoute, stops, mapProvider, closePane} = $props();
 
 	function handleStopItemClick(stop) {
 		mapProvider.flyTo(stop.lat, stop.lon, 18);
+		mapProvider.openStopMarker(stop);
 	}
 
 	function title() {
@@ -14,26 +15,26 @@
 			return '';
 		}
 
-		return $t('route_modal_title', { values: { name: selectedRoute.shortName } });
+		return $t('route_modal_title', {values: {name: selectedRoute.shortName}});
 	}
 </script>
 
 <ModalPane {closePane} title={title()}>
 	{#if stops && selectedRoute}
-		<div class="space-y-4">
+		<div className="space-y-4">
 			<div>
-				<div class="h-36 rounded-lg bg-brand-secondary bg-opacity-80 p-4">
-					<h1 class="mb-6 text-center text-2xl font-bold text-white">
+				<div className="h-36 rounded-lg bg-brand-secondary bg-opacity-80 p-4">
+					<h1 className="mb-6 text-center text-2xl font-bold text-white">
 						Route: {selectedRoute.shortName}
 					</h1>
-					<h2 class="mb-6 text-center text-xl text-white">{selectedRoute.description}</h2>
+					<h2 className="mb-6 text-center text-xl text-white">{selectedRoute.description}</h2>
 				</div>
 			</div>
 
-			<div class="space-y-2 rounded-lg">
+			<div className="space-y-2 rounded-lg">
 				<div>
 					{#each stops as stop}
-						<StopItem {stop} {handleStopItemClick} />
+						<StopItem {stop} {handleStopItemClick}/>
 					{/each}
 				</div>
 			</div>

--- a/src/components/routes/RouteModal.svelte
+++ b/src/components/routes/RouteModal.svelte
@@ -21,17 +21,17 @@
 
 <ModalPane {closePane} title={title()}>
 	{#if stops && selectedRoute}
-		<div className="space-y-4">
+		<div class="space-y-4">
 			<div>
-				<div className="h-36 rounded-lg bg-brand-secondary bg-opacity-80 p-4">
-					<h1 className="mb-6 text-center text-2xl font-bold text-white">
+				<div class="h-36 rounded-lg bg-brand-secondary bg-opacity-80 p-4">
+					<h1 class="mb-6 text-center text-2xl font-bold text-white">
 						Route: {selectedRoute.shortName}
 					</h1>
-					<h2 className="mb-6 text-center text-xl text-white">{selectedRoute.description}</h2>
+					<h2 class="mb-6 text-center text-xl text-white">{selectedRoute.description}</h2>
 				</div>
 			</div>
 
-			<div className="space-y-2 rounded-lg">
+			<div class="space-y-2 rounded-lg">
 				<div>
 					{#each stops as stop}
 						<StopItem {stop} {handleStopItemClick}/>

--- a/src/components/routes/RouteModal.svelte
+++ b/src/components/routes/RouteModal.svelte
@@ -1,9 +1,9 @@
 <script>
 	import StopItem from '$components/StopItem.svelte';
 	import ModalPane from '$components/navigation/ModalPane.svelte';
-	import {t} from 'svelte-i18n';
+	import { t } from 'svelte-i18n';
 
-	let {selectedRoute, stops, mapProvider, closePane} = $props();
+	let { selectedRoute, stops, mapProvider, closePane } = $props();
 
 	function handleStopItemClick(stop) {
 		mapProvider.flyTo(stop.lat, stop.lon, 18);
@@ -15,7 +15,7 @@
 			return '';
 		}
 
-		return $t('route_modal_title', {values: {name: selectedRoute.shortName}});
+		return $t('route_modal_title', { values: { name: selectedRoute.shortName } });
 	}
 </script>
 
@@ -34,7 +34,7 @@
 			<div class="space-y-2 rounded-lg">
 				<div>
 					{#each stops as stop}
-						<StopItem {stop} {handleStopItemClick}/>
+						<StopItem {stop} {handleStopItemClick} />
 					{/each}
 				</div>
 			</div>

--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -123,7 +123,7 @@ export default class GoogleMapProvider {
 
 		this.stopsMap.set(stop.id, stop);
 
-		marker.addListener('click', () => this.openStopMarker(stop));
+		marker.addListener('click', () => this.openStopMarker(stop, stopTime));
 
 		this.markersMap.set(stop.id, marker);
 		this.stopMarkers.push(marker);

--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -9,7 +9,7 @@ import TripPlanPinMarker from '$components/trip-planner/tripPlanPinMarker.svelte
 import { mount, unmount } from 'svelte';
 
 export default class GoogleMapProvider {
-	constructor(apiKey) {
+	constructor(apiKey, handleStopMarkerSelect) {
 		this.apiKey = apiKey;
 		this.map = null;
 		this.globalInfoWindow = null;
@@ -18,6 +18,7 @@ export default class GoogleMapProvider {
 		this.stopMarkers = [];
 		this.vehicleMarkers = [];
 		this.markersMap = new Map();
+		this.handleStopMarkerSelect = handleStopMarkerSelect;
 	}
 
 	async initMap(element, options) {
@@ -122,33 +123,37 @@ export default class GoogleMapProvider {
 
 		this.stopsMap.set(stop.id, stop);
 
-		marker.addListener('click', () => {
-			if (this.globalInfoWindow) {
-				this.globalInfoWindow.close();
+		marker.addListener('click', () => this.openStopMarker(stop));
+
+		this.markersMap.set(stop.id, marker);
+		this.stopMarkers.push(marker);
+	}
+
+	openStopMarker(stop, stopTime = null) {
+		if (this.globalInfoWindow) {
+			this.globalInfoWindow.close();
+		}
+
+		if (this.popupContentComponent) {
+			unmount(this.popupContentComponent);
+		}
+
+		const popupContainer = document.createElement('div');
+
+		this.popupContentComponent = mount(PopupContent, {
+			target: popupContainer,
+			props: {
+				stopName: stop.name,
+				arrivalTime: stopTime ? stopTime.arrivalTime : null,
+				handleStopMarkerSelect: () => this.handleStopMarkerSelect(stop)
 			}
-
-			if (this.popupContentComponent) {
-				unmount(this.popupContentComponent);
-			}
-
-			const popupContainer = document.createElement('div');
-
-			this.popupContentComponent = mount(PopupContent, {
-				target: popupContainer,
-				props: {
-					stopName: stop.name,
-					arrivalTime: stopTime ? stopTime.arrivalTime : null
-				}
-			});
-
-			this.globalInfoWindow = new google.maps.InfoWindow({
-				content: popupContainer
-			});
-
-			this.globalInfoWindow.open(this.map, marker);
 		});
 
-		this.stopMarkers.push(marker);
+		this.globalInfoWindow = new google.maps.InfoWindow({
+			content: popupContainer
+		});
+
+		this.globalInfoWindow.open(this.map, this.markersMap.get(stop.id));
 	}
 
 	highlightMarker(stopId) {

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -154,7 +154,7 @@ export default class OpenStreetMapProvider {
 
 		this.stopsMap.set(stop.id, stop);
 
-		marker.on('click', () => this.openStopMarker(stop));
+		marker.on('click', () => this.openStopMarker(stop, stopTime));
 
 		this.stopMarkers.push(marker);
 	}

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -150,7 +150,7 @@ export default class OpenStreetMapProvider {
 			iconAnchor: [10, 10]
 		});
 
-		const marker = L.marker([stop.lat, stop.lon], {icon: customIcon}).addTo(this.map);
+		const marker = L.marker([stop.lat, stop.lon], { icon: customIcon }).addTo(this.map);
 
 		this.stopsMap.set(stop.id, stop);
 
@@ -180,9 +180,9 @@ export default class OpenStreetMapProvider {
 		});
 
 		this.globalInfoWindow = L.popup()
-		.setLatLng([stop.lat, stop.lon])
-		.setContent(popupContainer)
-		.openOn(this.map);
+			.setLatLng([stop.lat, stop.lon])
+			.setContent(popupContainer)
+			.openOn(this.map);
 	}
 
 	removeStopMarkers() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -108,5 +108,6 @@
 		"page": "Page",
 		"show": "Show",
 		"hide": "Hide"
-	}
+	},
+	"view_stop_information": "View Stop Information"
 }


### PR DESCRIPTION
Resolves https://github.com/OneBusAway/wayfinder/issues/193 -- makes some improvements to the experience when a stop is selected within the Route Modal, namely:
- shows the popup on the map for the stop you've selected
- adds a button to that popup to allow you to open the stop modal from the popup itself.