### PR TITLE
Fix accessibility violations: add landmarks, skip link, heading, and button labels

### DIFF
--- a/src/components/map/StopMarker.svelte
+++ b/src/components/map/StopMarker.svelte
@@ -73,6 +73,7 @@
 		class="custom-marker dark:border-[#5a2c2c] {isHighlighted ? 'highlight' : ''}"
 		onclick={onClick}
 	>
+		<span class="sr-only">{stop.name}</span>
 		<span class="bus-icon dark:text-white">
 			<FontAwesomeIcon {icon} class=" text-black" />
 			{#if stop.direction}

--- a/src/components/navigation/Header.svelte
+++ b/src/components/navigation/Header.svelte
@@ -218,7 +218,7 @@
 	});
 </script>
 
-<div
+<header
 	class="relative z-[9999] flex items-center justify-between border-b border-gray-500 bg-brand/80 text-brand-foreground backdrop-blur-md dark:bg-surface-dark dark:text-surface-foreground-dark md:flex-row md:px-8"
 	bind:this={navContainer}
 >
@@ -243,7 +243,10 @@
 
 	<div class="flex-1"></div>
 
-	<div class="flex items-center gap-x-2 px-1 py-1 md:gap-x-4 md:px-2 md:py-2">
+	<nav
+		aria-label="Main navigation"
+		class="flex items-center gap-x-2 px-1 py-1 md:gap-x-4 md:px-2 md:py-2"
+	>
 		{#each visibleLinks as { key, value }}
 			<div class="flex-shrink-0 rounded-md border bg-surface/80 dark:bg-surface-dark">
 				<a
@@ -282,5 +285,5 @@
 		<div class="language-switcher-container flex-shrink-0" bind:this={languageSwitcherElement}>
 			<LanguageSwitcher />
 		</div>
-	</div>
-</div>
+	</nav>
+</header>

--- a/src/components/navigation/__tests__/Header.test.js
+++ b/src/components/navigation/__tests__/Header.test.js
@@ -118,7 +118,7 @@ describe('Header', () => {
 	test('header has proper CSS classes for styling', () => {
 		const { container } = render(Header);
 
-		const header = container.querySelector('div');
+		const header = container.querySelector('header');
 		expect(header).toHaveClass(
 			'flex',
 			'items-center',

--- a/src/lib/LocationButton/LocationButton.svelte
+++ b/src/lib/LocationButton/LocationButton.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 	import { faLocationCrosshairs } from '@fortawesome/free-solid-svg-icons';
+	import { t } from 'svelte-i18n';
 
 	let { handleLocationObtained } = $props();
 
@@ -29,7 +30,11 @@
 	});
 </script>
 
-<button bind:this={button} class="custom-map-control-button">
+<button
+	bind:this={button}
+	class="custom-map-control-button"
+	aria-label={$t('map.find_my_location')}
+>
 	<FontAwesomeIcon icon={faLocationCrosshairs} />
 </button>
 

--- a/src/locales/am.json
+++ b/src/locales/am.json
@@ -153,6 +153,9 @@
 		"select_language": "ቋንቋ ይምረጡ: {language}",
 		"available_languages": "የሚገኙ ቋንቋዎች"
 	},
+	"map": {
+		"find_my_location": "ቦታዬን ፈልግ"
+	},
 	"context-menu": {
 		"start_here": "ከዚህ ጀምር",
 		"end_here": "ዚህ ጨርስ"

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -153,6 +153,9 @@
 		"select_language": "اختر اللغة: {language}",
 		"available_languages": "اللغات المتاحة"
 	},
+	"map": {
+		"find_my_location": "تحديد موقعي"
+	},
 	"context-menu": {
 		"start_here": "ابدأ من هنا",
 		"end_here": "انتهِ هنا"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -175,6 +175,9 @@
 		"select_language": "Select language: {language}",
 		"available_languages": "Available languages"
 	},
+	"map": {
+		"find_my_location": "Find My Location"
+	},
 	"context-menu": {
 		"start_here": "Start Here",
 		"end_here": "End Here"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -150,6 +150,9 @@
 		"select_language": "Seleccionar idioma: {language}",
 		"available_languages": "Idiomas disponibles"
 	},
+	"map": {
+		"find_my_location": "Encontrar mi ubicación"
+	},
 	"context-menu": {
 		"start_here": "Comenzar aquí",
 		"end_here": "Terminar aquí"

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -153,6 +153,9 @@
 		"select_language": "انتخاب زبان: {language}",
 		"available_languages": "زبان‌های موجود"
 	},
+	"map": {
+		"find_my_location": "موقعیت من را پیدا کن"
+	},
 	"context-menu": {
 		"start_here": "شروع از اینجا",
 		"end_here": "پایان در اینجا"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -153,6 +153,9 @@
 		"select_language": "Sélectionner la langue : {language}",
 		"available_languages": "Langues disponibles"
 	},
+	"map": {
+		"find_my_location": "Trouver ma position"
+	},
 	"context-menu": {
 		"start_here": "Partir d'ici",
 		"end_here": "Arriver ici"

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -153,6 +153,9 @@
 		"select_language": "भाषा चुनें: {language}",
 		"available_languages": "उपलब्ध भाषाएं"
 	},
+	"map": {
+		"find_my_location": "मेरा स्थान खोजें"
+	},
 	"context-menu": {
 		"start_here": "यहाँ से शुरू करें",
 		"end_here": "यहाँ समाप्त करें"

--- a/src/locales/ht.json
+++ b/src/locales/ht.json
@@ -153,6 +153,9 @@
 		"select_language": "Chwazi lang: {language}",
 		"available_languages": "Lang ki disponib"
 	},
+	"map": {
+		"find_my_location": "Jwenn kote mwen ye"
+	},
 	"context-menu": {
 		"start_here": "Kòmanse isit",
 		"end_here": "Fini isit"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -153,6 +153,9 @@
 		"select_language": "言語を選択: {language}",
 		"available_languages": "利用可能な言語"
 	},
+	"map": {
+		"find_my_location": "現在地を表示"
+	},
 	"context-menu": {
 		"start_here": "ここから出発",
 		"end_here": "ここに到着"

--- a/src/locales/km.json
+++ b/src/locales/km.json
@@ -153,6 +153,9 @@
 		"select_language": "ជ្រើសរើសភាសា: {language}",
 		"available_languages": "ភាសាដែលមាន"
 	},
+	"map": {
+		"find_my_location": "រកទីតាំងរបស់ខ្ញុំ"
+	},
 	"context-menu": {
 		"start_here": "ចាប់ផ្ដើមនៅទីនេះ",
 		"end_here": "បញ្ចប់នៅទីនេះ"

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -153,6 +153,9 @@
 		"select_language": "언어 선택: {language}",
 		"available_languages": "사용 가능한 언어"
 	},
+	"map": {
+		"find_my_location": "내 위치 찾기"
+	},
 	"context-menu": {
 		"start_here": "여기에서 출발",
 		"end_here": "여기에서 도착"

--- a/src/locales/lo.json
+++ b/src/locales/lo.json
@@ -153,6 +153,9 @@
 		"select_language": "ເລືອກພາສາ: {language}",
 		"available_languages": "ພາສາທີ່ມີ"
 	},
+	"map": {
+		"find_my_location": "ຊອກຫາທີ່ຕັ້ງຂອງຂ້ອຍ"
+	},
 	"context-menu": {
 		"start_here": "ເລີ່ມຈາກບ່ອນນີ້",
 		"end_here": "ສິ້ນສຸດທີ່ນີ້"

--- a/src/locales/om.json
+++ b/src/locales/om.json
@@ -153,6 +153,9 @@
 		"select_language": "Afaan filadhu: {language}",
 		"available_languages": "Afaanota jiran"
 	},
+	"map": {
+		"find_my_location": "Bakka Koo Barbaadi"
+	},
 	"context-menu": {
 		"start_here": "As'itti eegali",
 		"end_here": "As'itti xumuri"

--- a/src/locales/pa.json
+++ b/src/locales/pa.json
@@ -153,6 +153,9 @@
 		"select_language": "ਭਾਸ਼ਾ ਚੁਣੋ: {language}",
 		"available_languages": "ਉਪਲਬਧ ਭਾਸ਼ਾਵਾਂ"
 	},
+	"map": {
+		"find_my_location": "ਮੇਰੀ ਸਥਿਤੀ ਲੱਭੋ"
+	},
 	"context-menu": {
 		"start_here": "ਇੱਥੋਂ ਸ਼ੁਰੂ ਕਰੋ",
 		"end_here": "ਇੱਥੇ ਖ਼ਤਮ ਕਰੋ"

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -149,6 +149,9 @@
 		"select_language": "Wybierz język: {language}",
 		"available_languages": "Dostępne języki"
 	},
+	"map": {
+		"find_my_location": "Znajdź moją lokalizację"
+	},
 	"context-menu": {
 		"start_here": "Rozpocznij tutaj",
 		"end_here": "Zakończ tutaj"

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -153,6 +153,9 @@
 		"select_language": "Selecionar idioma: {language}",
 		"available_languages": "Idiomas disponíveis"
 	},
+	"map": {
+		"find_my_location": "Encontrar minha localização"
+	},
 	"context-menu": {
 		"start_here": "Começar aqui",
 		"end_here": "Terminar aqui"

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -153,6 +153,9 @@
 		"select_language": "Выберите язык: {language}",
 		"available_languages": "Доступные языки"
 	},
+	"map": {
+		"find_my_location": "Найти моё местоположение"
+	},
 	"context-menu": {
 		"start_here": "Начать отсюда",
 		"end_here": "Закончить здесь"

--- a/src/locales/sm.json
+++ b/src/locales/sm.json
@@ -153,6 +153,9 @@
 		"select_language": "Filifili gagana: {language}",
 		"available_languages": "Gagana avanoa"
 	},
+	"map": {
+		"find_my_location": "Su'e Lo'u Nofoaga"
+	},
 	"context-menu": {
 		"start_here": "Amata mai iinei",
 		"end_here": "Fa'ai'u iinei"

--- a/src/locales/so.json
+++ b/src/locales/so.json
@@ -153,6 +153,9 @@
 		"select_language": "Dooro luuqadda: {language}",
 		"available_languages": "Luuqadaha la heli karo"
 	},
+	"map": {
+		"find_my_location": "Raadi Goobteeyda"
+	},
 	"context-menu": {
 		"start_here": "Halkan ka bilow",
 		"end_here": "Halkan ku dhamee"

--- a/src/locales/ti.json
+++ b/src/locales/ti.json
@@ -153,6 +153,9 @@
 		"select_language": "ቋንቋ ምረጽ: {language}",
 		"available_languages": "ዝርከቡ ቋንቋታት"
 	},
+	"map": {
+		"find_my_location": "ቦታይ ፈልጥ"
+	},
 	"context-menu": {
 		"start_here": "ካብዚ ጀምር",
 		"end_here": "ኣብዚ ውድእ"

--- a/src/locales/tl.json
+++ b/src/locales/tl.json
@@ -154,6 +154,9 @@
 		"select_language": "Piliin ang wika: {language}",
 		"available_languages": "Mga available na wika"
 	},
+	"map": {
+		"find_my_location": "Hanapin ang Aking Lokasyon"
+	},
 	"context-menu": {
 		"start_here": "Magsimula dito",
 		"end_here": "Magtapos dito"

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -153,6 +153,9 @@
 		"select_language": "Оберіть мову: {language}",
 		"available_languages": "Доступні мови"
 	},
+	"map": {
+		"find_my_location": "Знайти моє місцезнаходження"
+	},
 	"context-menu": {
 		"start_here": "Почати звідси",
 		"end_here": "Закінчити тут"

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -153,6 +153,9 @@
 		"select_language": "Chọn ngôn ngữ: {language}",
 		"available_languages": "Ngôn ngữ có sẵn"
 	},
+	"map": {
+		"find_my_location": "Tìm vị trí của tôi"
+	},
 	"context-menu": {
 		"start_here": "Bắt đầu từ đây",
 		"end_here": "Kết thúc tại đây"

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -153,6 +153,9 @@
 		"select_language": "选择语言: {language}",
 		"available_languages": "可用语言"
 	},
+	"map": {
+		"find_my_location": "查找我的位置"
+	},
 	"context-menu": {
 		"start_here": "从这里出发",
 		"end_here": "到这里结束"

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -153,6 +153,9 @@
 		"select_language": "選擇語言: {language}",
 		"available_languages": "可用語言"
 	},
+	"map": {
+		"find_my_location": "尋找我的位置"
+	},
 	"context-menu": {
 		"start_here": "從這裡出發",
 		"end_here": "到這裡結束"

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -45,8 +45,14 @@
 </svelte:head>
 
 <div class="flex h-dvh w-full flex-col">
+	<a
+		href="#main-content"
+		class="sr-only z-[99999] focus:not-sr-only focus:fixed focus:left-2 focus:top-2 focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-black focus:shadow-lg focus:ring-2 focus:ring-blue-500"
+	>
+		Skip to main content
+	</a>
 	<Header />
-	<div class="relative flex-1 overflow-hidden dark:bg-black">
+	<main id="main-content" class="relative flex-1 overflow-hidden dark:bg-black">
 		{@render children?.()}
-	</div>
+	</main>
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -278,6 +278,7 @@
 {#if $isLoading}
 	<p>Loading...</p>
 {:else}
+	<h1 class="sr-only">{PUBLIC_OBA_REGION_NAME}</h1>
 	<div class="pointer-events-none absolute bottom-0 left-0 right-0 top-0 z-40">
 		<div class="mx-2 mt-2 flex h-full flex-col md:mx-4 md:mt-4 md:w-96">
 			<SearchPane


### PR DESCRIPTION
- Add semantic HTML landmarks: `<header>`, `<nav>`, `<main>` to replace generic divs
- Add "Skip to main content" link for keyboard navigation (WCAG 2.4.1)
- Add sr-only `<h1>` heading with region name to main page
- Add aria-label to location crosshairs button (WCAG 4.1.2)
- Add sr-only label to stop markers for screen reader access
- Add map.find_my_location i18n key across all 25 locales