### PR TITLE
hotfix/converted-string-to-uppercase-in-convertUnixToTime

### DIFF
--- a/src/lib/formatters.js
+++ b/src/lib/formatters.js
@@ -24,5 +24,7 @@ export function convertUnixToTime(seconds) {
 	if (!seconds) return '';
 	const date = new Date(seconds * 1000);
 	const utcDate = new Date(date.toUTCString().slice(0, -4));
-	return utcDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+	const localDateTime = utcDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+	return localDateTime.replace(/am|pm/, time => time.toUpperCase());
 }


### PR DESCRIPTION
This PR fixes the issue where the convertUnixToTime function returned lowercase "am" / "pm" instead of uppercase "AM" / "PM".
The test was failing because of case-sensitive string comparison.

- Before: 01:00 pm
- After: 01:00 PM

**Changes Made**
`localDateTime.replace(/am|pm/, time => time.toUpperCase());`

**Fix**
<img width="1062" height="193" alt="Screenshot 2025-08-31 011844" src="https://github.com/user-attachments/assets/a0eef0ef-cd54-4f39-ad3b-b0e20049f09f" />

**ISSUE**: [issue-52](https://github.com/OneBusAway/waystation/issues/52)