### PR TITLE
Only update trip planner route and endpoints on plan button click

### DIFF
--- a/src/components/trip-planner/TripPlan.svelte
+++ b/src/components/trip-planner/TripPlan.svelte
@@ -76,21 +76,11 @@
 		try {
 			const response = await geocodeLocation(suggestion.name);
 			if (isFrom) {
-				// if (fromMarker) {
-				// 	mapProvider.removePinMarker(fromMarker);
-				// }
-
 				selectedFrom = response.location.geometry.location;
-				// fromMarker = mapProvider.addPinMarker(selectedFrom, $t('trip-planner.from'));
 				fromPlace = suggestion.name;
 				fromResults = [];
 			} else {
-				// if (toMarker) {
-				// 	mapProvider.removePinMarker(toMarker);
-				// }
-
 				selectedTo = response.location.geometry.location;
-				// toMarker = mapProvider.addPinMarker(selectedTo, $t('trip-planner.to'));
 				toPlace = suggestion.name;
 				toResults = [];
 			}
@@ -106,12 +96,10 @@
 			fromPlace = '';
 			fromResults = [];
 			selectedFrom = null;
-			// mapProvider.removePinMarker(fromMarker);
 		} else {
 			toPlace = '';
 			toResults = [];
 			selectedTo = null;
-			// mapProvider.removePinMarker(toMarker);
 		}
 	}
 

--- a/src/components/trip-planner/TripPlan.svelte
+++ b/src/components/trip-planner/TripPlan.svelte
@@ -139,19 +139,19 @@
 
 		loading = true;
 		try {
-			if (fromMarker) {
-				mapProvider.removePinMarker(fromMarker);
-			}
-			if (toMarker) {
-				mapProvider.removePinMarker(toMarker);
-			}
-
-			fromMarker = mapProvider.addPinMarker(selectedFrom, $t('trip-planner.from'));
-			toMarker = mapProvider.addPinMarker(selectedTo, $t('trip-planner.to'));
-
 			const data = await fetchTripPlan(selectedFrom, selectedTo);
 
 			if (data) {
+				if (fromMarker) {
+					mapProvider.removePinMarker(fromMarker);
+				}
+				if (toMarker) {
+					mapProvider.removePinMarker(toMarker);
+				}
+
+				fromMarker = mapProvider.addPinMarker(selectedFrom, $t('trip-planner.from'));
+				toMarker = mapProvider.addPinMarker(selectedTo, $t('trip-planner.to'));
+
 				const tripPlanData = {
 					data,
 					fromMarker,

--- a/src/components/trip-planner/TripPlan.svelte
+++ b/src/components/trip-planner/TripPlan.svelte
@@ -76,13 +76,21 @@
 		try {
 			const response = await geocodeLocation(suggestion.name);
 			if (isFrom) {
+				// if (fromMarker) {
+				// 	mapProvider.removePinMarker(fromMarker);
+				// }
+
 				selectedFrom = response.location.geometry.location;
-				fromMarker = mapProvider.addPinMarker(selectedFrom, $t('trip-planner.from'));
+				// fromMarker = mapProvider.addPinMarker(selectedFrom, $t('trip-planner.from'));
 				fromPlace = suggestion.name;
 				fromResults = [];
 			} else {
+				// if (toMarker) {
+				// 	mapProvider.removePinMarker(toMarker);
+				// }
+
 				selectedTo = response.location.geometry.location;
-				toMarker = mapProvider.addPinMarker(selectedTo, $t('trip-planner.to'));
+				// toMarker = mapProvider.addPinMarker(selectedTo, $t('trip-planner.to'));
 				toPlace = suggestion.name;
 				toResults = [];
 			}
@@ -98,12 +106,12 @@
 			fromPlace = '';
 			fromResults = [];
 			selectedFrom = null;
-			mapProvider.removePinMarker(fromMarker);
+			// mapProvider.removePinMarker(fromMarker);
 		} else {
 			toPlace = '';
 			toResults = [];
 			selectedTo = null;
-			mapProvider.removePinMarker(toMarker);
+			// mapProvider.removePinMarker(toMarker);
 		}
 	}
 

--- a/src/components/trip-planner/TripPlanModal.svelte
+++ b/src/components/trip-planner/TripPlanModal.svelte
@@ -3,7 +3,7 @@
 	import LoadingSpinner from '$components/LoadingSpinner.svelte';
 	import ItineraryDetails from './ItineraryDetails.svelte';
 	import ItineraryTab from './ItineraryTab.svelte';
-	import { onDestroy, onMount } from 'svelte';
+	import { onDestroy } from 'svelte';
 	import { t } from 'svelte-i18n';
 
 	/**

--- a/src/components/trip-planner/TripPlanModal.svelte
+++ b/src/components/trip-planner/TripPlanModal.svelte
@@ -61,9 +61,8 @@
 		});
 	}
 
-	$effect(() => {
-		drawRoute();
-	});
+	$effect(drawRoute);
+
 	onDestroy(() => {
 		mapProvider.removePinMarker(fromMarker);
 		mapProvider.removePinMarker(toMarker);

--- a/src/components/trip-planner/TripPlanModal.svelte
+++ b/src/components/trip-planner/TripPlanModal.svelte
@@ -61,7 +61,7 @@
 		});
 	}
 
-	onMount(() => {
+	$effect(() => {
 		drawRoute();
 	});
 	onDestroy(() => {


### PR DESCRIPTION
I noticed that trip endpoints and routes can get out of whack when changing the start or end location of a route. For example, I saw the following as I chose different start/end locations:

![image](https://github.com/user-attachments/assets/2b8a7b15-e396-4574-83b8-67e4ec068b17) 

This is slightly a product-y choice, but this change makes it so that the start/stop locations on the map are only updated when you actually click the "Plan Your Trip" button. This seemed sensible since the routes shown (ie, "Itinerary 1", "Itinerary 2", etc.) represent the points on the map that were selected when you last clicked the "Plan Your Trip" button.

There's also a slight timing tweak here to only render the new start/stop locations once we've received the new route from the API, such that the route and the start/stop locations change at the same time.

