### PR TITLE
feat: implement smooth fade-in animation for route polylines #407

### DIFF
--- a/src/components/map/RouteMap.svelte
+++ b/src/components/map/RouteMap.svelte
@@ -51,8 +51,12 @@
 		const routeId = moreTripData?.routeId;
 
 		if (shapeId && isMounted) {
+			shapeData = null;
 			const shapeResponse = await fetch(`/api/oba/shape/${shapeId}`);
-			shapeData = await shapeResponse.json();
+			if (shapeResponse.ok) {
+				shapeData = await shapeResponse.json();
+			}
+
 			const shapePoints = shapeData?.data?.entry?.points;
 			if (shapePoints && isMounted) {
 				await mapProvider.createPolyline(shapePoints);
@@ -61,7 +65,6 @@
 
 		const stopTimes = tripData?.data?.entry?.schedule?.stopTimes ?? [];
 		const stops = tripData?.data?.references?.stops ?? [];
-		// TODO: implement better way to transition to route shape
 		const location = calculateMidpoint(stops);
 
 		mapProvider.flyTo(location.lat, location.lng, 13);

--- a/src/components/map/RouteMap.svelte
+++ b/src/components/map/RouteMap.svelte
@@ -55,6 +55,8 @@
 			const shapeResponse = await fetch(`/api/oba/shape/${shapeId}`);
 			if (shapeResponse.ok) {
 				shapeData = await shapeResponse.json();
+			} else {
+				console.error(`Failed to fetch shape: shapeId=${shapeId}, status=${shapeResponse.status}`);
 			}
 
 			const shapePoints = shapeData?.data?.entry?.points;

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -464,11 +464,15 @@ export default class OpenStreetMapProvider {
 		}
 
 		const withArrow = options.withArrow ?? true;
+		const targetOpacity = options.opacity ?? 1;
+
+		// Used to avoid running fade/arrow logic after the polyline was removed.
+		const fadeInToken = Symbol('fadeInToken');
 
 		const polylineOpts = {
 			color: options.color || COLORS.POLYLINE,
 			weight: options.weight || 4,
-			opacity: options.opacity ?? 1
+			opacity: 0
 		};
 		if (options.dashArray) {
 			polylineOpts.dashArray = options.dashArray;
@@ -477,7 +481,65 @@ export default class OpenStreetMapProvider {
 
 		this.polylines.push(polyline);
 
-		if (!withArrow) return polyline;
+		polyline.__fadeInToken = fadeInToken;
+		polyline.__fadeInRafId = null;
+		polyline.__fadeDeferredMoveEnd = null;
+
+		// Defer fade-in until the route is relevant to what the user sees:
+		// - Already intersects the viewport → start immediately.
+		// - Otherwise wait for the next moveend (e.g. after flyTo / pan / zoom), then start.
+		// startTime is taken when the fade actually begins so the 600ms isn't "burned" while off-screen.
+		const beginFadeIn = () => {
+			if (polyline.__fadeInToken !== fadeInToken || !this.map?.hasLayer(polyline)) return;
+
+			const durationMs = 600;
+			const startTime = performance.now();
+			const step = (now) => {
+				if (polyline.__fadeInToken !== fadeInToken || !this.map?.hasLayer(polyline)) {
+					polyline.__fadeInRafId = null;
+					return;
+				}
+
+				const elapsed = now - startTime;
+				const progress = Math.min(elapsed / durationMs, 1);
+
+				if (progress < 1) {
+					const easedProgress = 1 - Math.pow(1 - progress, 3);
+					polyline.setStyle({ opacity: targetOpacity * easedProgress });
+					polyline.__fadeInRafId = requestAnimationFrame(step);
+				} else {
+					polyline.setStyle({ opacity: targetOpacity });
+					if (withArrow) {
+						this.addArrowDecorator(polyline);
+					}
+					polyline.__fadeInRafId = null;
+				}
+			};
+
+			polyline.__fadeInRafId = requestAnimationFrame(step);
+		};
+
+		const polyBounds = polyline.getBounds();
+		const mapBounds = this.map.getBounds();
+		const overlapsViewport = mapBounds.intersects(polyBounds);
+
+		if (overlapsViewport) {
+			beginFadeIn();
+		} else {
+			const onMoveEnd = () => {
+				this.map.off('moveend', onMoveEnd);
+				polyline.__fadeDeferredMoveEnd = null;
+				beginFadeIn();
+			};
+			polyline.__fadeDeferredMoveEnd = onMoveEnd;
+			this.map.on('moveend', onMoveEnd);
+		}
+
+		return polyline;
+	}
+
+	addArrowDecorator(polyline) {
+		if (!polyline || !this.L || !this.map) return null;
 
 		const arrowDecorator = this.L.polylineDecorator(polyline, {
 			patterns: [
@@ -498,12 +560,23 @@ export default class OpenStreetMapProvider {
 		}).addTo(this.map);
 
 		polyline.arrowDecorator = arrowDecorator;
-
-		return polyline;
+		return arrowDecorator;
 	}
 
 	removePolyline(polyline) {
 		if (!polyline) return;
+
+		if (polyline.__fadeDeferredMoveEnd && this.map) {
+			this.map.off('moveend', polyline.__fadeDeferredMoveEnd);
+			polyline.__fadeDeferredMoveEnd = null;
+		}
+
+		if (polyline.__fadeInRafId != null) {
+			cancelAnimationFrame(polyline.__fadeInRafId);
+			polyline.__fadeInRafId = null;
+		}
+
+		polyline.__fadeInToken = null;
 
 		if (polyline.arrowDecorator) {
 			polyline.arrowDecorator.remove();
@@ -527,6 +600,15 @@ export default class OpenStreetMapProvider {
 
 		this.polylines.forEach((polyline) => {
 			if (polyline) {
+				if (polyline.__fadeDeferredMoveEnd && this.map) {
+					this.map.off('moveend', polyline.__fadeDeferredMoveEnd);
+					polyline.__fadeDeferredMoveEnd = null;
+				}
+				if (polyline.__fadeInRafId != null) {
+					cancelAnimationFrame(polyline.__fadeInRafId);
+					polyline.__fadeInRafId = null;
+				}
+				polyline.__fadeInToken = null;
 				if (polyline.arrowDecorator) {
 					polyline.arrowDecorator.remove();
 					polyline.arrowDecorator = null;

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -12,6 +12,8 @@ import VehiclePopupContent from '$components/map/VehiclePopupContent.svelte';
 import TripPlanPinMarker from '$components/trip-planner/tripPlanPinMarker.svelte';
 import { mount, unmount } from 'svelte';
 
+const polylineAnimationState = new WeakMap();
+
 export default class OpenStreetMapProvider {
 	constructor(handleStopMarkerSelect) {
 		this.handleStopMarkerSelect = handleStopMarkerSelect;
@@ -466,9 +468,6 @@ export default class OpenStreetMapProvider {
 		const withArrow = options.withArrow ?? true;
 		const targetOpacity = options.opacity ?? 1;
 
-		// Used to avoid running fade/arrow logic after the polyline was removed.
-		const fadeInToken = Symbol('fadeInToken');
-
 		const polylineOpts = {
 			color: options.color || COLORS.POLYLINE,
 			weight: options.weight || 4,
@@ -481,22 +480,29 @@ export default class OpenStreetMapProvider {
 
 		this.polylines.push(polyline);
 
-		polyline.__fadeInToken = fadeInToken;
-		polyline.__fadeInRafId = null;
-		polyline.__fadeDeferredMoveEnd = null;
+		const state = {
+			fadeInToken: Symbol('fadeInToken'),
+			fadeInRafId: null,
+			fadeDeferredMoveEnd: null
+		};
+		polylineAnimationState.set(polyline, state);
 
 		// Defer fade-in until the route is relevant to what the user sees:
 		// - Already intersects the viewport → start immediately.
 		// - Otherwise wait for the next moveend (e.g. after flyTo / pan / zoom), then start.
 		// startTime is taken when the fade actually begins so the 600ms isn't "burned" while off-screen.
 		const beginFadeIn = () => {
-			if (polyline.__fadeInToken !== fadeInToken || !this.map?.hasLayer(polyline)) return;
+			const currentState = polylineAnimationState.get(polyline);
+			if (!currentState || !this.map?.hasLayer(polyline)) return;
 
 			const durationMs = 600;
 			const startTime = performance.now();
 			const step = (now) => {
-				if (polyline.__fadeInToken !== fadeInToken || !this.map?.hasLayer(polyline)) {
-					polyline.__fadeInRafId = null;
+				const stepState = polylineAnimationState.get(polyline);
+				if (!stepState || !this.map?.hasLayer(polyline)) {
+					if (stepState) {
+						stepState.fadeInRafId = null;
+					}
 					return;
 				}
 
@@ -506,17 +512,17 @@ export default class OpenStreetMapProvider {
 				if (progress < 1) {
 					const easedProgress = 1 - Math.pow(1 - progress, 3);
 					polyline.setStyle({ opacity: targetOpacity * easedProgress });
-					polyline.__fadeInRafId = requestAnimationFrame(step);
+					stepState.fadeInRafId = requestAnimationFrame(step);
 				} else {
 					polyline.setStyle({ opacity: targetOpacity });
 					if (withArrow) {
 						this.addArrowDecorator(polyline);
 					}
-					polyline.__fadeInRafId = null;
+					stepState.fadeInRafId = null;
 				}
 			};
 
-			polyline.__fadeInRafId = requestAnimationFrame(step);
+			currentState.fadeInRafId = requestAnimationFrame(step);
 		};
 
 		const polyBounds = polyline.getBounds();
@@ -527,12 +533,14 @@ export default class OpenStreetMapProvider {
 			beginFadeIn();
 		} else {
 			const onMoveEnd = () => {
-				this.map.off('moveend', onMoveEnd);
-				polyline.__fadeDeferredMoveEnd = null;
+				const moveState = polylineAnimationState.get(polyline);
+				if (moveState) {
+					moveState.fadeDeferredMoveEnd = null;
+				}
 				beginFadeIn();
 			};
-			polyline.__fadeDeferredMoveEnd = onMoveEnd;
-			this.map.on('moveend', onMoveEnd);
+			state.fadeDeferredMoveEnd = onMoveEnd;
+			this.map.once('moveend', onMoveEnd);
 		}
 
 		return polyline;
@@ -563,25 +571,31 @@ export default class OpenStreetMapProvider {
 		return arrowDecorator;
 	}
 
-	removePolyline(polyline) {
-		if (!polyline) return;
+	_cleanupPolyline(polyline) {
+		const state = polylineAnimationState.get(polyline);
 
-		if (polyline.__fadeDeferredMoveEnd && this.map) {
-			this.map.off('moveend', polyline.__fadeDeferredMoveEnd);
-			polyline.__fadeDeferredMoveEnd = null;
+		if (state?.fadeInRafId != null) {
+			cancelAnimationFrame(state.fadeInRafId);
+			state.fadeInRafId = null;
 		}
 
-		if (polyline.__fadeInRafId != null) {
-			cancelAnimationFrame(polyline.__fadeInRafId);
-			polyline.__fadeInRafId = null;
+		this.map?.off('moveend', state?.fadeDeferredMoveEnd);
+		if (state) {
+			state.fadeDeferredMoveEnd = null;
 		}
 
-		polyline.__fadeInToken = null;
-
-		if (polyline.arrowDecorator) {
+		if (polyline?.arrowDecorator) {
 			polyline.arrowDecorator.remove();
 			polyline.arrowDecorator = null;
 		}
+
+		polylineAnimationState.delete(polyline);
+	}
+
+	removePolyline(polyline) {
+		if (!polyline) return;
+
+		this._cleanupPolyline(polyline);
 
 		polyline.remove();
 
@@ -600,19 +614,7 @@ export default class OpenStreetMapProvider {
 
 		this.polylines.forEach((polyline) => {
 			if (polyline) {
-				if (polyline.__fadeDeferredMoveEnd && this.map) {
-					this.map.off('moveend', polyline.__fadeDeferredMoveEnd);
-					polyline.__fadeDeferredMoveEnd = null;
-				}
-				if (polyline.__fadeInRafId != null) {
-					cancelAnimationFrame(polyline.__fadeInRafId);
-					polyline.__fadeInRafId = null;
-				}
-				polyline.__fadeInToken = null;
-				if (polyline.arrowDecorator) {
-					polyline.arrowDecorator.remove();
-					polyline.arrowDecorator = null;
-				}
+				this._cleanupPolyline(polyline);
 				polyline.remove();
 			}
 		});


### PR DESCRIPTION
## Description
This PR implements a smooth fade-in transition for route polylines, addressing the legacy TODO in `RouteMap.svelte`. It replaces the abrupt "popping" of route shapes with a polished, high-performance animation.

Fixes #407

## Key Changes
- **Animation Logic:** Refactored `createPolyline` in `OpenStreetMapProvider` to use `requestAnimationFrame` for a smooth **600ms** opacity transition.
- **Zero-Jank Sync:** Synchronized the line fade-in with the arrow decorators. Arrows now trigger in the same frame as the final opacity lock, ensuring a seamless visual entry.
- **Resource Management:** Implemented `cancelAnimationFrame` cleanup to prevent memory leaks or animation overlaps during rapid route switching.
- **Code Quality:** - Moved arrow decorator logic to a dedicated helper method `addArrowDecorator`.
    - Removed the TODO comment in `src/components/map/RouteMap.svelte`.
    - Added state reset (`shapeData = null`) before new fetches to prevent data ghosting.

## Verification
- [x] Verified smooth 600ms transition on OpenStreetMap provider.
- [x] Confirmed arrow decorators sync perfectly with the animation completion.
- [x] `npx eslint` passes on modified files.
- [x] Verified no jank or performance lag during map movement.

## Demo

https://github.com/user-attachments/assets/2015c220-1a2f-4c58-b8bf-fd498d79bf36

