### PR TITLE
Chore: Remove unused COLORS import from googleMaps.js

### DIFF
--- a/src/lib/googleMaps.js
+++ b/src/lib/googleMaps.js
@@ -1,5 +1,3 @@
-import { COLORS } from '$lib/colors';
-
 /**
  * Loads the Google Maps JavaScript library.
  * @param {string} apiKey - The API key for accessing the Google Maps API.


### PR DESCRIPTION
Fixes: #214 

### Description:  
Removed an unused import statement to improve code cleanliness and avoid unnecessary dependencies. 