### PR TITLE
Improved Accessibility: Added labels to theme switcher

### DIFF
--- a/src/lib/ThemeSwitch/ThemeSwitcher.svelte
+++ b/src/lib/ThemeSwitch/ThemeSwitcher.svelte
@@ -40,6 +40,7 @@
 			class="sr-only"
 			checked={darkMode}
 			onclick={handleThemeSwitch}
+			aria-label="Toggle theme"
 		/>
 		<label
 			for="theme-toggle"


### PR DESCRIPTION
# Fix: #206 

**Changes**
- Increased website accessibility by 5% by adding `aria-label="Toggle theme"` to the checkbox input in `ThemeSwitcher.svelte`

**Screenshot**
![image](https://github.com/user-attachments/assets/a1b9f57d-e387-498e-a203-fa780730797d)
