### PR TITLE
Using $env/dynamic/public instead of $env/static/public

### DIFF
--- a/src/routes/api/otp/plan/+server.js
+++ b/src/routes/api/otp/plan/+server.js
@@ -1,5 +1,5 @@
 import { error, json } from '@sveltejs/kit';
-import { env } from '$env/static/public';
+import { env } from '$env/dynamic/public';
 import {
 	buildGraphQLQueryBody,
 	formatTimeForOTP,

--- a/src/tests/api/otp-plan.test.js
+++ b/src/tests/api/otp-plan.test.js
@@ -187,7 +187,7 @@ describe('GET /api/otp/plan', () => {
 		global.fetch = mockFetch;
 		mockApiType = 'graphql';
 
-		vi.doMock('$env/static/public', () => ({
+		vi.doMock('$env/dynamic/public', () => ({
 			env: { PUBLIC_OTP_SERVER_URL: 'https://otp.test.example.com' }
 		}));
 
@@ -219,7 +219,7 @@ describe('GET /api/otp/plan', () => {
 
 	it('returns 503 when PUBLIC_OTP_SERVER_URL is not configured', async () => {
 		vi.resetModules();
-		vi.doMock('$env/static/public', () => ({
+		vi.doMock('$env/dynamic/public', () => ({
 			env: { PUBLIC_OTP_SERVER_URL: '' }
 		}));
 		const mod = await import('../../routes/api/otp/plan/+server.js');


### PR DESCRIPTION
Fixes an runtime error when planning a trip