### PR TITLE
fix: add dark mode support to VehiclePopupContent

### DIFF
--- a/src/components/map/VehiclePopupContent.svelte
+++ b/src/components/map/VehiclePopupContent.svelte
@@ -12,26 +12,34 @@
 	});
 </script>
 
-<div class="max-w-xs rounded-lg bg-white p-4 text-gray-800 shadow-md">
+<div
+	class="max-w-xs rounded-lg bg-white p-4 text-gray-800 shadow-md dark:bg-gray-800 dark:text-gray-100"
+>
 	<div class="mb-2 flex items-center">
-		<div class="rounded bg-green-100 px-2 py-1 text-lg font-bold text-brand-accent">
+		<div
+			class="rounded bg-green-100 px-2 py-1 text-lg font-bold text-brand-accent dark:bg-green-900/30"
+		>
 			{nextDestination}
 		</div>
 	</div>
-	<div class="text-sm text-gray-600">
+	<div class="text-sm text-gray-600 dark:text-gray-400">
 		{#if predicted}
 			<span>{$t('vehicle.number')}</span>
-			<span class="font-semibold text-blue-500">{vehicleId || $t('NA')}</span> |
+			<span class="font-semibold text-blue-500 dark:text-blue-400">{vehicleId || $t('NA')}</span> |
 			<span>{$t('vehicle.data_updated')}</span>
-			<span class="font-semibold text-blue-500">{lastUpdatedText}</span>
+			<span class="font-semibold text-blue-500 dark:text-blue-400">{lastUpdatedText}</span>
 		{:else}
-			<span class="font-semibold text-gray-500">{$t('vehicle.no_real_time_data')}</span>
+			<span class="font-semibold text-gray-500 dark:text-gray-400"
+				>{$t('vehicle.no_real_time_data')}</span
+			>
 		{/if}
 	</div>
-	<hr class="my-2" />
-	<div class="text-sm font-bold text-gray-800">{$t('vehicle.next_stop')}</div>
-	<div class="text-sm text-gray-600">
-		<strong class="font-semibold text-blue-500">{nextStopName || $t('NA')}</strong>
+	<hr class="my-2 dark:border-gray-700" />
+	<div class="text-sm font-bold text-gray-800 dark:text-gray-100">{$t('vehicle.next_stop')}</div>
+	<div class="text-sm text-gray-600 dark:text-gray-400">
+		<strong class="font-semibold text-blue-500 dark:text-blue-400"
+			>{nextStopName || $t('NA')}</strong
+		>
 	</div>
-	<hr class="my-2" />
+	<hr class="my-2 dark:border-gray-700" />
 </div>


### PR DESCRIPTION
## Summary
- Added Tailwind `dark:` variant classes to all color-related styles in `VehiclePopupContent.svelte`
- The vehicle popup now renders with a dark background, readable text, subtle blue accents, and visible dividers in dark mode
- Light mode appearance is unchanged

## Changes
Single file: `src/components/map/VehiclePopupContent.svelte`

| Element | Light (unchanged) | Dark (added) |
|---|---|---|
| Container | `bg-white text-gray-800` | `dark:bg-gray-800 dark:text-gray-100` |
| Destination badge | `bg-green-100` | `dark:bg-green-900/30` |
| Muted text | `text-gray-600` / `text-gray-500` | `dark:text-gray-400` |
| Blue accents | `text-blue-500` | `dark:text-blue-400` |
| "Next stop" label | `text-gray-800` | `dark:text-gray-100` |
| Horizontal rules | default border | `dark:border-gray-700` |

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] All 1157 tests pass
- [x] Manually verified: open a stop → expand an arrival → click a vehicle marker → popup has dark background and readable text in dark mode

<img width="2052" height="1738" alt="popup_dark" src="https://github.com/user-attachments/assets/b1230872-ce97-42a8-9959-c7c741018755" />

fixes #401 