### PR TITLE
fix: crash when alerts have empty activePeriod

### DIFF
--- a/src/routes/api/oba/alerts/+server.js
+++ b/src/routes/api/oba/alerts/+server.js
@@ -89,8 +89,11 @@ function getSeverityLevel(alert) {
 	return alert.severityLevel;
 }
 
-function isStartDateWithin24Hours(alert) {
+export function isStartDateWithin24Hours(alert) {
+	if (!alert) return false;
+	if (!alert.activePeriod || alert.activePeriod.length === 0) return false;
 	const startDate = alert.activePeriod[0].start;
+	if (!startDate) return false;
 	const now = Date.now() / 1000;
 	return startDate <= now && startDate >= now - 24 * 60 * 60;
 }

--- a/src/tests/api/alerts.test.js
+++ b/src/tests/api/alerts.test.js
@@ -37,7 +37,7 @@ vi.mock('gtfs-realtime-bindings', () => ({
 	}
 }));
 
-import { GET } from '../../routes/api/oba/alerts/+server.js';
+import { GET, isStartDateWithin24Hours } from '../../routes/api/oba/alerts/+server.js';
 
 describe('GET /api/oba/alerts', () => {
 	beforeEach(() => {
@@ -62,5 +62,37 @@ describe('GET /api/oba/alerts', () => {
 		const response = await GET();
 
 		expect(response.status).toBe(204);
+	});
+});
+
+describe('isStartDateWithin24Hours', () => {
+	it('returns false when alert is null', () => {
+		expect(isStartDateWithin24Hours(null)).toBe(false);
+	});
+
+	it('returns false when alert is undefined', () => {
+		expect(isStartDateWithin24Hours(undefined)).toBe(false);
+	});
+
+	it('returns false when activePeriod is an empty array', () => {
+		expect(isStartDateWithin24Hours({ activePeriod: [] })).toBe(false);
+	});
+
+	it('returns false when activePeriod is undefined', () => {
+		expect(isStartDateWithin24Hours({ activePeriod: undefined })).toBe(false);
+	});
+
+	it('returns false when activePeriod is null', () => {
+		expect(isStartDateWithin24Hours({ activePeriod: null })).toBe(false);
+	});
+
+	it('returns false when activePeriod[0].start is undefined', () => {
+		expect(isStartDateWithin24Hours({ activePeriod: [{}] })).toBe(false);
+	});
+
+	it('returns true when start is within the last 24 hours', () => {
+		const nowSeconds = Math.floor(Date.now() / 1000);
+		const oneHourAgo = nowSeconds - 60 * 60;
+		expect(isStartDateWithin24Hours({ activePeriod: [{ start: oneHourAgo }] })).toBe(true);
 	});
 });


### PR DESCRIPTION
## SUMMARY

Fixes a crash in the alerts API when an alert has an empty `activePeriod`. Since this field can be empty in the GTFS-RT spec, accessing `activePeriod[0]` without checks can throw a runtime error.
Adds simple guards in `isStartDateWithin24Hours()` in `src/routes/api/oba/alerts/+server.js`.

---

## FIX

**Before**

```javascript
const startDate = alert.activePeriod[0].start;
```

**After**

```javascript
if (!alert.activePeriod || alert.activePeriod.length === 0) return false;

const startDate = alert.activePeriod[0].start;
if (!startDate) return false;
```

Adds defensive checks so the function safely skips alerts without a valid `activePeriod`.

---

## VERIFICATION

**Steps**

1. Use an alert with `activePeriod: []`.
2. Call `/api/oba/alerts`.
