### PR TITLE
fix: enable translation of navbar buttons

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ PRIVATE_OBACO_SHOW_TEST_ALERTS=false
 # Example: PRIVATE_OBA_AGENCY_FILTER=19,29
 PRIVATE_OBA_AGENCY_FILTER=
 
-PUBLIC_NAV_BAR_LINKS={"Home": "/","About": "/about","Contact": "/contact","Fares & Tolls": "/fares-and-tolls"}
+PUBLIC_NAV_BAR_LINKS={"header.home": "/","header.about": "/about","header.contact": "/contact","header.fares_and_tolls": "/fares-and-tolls"}
 PUBLIC_OBA_GOOGLE_MAPS_API_KEY=""
 PUBLIC_OBA_LOGO_URL="https://onebusaway.org/wp-content/uploads/oba_logo-1.png"
 OBA_LOGO_URL_DARK=""

--- a/src/components/navigation/Header.svelte
+++ b/src/components/navigation/Header.svelte
@@ -5,6 +5,7 @@
 		PUBLIC_NAV_BAR_LINKS
 	} from '$env/static/public';
 
+	import { t } from 'svelte-i18n';
 	import { onMount } from 'svelte';
 	import OverflowMenu from './OverflowMenu.svelte';
 	import LanguageSwitcher from './LanguageSwitcher/LanguageSwitcher.svelte';
@@ -252,8 +253,9 @@
 				<a
 					href={value}
 					class="block px-2 py-1 font-semibold text-surface-foreground dark:text-surface-foreground-dark"
-					>{key}</a
-				>
+					>
+						{$t(key)}
+				</a>
 			</div>
 		{/each}
 

--- a/src/components/navigation/OverflowMenu.svelte
+++ b/src/components/navigation/OverflowMenu.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { t } from 'svelte-i18n';
 	let { links = [], onClose } = $props();
 	let menuRef = $state(null);
 
@@ -30,7 +31,7 @@
 				onclick={onClose}
 				class="block px-4 py-2 text-sm font-semibold text-surface-foreground hover:bg-gray-100 dark:text-surface-foreground-dark dark:hover:bg-gray-700"
 			>
-				{key}
+				{$t(key)}
 			</a>
 		{/each}
 	</div>


### PR DESCRIPTION
## Summary
This PR fixes an UI issue where navigation bar buttons remain in English after switching languages.

## Related Issue
Closes #395 

## Changes Made
- Imported `t` from `svelte-i18n` in `src/components/navigation/Header.svelte` and `src/components/navigation/OverflowMenu.svelte`
- Updated the original `<a>{key}</a>` to `<a>{$t(key)}</a>` in both files
- Updated the `PUBLIC_NAV_BAR_LINKS` IN `.env.example` to enable translation of the 4 buttons

## Notes
This PR only affects static navigation bar labels