### PR TITLE
Fix server unresponsive on startup by making cache preload non-blocking

### DIFF
--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -2,7 +2,8 @@ import { preloadRoutesData } from '$lib/serverCache.js';
 import { preloadOtpVersion } from '$lib/otpServerCache.js';
 
 export async function handle({ event, resolve }) {
-	await Promise.all([preloadRoutesData(), preloadOtpVersion()]);
+	// Preload caches in background — don't block requests (or health checks)
+	Promise.all([preloadRoutesData(), preloadOtpVersion()]);
 	return resolve(event);
 }
 


### PR DESCRIPTION
## Summary

- The `handle` hook was `await`ing `preloadRoutesData()` and `preloadOtpVersion()` on every request, blocking ALL incoming traffic — including Render's health checks — until the OBA API responded.
- The OBA SDK has a 60s timeout with 2 retries, so when the API was unreachable from Render's network, every request was blocked for ~3 minutes.
- Render reported "No open HTTP ports detected" and clients received 499 errors.
- Fix: run preloading in the background so requests proceed immediately.

## Test plan
- [x] All 1047 existing tests pass
- [ ] Deploy to Render and verify the server responds to health checks immediately on startup
- [ ] Verify route/stop data loads correctly after the background cache populates