### PR TITLE
Fix rendering of SVG bus icons

### DIFF
--- a/src/components/search/SearchPane.svelte
+++ b/src/components/search/SearchPane.svelte
@@ -133,7 +133,7 @@
 				clearInterval(currentIntervalId);
 				currentIntervalId = null;
 			}
-			currentIntervalId = await fetchAndUpdateVehicles(route.id, mapProvider);
+			currentIntervalId = await fetchAndUpdateVehicles(route.id, mapProvider, route.type);
 
 			const routeData = {
 				route,

--- a/src/config/routeConfig.js
+++ b/src/config/routeConfig.js
@@ -35,18 +35,38 @@ const prioritizedRouteTypeForDisplay = (routeType) => {
 		case RouteType.FERRY:
 			return faFerry;
 		case RouteType.LIGHT_RAIL:
-			return faTrainSubway;
 		case RouteType.SUBWAY:
 			return faTrainSubway;
-		case RouteType.CABLE_CAR:
-			return faCableCar;
 		case RouteType.RAIL:
 			return faTrain;
+		case RouteType.CABLE_CAR:
 		case RouteType.GONDOLA:
+		case RouteType.FUNICULAR:
 			return faCableCar;
 		default:
 			return faBus;
 	}
 };
 
-export { RouteType, routePriorities, prioritizedRouteTypeForDisplay };
+const generateRouteTypeSvgForDisplay = (routeType) => {
+	const faIcon = prioritizedRouteTypeForDisplay(routeType);
+	const { icon } = faIcon;
+	const [width, height, , , pathData] = icon;
+	const svgWidth = width / 32;
+	const svgHeight = height / 32;
+	const svgX = -svgWidth / 2;
+	const svgY = -svgHeight / 2;
+
+	return `
+		<svg x="${svgX}" y="${svgY}" width="${svgWidth}" height="${svgHeight}" viewBox="0 0 ${width} ${height}">
+			<path d="${pathData}" />
+		</svg>
+	`;
+};
+
+export {
+	RouteType,
+	routePriorities,
+	prioritizedRouteTypeForDisplay,
+	generateRouteTypeSvgForDisplay
+};

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -2,8 +2,7 @@ import { preloadRoutesData } from '$lib/serverCache.js';
 import { preloadOtpVersion } from '$lib/otpServerCache.js';
 
 export async function handle({ event, resolve }) {
-	// Preload caches in background — don't block requests (or health checks)
-	Promise.all([preloadRoutesData(), preloadOtpVersion()]);
+	await Promise.all([preloadRoutesData(), preloadOtpVersion()]);
 	return resolve(event);
 }
 

--- a/src/lib/MapHelpers/generateVehicleIcon.js
+++ b/src/lib/MapHelpers/generateVehicleIcon.js
@@ -1,4 +1,8 @@
 import { toDirection } from '$lib/mathUtils';
+import { generateRouteTypeSvgForDisplay, RouteType } from '$config/routeConfig';
+
+const iconWidth = 56;
+const iconHeight = 56;
 
 const DIRECTIONS = [
 	{ angle: 0, icon: 'north' },
@@ -18,39 +22,30 @@ function getDirectionFromOrientation(orientation) {
 	return nearestDirection.icon;
 }
 
-function createVehicleIconSvg(orientation, color = '#007BFF') {
+function createVehicleIconSvg(orientation, color = '#007BFF', routeType = RouteType.BUS) {
 	const direction = getDirectionFromOrientation(toDirection(orientation));
 	const angle = DIRECTIONS.find((d) => d.icon === direction).angle;
 
 	const arrowPath = `
-    <line x1="20" y1="20" x2="20" y2="5" stroke="${color}" stroke-width="2" transform="rotate(${angle}, 20, 20)" />
-    <polygon points="20,-5 25,5 15,5" fill="${color}" stroke="white" stroke-width="1" transform="rotate(${angle}, 20, 20)" />
+    <line x1="0" y1="0" x2="0" y2="-15" stroke-width="2" transform="rotate(${angle})"/>
+    <polygon points="0,-25 5,-15 -5, -15" stroke="white" stroke-width="1" transform="rotate(${angle})"/>
 `;
 
-	const busIcon = `
-        <!-- Main bus body -->
-        <rect x="14" y="14" width="12" height="12" rx="2" ry="2" fill="${color}"/>
-        <!-- Windows -->
-        <rect x="16" y="18" width="2" height="2" fill="white"/>
-        <rect x="22" y="18" width="2" height="2" fill="white"/>
-        <!-- Bumper -->
-        <rect x="17" y="22" width="6" height="1.5" fill="white"/>
-        <!-- Wheels -->
-        <circle cx="17" cy="26" r="1.5" fill="${color}"/>
-        <circle cx="23" cy="26" r="1.5" fill="${color}"/>
-    `;
+	const vehicleSvg = generateRouteTypeSvgForDisplay(routeType);
 
 	return `
-        <svg width="60" height="60" viewBox="0 0 40 50" xmlns="http://www.w3.org/2000/svg">
-            <!-- Directional arrow -->
-            ${arrowPath}
+        <svg width="${iconWidth}" height="${iconHeight}" viewBox="-28 -28 56 56" xmlns="http://www.w3.org/2000/svg">
+            <g stroke="${color}" fill="${color}">
+                <!-- Directional arrow -->
+                ${arrowPath}
 
-            <!-- Circle background -->
-            <circle cx="20" cy="20" r="13" stroke="${color}" stroke-width="2" fill="white"/>
+                <!-- Circle background -->
+                <circle cx="0" cy="0" r="13" stroke-width="2" fill="white"/>
 
-            <!-- Bus icon inside the circle -->
-            ${busIcon}
+                <!-- vehicle icon inside the circle -->
+                ${vehicleSvg}
+            </g>
         </svg>`;
 }
 
-export { createVehicleIconSvg };
+export { createVehicleIconSvg, iconWidth, iconHeight };

--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -6,7 +6,7 @@ import { COLORS } from '$lib/colors';
 import PopupContent from '$components/map/PopupContent.svelte';
 import ContextMenuPopup from '$components/map/ContextMenuPopup.svelte';
 import VehiclePopupContent from '$components/map/VehiclePopupContent.svelte';
-import { createVehicleIconSvg } from '$lib/MapHelpers/generateVehicleIcon';
+import { createVehicleIconSvg, iconHeight, iconWidth } from '$lib/MapHelpers/generateVehicleIcon';
 import TripPlanPinMarker from '$components/trip-planner/tripPlanPinMarker.svelte';
 import { mount, unmount } from 'svelte';
 
@@ -327,7 +327,7 @@ export default class GoogleMapProvider {
 		}
 	}
 
-	addVehicleMarker(vehicle, activeTrip) {
+	addVehicleMarker(vehicle, activeTrip, routeType) {
 		if (!this.map) return null;
 
 		let color;
@@ -335,11 +335,11 @@ export default class GoogleMapProvider {
 			color = COLORS.VEHICLE_REAL_TIME_OFF;
 		}
 
-		const busIcon = createVehicleIconSvg(vehicle?.orientation, color);
+		const vehicleIconSvg = createVehicleIconSvg(vehicle?.orientation, color, routeType);
 		const icon = {
-			url: `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(busIcon)}`,
-			scaledSize: new google.maps.Size(40, 40),
-			anchor: new google.maps.Point(20, 20)
+			url: `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(vehicleIconSvg)}`,
+			scaledSize: new google.maps.Size(iconWidth, iconHeight),
+			anchor: new google.maps.Point(iconWidth / 2, iconHeight / 2)
 		};
 
 		const marker = new google.maps.Marker({
@@ -376,7 +376,7 @@ export default class GoogleMapProvider {
 		return marker;
 	}
 
-	updateVehicleMarker(marker, vehicleStatus, activeTrip) {
+	updateVehicleMarker(marker, vehicleStatus, activeTrip, routeType) {
 		if (!this.map || !marker) return;
 
 		marker.setPosition({ lat: vehicleStatus.position.lat, lng: vehicleStatus.position.lon });
@@ -386,11 +386,11 @@ export default class GoogleMapProvider {
 			color = COLORS.VEHICLE_REAL_TIME_OFF;
 		}
 
-		const updatedIcon = createVehicleIconSvg(vehicleStatus.orientation, color);
+		const updatedIcon = createVehicleIconSvg(vehicleStatus.orientation, color, routeType);
 		marker.setIcon({
 			url: `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(updatedIcon)}`,
-			scaledSize: new google.maps.Size(40, 40),
-			anchor: new google.maps.Point(20, 20)
+			scaledSize: new google.maps.Size(iconWidth, iconHeight),
+			anchor: new google.maps.Point(iconWidth / 2, iconHeight / 2)
 		});
 
 		const updatedData = {

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -7,7 +7,7 @@ import PolylineUtil from 'polyline-encoded';
 import { COLORS } from '$lib/colors';
 import PopupContent from '$components/map/PopupContent.svelte';
 import ContextMenuPopup from '$components/map/ContextMenuPopup.svelte';
-import { createVehicleIconSvg } from '$lib/MapHelpers/generateVehicleIcon';
+import { createVehicleIconSvg, iconHeight, iconWidth } from '$lib/MapHelpers/generateVehicleIcon';
 import VehiclePopupContent from '$components/map/VehiclePopupContent.svelte';
 import TripPlanPinMarker from '$components/trip-planner/tripPlanPinMarker.svelte';
 import { mount, unmount } from 'svelte';
@@ -271,7 +271,7 @@ export default class OpenStreetMapProvider {
 		marker.remove();
 	}
 
-	addVehicleMarker(vehicle, activeTrip) {
+	addVehicleMarker(vehicle, activeTrip, routeType) {
 		if (!this.map || !this.L) return null;
 
 		let color;
@@ -279,11 +279,11 @@ export default class OpenStreetMapProvider {
 			color = COLORS.VEHICLE_REAL_TIME_OFF;
 		}
 
-		const busIconSvg = createVehicleIconSvg(vehicle?.orientation, color);
+		const vehicleIconSvg = createVehicleIconSvg(vehicle?.orientation, color, routeType);
 		const customIcon = this.L.divIcon({
-			html: `<img src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(busIconSvg)}" style="width:45px;height:45px;" />`,
-			iconSize: [40, 40],
-			iconAnchor: [20, 20],
+			html: `<img src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(vehicleIconSvg)}" />`,
+			iconSize: [iconWidth, iconHeight],
+			iconAnchor: [iconWidth / 2, iconHeight / 2],
 			className: '',
 			zIndexOffset: 1000
 		});
@@ -326,7 +326,7 @@ export default class OpenStreetMapProvider {
 		return marker;
 	}
 
-	updateVehicleMarker(marker, vehicleStatus, activeTrip) {
+	updateVehicleMarker(marker, vehicleStatus, activeTrip, routeType) {
 		if (!this.map || !this.L || !marker) return;
 
 		let color;
@@ -334,11 +334,11 @@ export default class OpenStreetMapProvider {
 			color = COLORS.VEHICLE_REAL_TIME_OFF;
 		}
 
-		const updatedIconSvg = createVehicleIconSvg(vehicleStatus.orientation, color);
+		const updatedIconSvg = createVehicleIconSvg(vehicleStatus.orientation, color, routeType);
 		const updatedIcon = this.L.divIcon({
-			html: `<img src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(updatedIconSvg)}" style="width:45px;height:45px;" />`,
-			iconSize: [40, 40],
-			iconAnchor: [20, 20],
+			html: `<img src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(updatedIconSvg)}" />`,
+			iconSize: [iconWidth, iconHeight],
+			iconAnchor: [iconWidth / 2, iconHeight / 2],
 			className: '',
 			zIndexOffset: 1000
 		});

--- a/src/lib/vehicleUtils.js
+++ b/src/lib/vehicleUtils.js
@@ -19,7 +19,7 @@ export async function fetchVehicles(routeId) {
 	return responseBody.data || {};
 }
 
-export async function updateVehicleMarkers(routeId, mapProvider) {
+export async function updateVehicleMarkers(routeId, mapProvider, routeType) {
 	const data = await fetchVehicles(routeId);
 
 	const activeTripIds = new Set();
@@ -42,9 +42,9 @@ export async function updateVehicleMarkers(routeId, mapProvider) {
 			if (vehicleMarkersMap.has(activeTripId)) {
 				const marker = vehicleMarkersMap.get(activeTripId);
 
-				mapProvider.updateVehicleMarker(marker, vehicleStatus, activeTrip);
+				mapProvider.updateVehicleMarker(marker, vehicleStatus, activeTrip, routeType);
 			} else {
-				const marker = mapProvider.addVehicleMarker(vehicleStatus, activeTrip);
+				const marker = mapProvider.addVehicleMarker(vehicleStatus, activeTrip, routeType);
 				vehicleMarkersMap.set(activeTripId, marker);
 			}
 		}
@@ -62,10 +62,10 @@ export function removeInactiveMarkers(activeTripIds, mapProvider) {
 	}
 }
 
-export async function fetchAndUpdateVehicles(routeId, mapProvider) {
-	await updateVehicleMarkers(routeId, mapProvider);
+export async function fetchAndUpdateVehicles(routeId, mapProvider, routeType) {
+	await updateVehicleMarkers(routeId, mapProvider, routeType);
 
-	return setInterval(() => updateVehicleMarkers(routeId, mapProvider), 30000);
+	return setInterval(() => updateVehicleMarkers(routeId, mapProvider, routeType), 30000);
 }
 
 export function clearVehicleMarkersMap() {


### PR DESCRIPTION
Updated real-time bus markers on route view to use the font-awesome bus icon instead of the silly looking "pac-man" bus. Also, the icon will now match the route type instead of just using the bus for everything.

Bus route
<img width="277" height="291" alt="Screenshot 2026-02-19 at 10 46 08 PM" src="https://github.com/user-attachments/assets/e817d96a-4a4e-418d-b185-155c08d0820d" />

Street-car route
<img width="680" height="793" alt="Screenshot 2026-02-19 at 10 45 57 PM" src="https://github.com/user-attachments/assets/3acf7789-f15b-40cf-892d-900d4a774289" />
