### PR TITLE
feat(i18n): internationalize LanguageSwitcher accessibility labels

### DIFF
--- a/src/components/navigation/LanguageSwitcher/LanguageSwitcher.svelte
+++ b/src/components/navigation/LanguageSwitcher/LanguageSwitcher.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { languages } from '$lib/i18n';
-	import { locale } from 'svelte-i18n';
+	import { locale, t } from 'svelte-i18n';
 	import { browser } from '$app/environment';
 	import { env } from '$env/dynamic/public';
 
@@ -114,7 +114,7 @@
 		<button
 			type="button"
 			onclick={() => (isOpen = !isOpen)}
-			aria-label="Select language"
+			aria-label={$t('language_switcher.select_language', { values: { language: getLanguageNameForLocale(currentLocale, buttonFormat) } })}
 			aria-expanded={isOpen}
 			aria-haspopup="listbox"
 			class="flex h-8 items-center justify-center gap-1 rounded-md border bg-surface/80 px-2 font-semibold text-surface-foreground dark:bg-surface-dark dark:text-surface-foreground-dark"
@@ -140,10 +140,12 @@
 			<div
 				class="absolute end-0 top-full z-[9999] mt-1 max-h-[400px] overflow-y-auto rounded-md border border-gray-300 bg-surface shadow-lg dark:border-gray-600 dark:bg-surface-dark"
 			>
-				<div class="flex flex-col py-1">
+				<div role="listbox" aria-label={$t('language_switcher.available_languages')} class="flex flex-col py-1">
 					{#each languages as lang}
 						<button
 							type="button"
+							role="option"
+							aria-selected={lang.code === currentLocale}
 							onclick={() => handleLanguageSelect(lang.code)}
 							class="block w-full whitespace-nowrap px-4 py-2 text-left text-sm font-semibold text-surface-foreground hover:bg-gray-100 dark:text-surface-foreground-dark dark:hover:bg-gray-700 {lang.code ===
 							currentLocale

--- a/src/locales/am.json
+++ b/src/locales/am.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "የማቆሚያ መረጃ ይመልከቱ",
 	"stop_details": {
 		"view_details": "ዝርዝሮችን ይመልከቱ"
+	},
+	"language_switcher": {
+		"select_language": "ቋንቋ ይምረጡ: {language}",
+		"available_languages": "የሚገኙ ቋንቋዎች"
 	}
 }

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "عرض معلومات المحطة",
 	"stop_details": {
 		"view_details": "عرض التفاصيل"
+	},
+	"language_switcher": {
+		"select_language": "اختر اللغة: {language}",
+		"available_languages": "اللغات المتاحة"
 	}
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -166,5 +166,9 @@
 	"view_stop_information": "View Stop Information",
 	"stop_details": {
 		"view_details": "View Details"
+	},
+	"language_switcher": {
+		"select_language": "Select language: {language}",
+		"available_languages": "Available languages"
 	}
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -145,5 +145,9 @@
 		"page": "Página",
 		"show": "Mostrar",
 		"hide": "Ocultar"
+	},
+	"language_switcher": {
+		"select_language": "Seleccionar idioma: {language}",
+		"available_languages": "Idiomas disponibles"
 	}
 }

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "مشاهده اطلاعات ایستگاه",
 	"stop_details": {
 		"view_details": "مشاهده جزئیات"
+	},
+	"language_switcher": {
+		"select_language": "انتخاب زبان: {language}",
+		"available_languages": "زبان‌های موجود"
 	}
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "Voir les informations de l'arrêt",
 	"stop_details": {
 		"view_details": "Voir les détails"
+	},
+	"language_switcher": {
+		"select_language": "Sélectionner la langue : {language}",
+		"available_languages": "Langues disponibles"
 	}
 }

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "स्टॉप जानकारी देखें",
 	"stop_details": {
 		"view_details": "विवरण देखें"
+	},
+	"language_switcher": {
+		"select_language": "भाषा चुनें: {language}",
+		"available_languages": "उपलब्ध भाषाएं"
 	}
 }

--- a/src/locales/ht.json
+++ b/src/locales/ht.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "Gade Enfòmasyon Arè",
 	"stop_details": {
 		"view_details": "Gade Detay"
+	},
+	"language_switcher": {
+		"select_language": "Chwazi lang: {language}",
+		"available_languages": "Lang ki disponib"
 	}
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "停留所情報を見る",
 	"stop_details": {
 		"view_details": "詳細を見る"
+	},
+	"language_switcher": {
+		"select_language": "言語を選択: {language}",
+		"available_languages": "利用可能な言語"
 	}
 }

--- a/src/locales/km.json
+++ b/src/locales/km.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "មើលព័ត៌មានចំណត",
 	"stop_details": {
 		"view_details": "មើលព័ត៌មានលម្អិត"
+	},
+	"language_switcher": {
+		"select_language": "ជ្រើសរើសភាសា: {language}",
+		"available_languages": "ភាសាដែលមាន"
 	}
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "정류장 정보 보기",
 	"stop_details": {
 		"view_details": "상세 정보 보기"
+	},
+	"language_switcher": {
+		"select_language": "언어 선택: {language}",
+		"available_languages": "사용 가능한 언어"
 	}
 }

--- a/src/locales/lo.json
+++ b/src/locales/lo.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "ເບິ່ງຂໍ້ມູນປ້າຍ",
 	"stop_details": {
 		"view_details": "ເບິ່ງລາຍລະອຽດ"
+	},
+	"language_switcher": {
+		"select_language": "ເລືອກພາສາ: {language}",
+		"available_languages": "ພາສາທີ່ມີ"
 	}
 }

--- a/src/locales/om.json
+++ b/src/locales/om.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "Odeeffannoo Dhaabbii Ilaali",
 	"stop_details": {
 		"view_details": "Bal'inaan Ilaali"
+	},
+	"language_switcher": {
+		"select_language": "Afaan filadhu: {language}",
+		"available_languages": "Afaanota jiran"
 	}
 }

--- a/src/locales/pa.json
+++ b/src/locales/pa.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "ਸਟਾਪ ਜਾਣਕਾਰੀ ਦੇਖੋ",
 	"stop_details": {
 		"view_details": "ਵੇਰਵੇ ਦੇਖੋ"
+	},
+	"language_switcher": {
+		"select_language": "ਭਾਸ਼ਾ ਚੁਣੋ: {language}",
+		"available_languages": "ਉਪਲਬਧ ਭਾਸ਼ਾਵਾਂ"
 	}
 }

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -144,5 +144,9 @@
 		"page": "Strona",
 		"show": "Pokaż",
 		"hide": "Ukryj"
+	},
+	"language_switcher": {
+		"select_language": "Wybierz język: {language}",
+		"available_languages": "Dostępne języki"
 	}
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "Ver Informações da Parada",
 	"stop_details": {
 		"view_details": "Ver Detalhes"
+	},
+	"language_switcher": {
+		"select_language": "Selecionar idioma: {language}",
+		"available_languages": "Idiomas disponíveis"
 	}
 }

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "Информация об остановке",
 	"stop_details": {
 		"view_details": "Подробнее"
+	},
+	"language_switcher": {
+		"select_language": "Выберите язык: {language}",
+		"available_languages": "Доступные языки"
 	}
 }

--- a/src/locales/sm.json
+++ b/src/locales/sm.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "Vaʻai Faʻamatalaga o le Nofoaga Taofi",
 	"stop_details": {
 		"view_details": "Vaʻai Faʻamatalaga"
+	},
+	"language_switcher": {
+		"select_language": "Filifili gagana: {language}",
+		"available_languages": "Gagana avanoa"
 	}
 }

--- a/src/locales/so.json
+++ b/src/locales/so.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "Eeg macluumaadka joogsiga",
 	"stop_details": {
 		"view_details": "Eeg faahfaahinta"
+	},
+	"language_switcher": {
+		"select_language": "Dooro luuqadda: {language}",
+		"available_languages": "Luuqadaha la heli karo"
 	}
 }

--- a/src/locales/ti.json
+++ b/src/locales/ti.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "ሓበሬታ መዕረፊ ርአ",
 	"stop_details": {
 		"view_details": "ዝርዝር ርአ"
+	},
+	"language_switcher": {
+		"select_language": "ቋንቋ ምረጽ: {language}",
+		"available_languages": "ዝርከቡ ቋንቋታት"
 	}
 }

--- a/src/locales/tl.json
+++ b/src/locales/tl.json
@@ -149,5 +149,9 @@
 	"view_stop_information": "Tingnan ang impormasyon ng hintuan",
 	"stop_details": {
 		"view_details": "Tingnan ang detalye"
+	},
+	"language_switcher": {
+		"select_language": "Piliin ang wika: {language}",
+		"available_languages": "Mga available na wika"
 	}
 }

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "Переглянути інформацію про зупинку",
 	"stop_details": {
 		"view_details": "Детальніше"
+	},
+	"language_switcher": {
+		"select_language": "Оберіть мову: {language}",
+		"available_languages": "Доступні мови"
 	}
 }

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "Xem thông tin trạm dừng",
 	"stop_details": {
 		"view_details": "Xem chi tiết"
+	},
+	"language_switcher": {
+		"select_language": "Chọn ngôn ngữ: {language}",
+		"available_languages": "Ngôn ngữ có sẵn"
 	}
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "查看站点信息",
 	"stop_details": {
 		"view_details": "查看详情"
+	},
+	"language_switcher": {
+		"select_language": "选择语言: {language}",
+		"available_languages": "可用语言"
 	}
 }

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -148,5 +148,9 @@
 	"view_stop_information": "查看站牌資訊",
 	"stop_details": {
 		"view_details": "查看詳情"
+	},
+	"language_switcher": {
+		"select_language": "選擇語言: {language}",
+		"available_languages": "可用語言"
 	}
 }


### PR DESCRIPTION
Add translations for aria-label attributes in the language switcher:
- "Select language: {language}" for the button
- "Available languages" for the listbox

Added language_switcher translation keys to all 25 locale files and updated tests to mock the t function from svelte-i18n.