### PR TITLE
refactor: switch analytics env vars to dynamic imports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ Configured in `src/lib/i18n.js`. English loaded synchronously as fallback; 24 ot
 - Setup file: `vitest-setup.js` (mocks for env vars, i18n, SvelteKit stores, browser APIs)
 - Coverage threshold: 70% for branches, functions, lines, statements
 
-When writing tests, the setup file already mocks `$env/static/public`, `$env/static/private`, `svelte-i18n`, `$app/stores`, and common browser APIs (ResizeObserver, IntersectionObserver, geolocation, localStorage, matchMedia).
+When writing tests, the setup file already mocks `$env/static/public`, `$env/static/private`, `$env/dynamic/public`, `svelte-i18n`, `$app/stores`, and common browser APIs (ResizeObserver, IntersectionObserver, geolocation, localStorage, matchMedia). Tests that need to mutate dynamic env values should declare their own `vi.mock('$env/dynamic/public', ...)` with a getter pattern (see `LanguageSwitcher.test.js` or `PlausibleAnalytics.test.js` for examples).
 
 ## Styling
 

--- a/src/components/navigation/LanguageSwitcher/LanguageSwitcher.svelte
+++ b/src/components/navigation/LanguageSwitcher/LanguageSwitcher.svelte
@@ -114,7 +114,9 @@
 		<button
 			type="button"
 			onclick={() => (isOpen = !isOpen)}
-			aria-label={$t('language_switcher.select_language', { values: { language: getLanguageNameForLocale(currentLocale, buttonFormat) } })}
+			aria-label={$t('language_switcher.select_language', {
+				values: { language: getLanguageNameForLocale(currentLocale, buttonFormat) }
+			})}
 			aria-expanded={isOpen}
 			aria-haspopup="listbox"
 			class="flex h-8 items-center justify-center gap-1 rounded-md border bg-surface/80 px-2 font-semibold text-surface-foreground dark:bg-surface-dark dark:text-surface-foreground-dark"
@@ -140,7 +142,11 @@
 			<div
 				class="absolute end-0 top-full z-[9999] mt-1 max-h-[400px] overflow-y-auto rounded-md border border-gray-300 bg-surface shadow-lg dark:border-gray-600 dark:bg-surface-dark"
 			>
-				<div role="listbox" aria-label={$t('language_switcher.available_languages')} class="flex flex-col py-1">
+				<div
+					role="listbox"
+					aria-label={$t('language_switcher.available_languages')}
+					class="flex flex-col py-1"
+				>
 					{#each languages as lang}
 						<button
 							type="button"

--- a/src/routes/api/events/+server.js
+++ b/src/routes/api/events/+server.js
@@ -1,42 +1,18 @@
-import { PUBLIC_ANALYTICS_DOMAIN, PUBLIC_ANALYTICS_API_HOST } from '$env/static/public';
+import { PlausibleAnalytics } from '$lib/Analytics/PlausibleAnalytics.js';
+
+const analytics = new PlausibleAnalytics();
 
 export async function POST({ request }) {
 	try {
-		const { name, url, referrer, props } = await request.json();
-
-		const res = await fetch(`${PUBLIC_ANALYTICS_API_HOST}/api/event`, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				domain: PUBLIC_ANALYTICS_DOMAIN,
-				name,
-				url,
-				referrer,
-				props
-			})
-		});
-
-		if (!res.ok) {
-			return new Response(JSON.stringify({ error: `Error sending event: ${res.statusText}` }), {
-				status: res.status,
-				headers: { 'Content-Type': 'application/json' }
-			});
-		}
-
-		const text = await res.text();
-		let data;
-		try {
-			data = JSON.parse(text);
-		} catch {
-			data = { status: text };
-		}
+		const event = await request.json();
+		const data = await analytics.forwardEvent(event);
 		return new Response(JSON.stringify(data), {
-			status: res.status,
+			status: 200,
 			headers: { 'Content-Type': 'application/json' }
 		});
 	} catch (error) {
 		return new Response(JSON.stringify({ error: error.message || 'Unknown error' }), {
-			status: 500,
+			status: error.upstreamStatus || 500,
 			headers: { 'Content-Type': 'application/json' }
 		});
 	}

--- a/src/tests/api/events.test.js
+++ b/src/tests/api/events.test.js
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockEnv = vi.hoisted(() => ({
+	PUBLIC_ANALYTICS_ENABLED: 'true',
+	PUBLIC_ANALYTICS_DOMAIN: 'example.com',
+	PUBLIC_ANALYTICS_API_HOST: 'https://analytics.example.com'
+}));
+
+vi.mock('$env/dynamic/public', () => ({
+	get env() {
+		return mockEnv;
+	}
+}));
+
+import { POST } from '../../routes/api/events/+server.js';
+
+describe('POST /api/events', () => {
+	beforeEach(() => {
+		mockEnv.PUBLIC_ANALYTICS_ENABLED = 'true';
+		mockEnv.PUBLIC_ANALYTICS_DOMAIN = 'example.com';
+		mockEnv.PUBLIC_ANALYTICS_API_HOST = 'https://analytics.example.com';
+		vi.restoreAllMocks();
+	});
+
+	it('returns analytics disabled when PUBLIC_ANALYTICS_ENABLED is not true', async () => {
+		mockEnv.PUBLIC_ANALYTICS_ENABLED = 'false';
+
+		const request = new Request('http://localhost/api/events', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'pageview', url: '/test' })
+		});
+
+		const response = await POST({ request });
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data).toEqual({ status: 'analytics disabled' });
+	});
+
+	it('returns analytics disabled when PUBLIC_ANALYTICS_API_HOST is empty', async () => {
+		mockEnv.PUBLIC_ANALYTICS_API_HOST = '';
+
+		const request = new Request('http://localhost/api/events', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'pageview', url: '/test' })
+		});
+
+		const response = await POST({ request });
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data).toEqual({ status: 'analytics disabled' });
+	});
+
+	it('returns analytics disabled when PUBLIC_ANALYTICS_DOMAIN is empty', async () => {
+		mockEnv.PUBLIC_ANALYTICS_DOMAIN = '';
+
+		const request = new Request('http://localhost/api/events', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'pageview', url: '/test' })
+		});
+
+		const response = await POST({ request });
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data).toEqual({ status: 'analytics disabled' });
+	});
+
+	it('proxies event to analytics API when enabled', async () => {
+		const upstreamResponse = { status: 'ok' };
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			text: async () => JSON.stringify(upstreamResponse)
+		});
+
+		const request = new Request('http://localhost/api/events', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'pageview', url: '/test', props: { id: '1' } })
+		});
+
+		const response = await POST({ request });
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data).toEqual(upstreamResponse);
+		expect(global.fetch).toHaveBeenCalledWith(
+			'https://analytics.example.com/api/event',
+			expect.objectContaining({
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: expect.stringContaining('"domain":"example.com"')
+			})
+		);
+	});
+
+	it('forwards upstream status code when API responds with error', async () => {
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 502,
+			statusText: 'Bad Gateway'
+		});
+
+		const request = new Request('http://localhost/api/events', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'pageview', url: '/test' })
+		});
+
+		const response = await POST({ request });
+		const data = await response.json();
+
+		expect(response.status).toBe(502);
+		expect(data).toEqual({ error: 'Error sending event: Bad Gateway' });
+	});
+
+	it('returns 500 when request body is not valid JSON', async () => {
+		const request = new Request('http://localhost/api/events', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: 'not json'
+		});
+
+		const response = await POST({ request });
+		const data = await response.json();
+
+		expect(response.status).toBe(500);
+		expect(data).toHaveProperty('error');
+	});
+
+	it('returns 500 when fetch throws', async () => {
+		global.fetch = vi.fn().mockRejectedValue(new Error('Network failure'));
+
+		const request = new Request('http://localhost/api/events', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'pageview', url: '/test' })
+		});
+
+		const response = await POST({ request });
+		const data = await response.json();
+
+		expect(response.status).toBe(500);
+		expect(data).toEqual({ error: 'Network failure' });
+	});
+});

--- a/vitest-setup.js
+++ b/vitest-setup.js
@@ -15,6 +15,16 @@ global.IntersectionObserver = vi.fn().mockImplementation(() => ({
 	disconnect: vi.fn()
 }));
 
+// Mock dynamic environment variables (fallback for tests that don't provide their own mock).
+// Test files that need to mutate env values should declare their own vi.mock with a getter pattern.
+vi.mock('$env/dynamic/public', () => ({
+	env: {
+		PUBLIC_ANALYTICS_DOMAIN: '',
+		PUBLIC_ANALYTICS_ENABLED: 'false',
+		PUBLIC_ANALYTICS_API_HOST: ''
+	}
+}));
+
 // Mock environment variables
 vi.mock('$env/static/public', () => ({
 	PUBLIC_OBA_REGION_NAME: 'Test Region',
@@ -22,8 +32,6 @@ vi.mock('$env/static/public', () => ({
 	PUBLIC_OBA_SERVER_URL: 'https://api.test.com',
 	PUBLIC_OBA_MAP_PROVIDER: 'osm',
 	PUBLIC_NAV_BAR_LINKS: '{"Home": "/", "About": "/about"}',
-	PUBLIC_ANALYTICS_DOMAIN: '',
-	PUBLIC_ANALYTICS_ENABLED: 'false',
 	PUBLIC_DISTANCE_UNIT: '' // Empty = auto-detect from browser
 }));
 


### PR DESCRIPTION
## Summary

- Migrate `PUBLIC_ANALYTICS_ENABLED`, `PUBLIC_ANALYTICS_DOMAIN`, and `PUBLIC_ANALYTICS_API_HOST` from `$env/static/public` to `$env/dynamic/public` so analytics configuration can change per-deployment without rebuilding
- Refactor `PlausibleAnalytics` into an exported class with injectable `env` constructor param, `isEnabled()`, `getEventUrl()`, `getDomain()`, and `forwardEvent()` methods
- Simplify `/api/events` server endpoint from 48 lines to 18 by delegating to `forwardEvent()` — upstream HTTP status codes are preserved in error responses
- Add `$env/dynamic/public` global fallback mock in `vitest-setup.js` with analytics disabled by default
- Update `CLAUDE.md` testing docs to document the new mock and getter pattern

## Test plan

- [x] All 916 tests pass (`npm run test`)
- [x] `PlausibleAnalytics.test.js`: 26 tests covering constructor injection, `getEventUrl`, `getDomain`, `forwardEvent` (disabled, success, non-JSON response, upstream error with status, missing fields, network failure), `isEnabled` guards (disabled, empty domain, empty API host, undefined domain, undefined API host), and all existing `postEvent`/report methods
- [x] `events.test.js`: 7 tests covering disabled state (3 variants), successful proxy, upstream error status forwarding, malformed request body, and network failure
- [ ] Verify analytics events are sent correctly in a deployed environment with `PUBLIC_ANALYTICS_ENABLED=true`