### PR TITLE
fix: add null safety guards to hexToRgb and getBrightness

### DIFF
--- a/src/lib/colorUtils.js
+++ b/src/lib/colorUtils.js
@@ -10,6 +10,7 @@
  * @returns {{r: number, g: number, b: number} | null} RGB object or null if invalid
  */
 export function hexToRgb(hex) {
+	if (!hex || typeof hex !== 'string') return null;
 	hex = hex.replace(/^#/, '');
 	// Expand 3-digit hex to 6-digit
 	if (hex.length === 3) {
@@ -21,10 +22,10 @@ export function hexToRgb(hex) {
 	const result = /^([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
 	return result
 		? {
-				r: parseInt(result[1], 16),
-				g: parseInt(result[2], 16),
-				b: parseInt(result[3], 16)
-			}
+			r: parseInt(result[1], 16),
+			g: parseInt(result[2], 16),
+			b: parseInt(result[3], 16)
+		}
 		: null;
 }
 
@@ -141,6 +142,7 @@ export function lightenColor(hexColor, amount) {
  * @returns {number} Brightness value (0-255)
  */
 export function getBrightness(rgb) {
+	if (!rgb) return 0;
 	// Standard luminance formula
 	return 0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b;
 }

--- a/src/tests/lib/colorUtils.test.js
+++ b/src/tests/lib/colorUtils.test.js
@@ -124,8 +124,8 @@ describe('colorUtils', () => {
 		let consoleErrorSpy;
 
 		beforeEach(() => {
-			consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
-			consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+			consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+			consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 		});
 
 		afterEach(() => {

--- a/src/tests/lib/colorUtils.test.js
+++ b/src/tests/lib/colorUtils.test.js
@@ -124,8 +124,8 @@ describe('colorUtils', () => {
 		let consoleErrorSpy;
 
 		beforeEach(() => {
-			consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-			consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+			consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+			consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
 		});
 
 		afterEach(() => {


### PR DESCRIPTION
this fixes a crash in the color utility pipeline when route or agency color data is missing.

hexToRgb() was calling .replace() on null/undefined, and getBrightness() could then crash by accessing .r/.g/.b on a null value. I added small defensive guards so these functions fail safely instead of throwing.

Changes:

hexToRgb() now returns null for missing or non-string input

getBrightness() now returns 0 for falsy input
Testing

Verified that:
valid 3-digit and 6-digit hex values still work

invalid inputs (null, undefined, empty string, bad values, non-strings) return safe fallbacks

getBrightness(hexToRgb(null)) no longer crashes

related helpers like adjustColorForDarkMode() and generatePalette() still handle missing colors safely

All tests are passing.
