### PR TITLE
Improve mobile navigation menu height to enhance usability

### DIFF
--- a/src/components/navigation/MobileMenu.svelte
+++ b/src/components/navigation/MobileMenu.svelte
@@ -6,8 +6,8 @@
 </script>
 
 <div
-	class="fixed inset-0 z-50 flex flex-col items-center justify-center space-y-6 bg-surface p-4 dark:bg-surface-dark"
-	transition:fly={{ x: 1000, duration: 300 }}
+	class="fixed inset-x-0 bottom-0 z-50 h-1/2 flex flex-col items-center justify-start space-y-6 bg-surface p-4 dark:bg-surface-dark sm:h-full sm:inset-0"
+	transition:fly={{ y: 500, duration: 300 }}
 >
 	<button onclick={closeMenu} aria-label="Close Menu">
 		<svg
@@ -22,7 +22,7 @@
 		</svg>
 	</button>
 
-	<div class="flex flex-col items-center gap-4">
+	<div class="flex flex-col items-center gap-4 pt-2">
 		{#each Object.entries(headerLinks) as [key, value]}
 			<a
 				href={value}


### PR DESCRIPTION
This PR improves the mobile navigation experience. Previously, when the menu button was clicked in mobile view, the navigation menu expanded to cover the entire screen, which hid important content such as the search section.
I’ve updated the behavior so that the mobile menu now covers only 50% of the screen from the bottom, ensuring that the search section remains visible and accessible while the menu is open.

**Changes made:**
Adjusted mobile navigation menu height to 50% of viewport
Prevented full-screen overlay in mobile view
Improved overall usability and visibility of key UI elements

**Impact:**
Better user experience on mobile devices
Search section remains visible while navigation menu is open
Cleaner and less intrusive mobile navigation behavior

**Screenshots / Demo :**
Before: Menu covered the entire screen:
<img width="260" height="576" alt="before image" src="https://github.com/user-attachments/assets/68534337-6561-4e71-b2f8-c5a044efb0b0" />

After: Menu covers only 50% from the bottom, keeping search visible:
<img width="263" height="577" alt="after image" src="https://github.com/user-attachments/assets/077df08d-ff0d-493e-b27d-35023d828444" />


