### PR TITLE
Make OTP server URL optional

### DIFF
--- a/src/routes/api/otp/plan/+server.js
+++ b/src/routes/api/otp/plan/+server.js
@@ -1,5 +1,5 @@
 import { error, json } from '@sveltejs/kit';
-import { PUBLIC_OTP_SERVER_URL } from '$env/static/public';
+import { env } from '$env/static/public';
 import {
 	buildGraphQLQueryBody,
 	formatTimeForOTP,
@@ -16,7 +16,7 @@ import {
  */
 async function fetchREST(params) {
 	const searchParams = new URLSearchParams(params);
-	const otpUrl = `${PUBLIC_OTP_SERVER_URL}/routers/default/plan?${searchParams}`;
+	const otpUrl = `${env.PUBLIC_OTP_SERVER_URL}/routers/default/plan?${searchParams}`;
 
 	const response = await fetch(otpUrl, {
 		headers: { Accept: 'application/json' }
@@ -36,7 +36,7 @@ async function fetchREST(params) {
  * @throws {HttpError} SvelteKit HttpError on non-2xx responses
  */
 async function fetchGraphQL(params) {
-	const graphqlUrl = `${PUBLIC_OTP_SERVER_URL}/gtfs/v1`;
+	const graphqlUrl = `${env.PUBLIC_OTP_SERVER_URL}/gtfs/v1`;
 
 	const response = await fetch(graphqlUrl, {
 		method: 'POST',
@@ -98,7 +98,7 @@ export async function GET({ url }) {
 		throw error(400, 'Missing required parameters: fromPlace and toPlace');
 	}
 
-	if (!PUBLIC_OTP_SERVER_URL) {
+	if (!env.PUBLIC_OTP_SERVER_URL) {
 		throw error(503, 'Trip planning is not configured for this region');
 	}
 

--- a/src/tests/api/otp-plan.test.js
+++ b/src/tests/api/otp-plan.test.js
@@ -188,7 +188,7 @@ describe('GET /api/otp/plan', () => {
 		mockApiType = 'graphql';
 
 		vi.doMock('$env/static/public', () => ({
-			PUBLIC_OTP_SERVER_URL: 'https://otp.test.example.com'
+			env: { PUBLIC_OTP_SERVER_URL: 'https://otp.test.example.com' }
 		}));
 
 		const mod = await import('../../routes/api/otp/plan/+server.js');
@@ -220,7 +220,7 @@ describe('GET /api/otp/plan', () => {
 	it('returns 503 when PUBLIC_OTP_SERVER_URL is not configured', async () => {
 		vi.resetModules();
 		vi.doMock('$env/static/public', () => ({
-			PUBLIC_OTP_SERVER_URL: ''
+			env: { PUBLIC_OTP_SERVER_URL: '' }
 		}));
 		const mod = await import('../../routes/api/otp/plan/+server.js');
 


### PR DESCRIPTION
## Summary
- Switches `PUBLIC_OTP_SERVER_URL` from a named import to the `env` object from `$env/static/public`, so the variable can be absent without causing a build-time error
- Regions without an OTP server will now build successfully and return a 503 when trip planning is requested
- Updates tests to match the new import pattern

## Test plan
- [x] Verify `npm run build` succeeds without `PUBLIC_OTP_SERVER_URL` set
- [x] Verify trip planning works when `PUBLIC_OTP_SERVER_URL` is configured
- [x] Verify a 503 is returned when `PUBLIC_OTP_SERVER_URL` is empty/unset
- [x] Run `npm run test` to confirm all tests pass