### PR TITLE
fix: add missing aria-labels to interactive elements

### DIFF
--- a/src/components/service-alerts/ServiceAlertItem.svelte
+++ b/src/components/service-alerts/ServiceAlertItem.svelte
@@ -8,7 +8,7 @@
 
 <div
 	class="flex cursor-pointer items-start gap-3 rounded-lg p-1 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700"
-	role="button"
+	role="button" aria-label={$t("service_alerts.view_alert_details")}
 	tabindex="0"
 	onclick={() => openModal(alert)}
 	onkeydown={(e) => {

--- a/src/components/service-alerts/ServiceAlerts.svelte
+++ b/src/components/service-alerts/ServiceAlerts.svelte
@@ -101,7 +101,7 @@
 {/if}
 
 {#if $modalOpen && modalAlert}
-	<div class="center" onkeydown={handleKeydown} role="button" tabindex="0">
+	<div class="center" onkeydown={handleKeydown} role="button" aria-label={$t("service_alerts.close")} tabindex="0">
 		<Modal
 			outsideclose={true}
 			title={modalAlert?.summary?.value || $t('service_alerts.service_alert')}

--- a/src/components/trip-planner/RecentTripsList.svelte
+++ b/src/components/trip-planner/RecentTripsList.svelte
@@ -35,7 +35,7 @@
 		<div class="space-y-2">
 			{#each $recentTrips as trip (trip.id)}
 				<div
-					role="button"
+					role="button" aria-label={$t("trip-planner.plan_this_trip")}
 					tabindex="0"
 					class="dark:hover:bg-gray-750 group relative flex w-full items-center rounded-lg border border-gray-200 bg-white p-2.5 shadow-sm transition-all hover:bg-gray-50 hover:shadow-md dark:border-gray-700 dark:bg-gray-800"
 					onclick={() => handleTripClick(trip)}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -7,6 +7,7 @@
 		"miles": "miles"
 	},
 	"trip-planner": {
+    "plan_this_trip": "Plan this trip",
 		"arrive": "Arrive",
 		"depart": "Depart",
 		"today": "Today",
@@ -161,6 +162,7 @@
 		"NW": "Northwest"
 	},
 	"service_alerts": {
+    "view_alert_details": "View alert details",
 		"more_info": "More info",
 		"close": "Close",
 		"service_alerts": "Service Alerts",


### PR DESCRIPTION
Fixes #399

### Changes
- Added `aria-label` to interactive elements using `role="button"` in the following files:
  - `src/components/service-alerts/ServiceAlertItem.svelte`
  - `src/components/service-alerts/ServiceAlerts.svelte`
  - `src/components/trip-planner/RecentTripsList.svelte`
- Added new translation keys to `src/locales/en.json` (`view_alert_details` and `plan_this_trip`).