### PR TITLE
fix: use brand theme tokens for trip planner From/To markers

### DIFF
--- a/src/components/trip-planner/__tests__/TripPlanPinMarker.test.js
+++ b/src/components/trip-planner/__tests__/TripPlanPinMarker.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import TripPlanPinMarker from '../tripPlanPinMarker.svelte';
+
+describe('TripPlanPinMarker', () => {
+	it('renders the label text', () => {
+		const { getByText } = render(TripPlanPinMarker, { props: { text: 'From' } });
+		expect(getByText('From')).toBeInTheDocument();
+	});
+
+	it('uses brand-accent background and brand-foreground text on the bubble', () => {
+		const { getByText } = render(TripPlanPinMarker, { props: { text: 'From' } });
+		const bubble = getByText('From');
+		expect(bubble).toHaveClass('bg-brand-accent', 'text-brand-foreground');
+	});
+
+	it('uses brand-accent fill on the pin SVG path', () => {
+		const { container } = render(TripPlanPinMarker, { props: { text: 'To' } });
+		const path = container.querySelector('svg path');
+		expect(path).toHaveClass('fill-brand-accent');
+	});
+
+	it('does not contain hardcoded green color #79aa38', () => {
+		const { container } = render(TripPlanPinMarker, { props: { text: 'From' } });
+		const html = container.innerHTML;
+		expect(html).not.toContain('#79aa38');
+	});
+
+	it('defaults text to "From"', () => {
+		const { getByText } = render(TripPlanPinMarker);
+		expect(getByText('From')).toBeInTheDocument();
+	});
+});

--- a/src/components/trip-planner/tripPlanPinMarker.svelte
+++ b/src/components/trip-planner/tripPlanPinMarker.svelte
@@ -2,18 +2,18 @@
 	/**
 	 * @typedef {Object} Props
 	 * @property {string} [text]
-	 * @property {string} [color]
 	 */
 
 	/** @type {Props} */
-	let { text = 'From', color = '#79aa38' } = $props();
+	let { text = 'From' } = $props();
 </script>
 
 <div
 	style="position: relative; display: flex; flex-direction: column; align-items: center; font-family: Arial, sans-serif;"
 >
 	<div
-		style="font-size: 14px; color: #ffffff; background-color: #79aa38; border-radius: 8px; padding: 6px 10px; margin-bottom: 6px; box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);"
+		class="bg-brand-accent text-brand-foreground"
+		style="font-size: 14px; border-radius: 8px; padding: 6px 10px; margin-bottom: 6px; box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);"
 	>
 		{text}
 	</div>
@@ -26,8 +26,8 @@
 		style="background-color: #ffffff; border-radius: 50%; padding: 8px; box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);"
 	>
 		<path
+			class="fill-brand-accent"
 			d="M12 2C8.13 2 5 5.13 5 9C5 14.25 12 22 12 22C12 22 19 14.25 19 9C19 5.13 15.87 2 12 2ZM12 11.5C10.62 11.5 9.5 10.38 9.5 9C9.5 7.62 10.62 6.5 12 6.5C13.38 6.5 14.5 7.62 14.5 9C14.5 10.38 13.38 11.5 12 11.5Z"
-			fill={color}
 			stroke="#333"
 			stroke-width="1.5"
 			stroke-linecap="round"


### PR DESCRIPTION
## Summary
Updated the trip planner “From” and “To” markers to use Wayfinder’s brand theme tokens instead of a hardcoded green color.


This keeps the marker bubbles and pin visually consistent with the configured agency branding and the rest of the app.

## Problem
The trip planner “From” / “To” label bubbles and map pin were using a fixed green color (`#79aa38`) rather than the app’s theme tokens. As a result, these markers did not reflect agency-specific branding and could look inconsistent in branded deployments.

## Changes

### `src/components/trip-planner/tripPlanPinMarker.svelte`
- Replaced bubble background color with `bg-brand-accent`
- Replaced bubble text color with `text-brand-foreground`
- Updated the pin styling to use the brand accent theme instead of the hardcoded green
- Removed the unused `color` prop since it was not passed by any caller

### `src/components/trip-planner/__tests__/TripPlanPinMarker.test.js`
- Added 5 unit tests to verify:
  - brand theme classes are applied correctly
  - hardcoded green styling is no longer used
  - marker rendering remains stable

## Test Plan
- [x] All 1162 tests pass (53 test files)
- [x] Verified that the marker uses brand theme classes

Closes #392 
