### PR TITLE
fix: malformed Tailwind dark mode class in StopItem

### DIFF
--- a/src/components/StopItem.svelte
+++ b/src/components/StopItem.svelte
@@ -4,7 +4,7 @@
 
 <button
 	type="button"
-	class="stop-item dark:bg[#000000] flex w-full items-center justify-between border-b border-gray-200 bg-[#f9f9f9] p-4 text-left hover:bg-[#e9e9e9] focus:outline-none dark:border-[#313135] dark:bg-[#1c1c1c] dark:hover:bg-[#363636]"
+	class="stop-item dark:bg-black flex w-full items-center justify-between border-b border-gray-200 bg-[#f9f9f9] p-4 text-left hover:bg-[#e9e9e9] focus:outline-none dark:border-[#313135] dark:bg-[#1c1c1c] dark:hover:bg-[#363636]"
 	onclick={() => handleStopItemClick(stop)}
 >
 	<div class="text-lg font-semibold text-[#000000] dark:text-white">


### PR DESCRIPTION
Fixes #400

### Changes
- Replace invalid `dark:bg[#000000]` with valid `dark:bg-black` in `src/components/StopItem.svelte`.

### Why
- The previous syntax was missing a `-` and was ignored by Tailwind, causing incorrect background in dark mode.