### PR TITLE
403 configure maplibre tile layer with env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,3 +70,5 @@ PUBLIC_LANGUAGE_SWITCHER_ENABLED=true
 PUBLIC_LANGUAGE_SWITCHER_BUTTON_FORMAT=native
 # Menu format (default: "native-english")
 PUBLIC_LANGUAGE_SWITCHER_MENU_FORMAT=native-english
+#Map style for MapLibre maps
+PUBLIC_MAPLIBRE_STYLE="dark-matter"

--- a/.env.example
+++ b/.env.example
@@ -70,5 +70,5 @@ PUBLIC_LANGUAGE_SWITCHER_ENABLED=true
 PUBLIC_LANGUAGE_SWITCHER_BUTTON_FORMAT=native
 # Menu format (default: "native-english")
 PUBLIC_LANGUAGE_SWITCHER_MENU_FORMAT=native-english
-#Map style for MapLibre maps
-PUBLIC_MAPLIBRE_STYLE="dark-matter"
+# Map style for MapLibre maps
+PUBLIC_MAPLIBRE_STYLE="positron"

--- a/env-schema.json
+++ b/env-schema.json
@@ -198,5 +198,10 @@
 		"type": "enum",
 		"enum": ["native", "english", "native-english", "english-native", "code"],
 		"description": "Display format for the language switcher dropdown menu"
+	},
+	"PUBLIC_MAPLIBRE_STYLE" : {
+		"required": false,
+		"type": "string",
+		"description": "Defines a style for MapLibre map. Defaults to positron if not set"
 	}
-}
+} 

--- a/env-schema.json
+++ b/env-schema.json
@@ -199,9 +199,9 @@
 		"enum": ["native", "english", "native-english", "english-native", "code"],
 		"description": "Display format for the language switcher dropdown menu"
 	},
-	"PUBLIC_MAPLIBRE_STYLE" : {
+	"PUBLIC_MAPLIBRE_STYLE": {
 		"required": false,
 		"type": "string",
 		"description": "Defines a style for MapLibre map. Defaults to positron if not set"
 	}
-} 
+}

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -11,7 +11,8 @@ import { createVehicleIconSvg, iconHeight, iconWidth } from '$lib/MapHelpers/gen
 import VehiclePopupContent from '$components/map/VehiclePopupContent.svelte';
 import TripPlanPinMarker from '$components/trip-planner/tripPlanPinMarker.svelte';
 import { mount, unmount } from 'svelte';
-import {PUBLIC_MAPLIBRE_STYLE} from '$env/static/public';
+import { PUBLIC_MAPLIBRE_STYLE } from '$env/static/public';
+
 export default class OpenStreetMapProvider {
 	constructor(handleStopMarkerSelect) {
 		this.handleStopMarkerSelect = handleStopMarkerSelect;

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -11,7 +11,7 @@ import { createVehicleIconSvg, iconHeight, iconWidth } from '$lib/MapHelpers/gen
 import VehiclePopupContent from '$components/map/VehiclePopupContent.svelte';
 import TripPlanPinMarker from '$components/trip-planner/tripPlanPinMarker.svelte';
 import { mount, unmount } from 'svelte';
-
+import {PUBLIC_MAPLIBRE_STYLE} from '$env/static/public';
 export default class OpenStreetMapProvider {
 	constructor(handleStopMarkerSelect) {
 		this.handleStopMarkerSelect = handleStopMarkerSelect;
@@ -22,7 +22,7 @@ export default class OpenStreetMapProvider {
 		this.stopsMap = new Map();
 		this.stopMarkers = [];
 		this.vehicleMarkers = [];
-		this.maplibreLayer = 'positron';
+		this.maplibreLayer = PUBLIC_MAPLIBRE_STYLE || 'positron';
 		this.markersMap = new Map();
 		this.polylines = []; // Track all polylines for easy cleanup
 		this.showStopsRoutesAtZoom = 16;
@@ -49,12 +49,6 @@ export default class OpenStreetMapProvider {
 		this.map = this.L.map(element, { zoomControl: false }).setView([options.lat, options.lng], 14);
 
 		this.L.control.zoom({ position: 'bottomright' }).addTo(this.map);
-
-		// TODO: Make this configurable through env file
-
-		/*
-		 * for more styles https://github.com/teamapps-org/maplibre-gl-styles
-		 */
 		this.maplibreLayer = this.L.maplibreGL({
 			style: `https://tiles.openfreemap.org/styles/${this.maplibreLayer}`,
 			interactive: true,


### PR DESCRIPTION
Closes #403 
- Added PUBLIC_MAPLIBRE_STYLE to .env.example with default 'positron'
- Updated env-schema.json to include PUBLIC_MAPLIBRE_STYLE following PUBLIC_ pattern
- Refactored OpenStreetMapProvider.svelte.js to read style from $env/static/public
- Added fallback to 'positron' when env var is not set
- Removed TODO for hardcoded style configuration

This allows deployments to customize map styles (e.g. dark-matter, voyager, or custom URLs) without code changes.

Lint passes successfully.