### PR TITLE
fix(map): reactive vehicle popup props via $state for OSM and Google providers

### DIFF
--- a/src/components/map/VehiclePopupContent.svelte
+++ b/src/components/map/VehiclePopupContent.svelte
@@ -5,11 +5,13 @@
 
 	let { nextDestination, vehicleId, lastUpdateTime, nextStopName, predicted } = $props();
 
-	const lastUpdatedText = formatLastUpdated(lastUpdateTime, {
-		min: $t('time.min'),
-		sec: $t('time.sec'),
-		ago: $t('time.ago')
-	});
+	const lastUpdatedText = $derived(
+		formatLastUpdated(lastUpdateTime, {
+			min: $t('time.min'),
+			sec: $t('time.sec'),
+			ago: $t('time.ago')
+		})
+	);
 </script>
 
 <div class="max-w-xs rounded-lg bg-white p-4 text-gray-800 shadow-md">

--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -351,13 +351,15 @@ export default class GoogleMapProvider {
 
 		this.vehicleMarkers.push(marker);
 
-		marker.vehicleData = $state({
+		let vehicleData = $state({
 			nextDestination: activeTrip.tripHeadsign,
 			vehicleId: vehicle.vehicleId,
 			lastUpdateTime: vehicle.lastUpdateTime,
 			nextStopName: this.stopsMap.get(vehicle.nextStop)?.name,
 			predicted: vehicle.predicted
 		});
+
+		marker.vehicleData = vehicleData;
 
 		const popupContainer = document.createElement('div');
 		marker.popupComponent = mount(VehiclePopupContent, {
@@ -397,7 +399,7 @@ export default class GoogleMapProvider {
 			nextDestination: activeTrip.tripHeadsign,
 			vehicleId: vehicleStatus.vehicleId,
 			lastUpdateTime: vehicleStatus.lastUpdateTime,
-			nextStopName: this.stopsMap.get(vehicleStatus.nextStop)?.name || 'N/A',
+			nextStopName: this.stopsMap.get(vehicleStatus.nextStop)?.name,
 			predicted: vehicleStatus.predicted
 		});
 	}

--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -351,18 +351,18 @@ export default class GoogleMapProvider {
 
 		this.vehicleMarkers.push(marker);
 
-		const vehicleData = {
+		marker.vehicleData = $state({
 			nextDestination: activeTrip.tripHeadsign,
 			vehicleId: vehicle.vehicleId,
 			lastUpdateTime: vehicle.lastUpdateTime,
 			nextStopName: this.stopsMap.get(vehicle.nextStop)?.name,
 			predicted: vehicle.predicted
-		};
+		});
 
 		const popupContainer = document.createElement('div');
 		marker.popupComponent = mount(VehiclePopupContent, {
 			target: popupContainer,
-			props: vehicleData
+			props: marker.vehicleData
 		});
 
 		marker.infoWindow = new google.maps.InfoWindow({
@@ -393,17 +393,13 @@ export default class GoogleMapProvider {
 			anchor: new google.maps.Point(iconWidth / 2, iconHeight / 2)
 		});
 
-		const updatedData = {
+		Object.assign(marker.vehicleData, {
 			nextDestination: activeTrip.tripHeadsign,
 			vehicleId: vehicleStatus.vehicleId,
 			lastUpdateTime: vehicleStatus.lastUpdateTime,
-			nextStopName: this.stopsMap.get(vehicleStatus.nextStop)?.name,
+			nextStopName: this.stopsMap.get(vehicleStatus.nextStop)?.name || 'N/A',
 			predicted: vehicleStatus.predicted
-		};
-
-		if (marker.popupComponent) {
-			marker.popupComponent.$set(updatedData);
-		}
+		});
 	}
 
 	removeVehicleMarker(marker) {

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -297,13 +297,13 @@ export default class OpenStreetMapProvider {
 
 		this.vehicleMarkers.push(marker);
 
-		marker.vehicleData = {
+		marker.vehicleData = $state({
 			nextDestination: activeTrip.tripHeadsign,
 			vehicleId: vehicle.vehicleId,
 			lastUpdateTime: vehicle.lastUpdateTime,
 			nextStopName: this.stopsMap.get(vehicle.nextStop)?.name,
 			predicted: vehicle.predicted
-		};
+		});
 
 		marker.bindPopup(document.createElement('div'));
 
@@ -348,20 +348,13 @@ export default class OpenStreetMapProvider {
 		marker.setLatLng([vehicleStatus.position.lat, vehicleStatus.position.lon]);
 		marker.setIcon(updatedIcon);
 
-		let vehicleData = $state({
-			...marker.vehicleData,
+		Object.assign(marker.vehicleData, {
 			nextDestination: activeTrip.tripHeadsign,
 			vehicleId: vehicleStatus.vehicleId,
 			lastUpdateTime: vehicleStatus.lastUpdateTime,
 			nextStopName: this.stopsMap.get(vehicleStatus.nextStop)?.name || 'N/A',
 			predicted: vehicleStatus.predicted
 		});
-
-		marker.vehicleData = vehicleData;
-
-		if (marker.isPopupOpen() && marker.popupComponent) {
-			marker.popupComponent = vehicleData;
-		}
 	}
 	removeVehicleMarker(marker) {
 		if (marker) {

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -297,13 +297,15 @@ export default class OpenStreetMapProvider {
 
 		this.vehicleMarkers.push(marker);
 
-		marker.vehicleData = $state({
+		let vehicleData = $state({
 			nextDestination: activeTrip.tripHeadsign,
 			vehicleId: vehicle.vehicleId,
 			lastUpdateTime: vehicle.lastUpdateTime,
 			nextStopName: this.stopsMap.get(vehicle.nextStop)?.name,
 			predicted: vehicle.predicted
 		});
+
+		marker.vehicleData = vehicleData;
 
 		marker.bindPopup(document.createElement('div'));
 
@@ -352,7 +354,7 @@ export default class OpenStreetMapProvider {
 			nextDestination: activeTrip.tripHeadsign,
 			vehicleId: vehicleStatus.vehicleId,
 			lastUpdateTime: vehicleStatus.lastUpdateTime,
-			nextStopName: this.stopsMap.get(vehicleStatus.nextStop)?.name || 'N/A',
+			nextStopName: this.stopsMap.get(vehicleStatus.nextStop)?.name,
 			predicted: vehicleStatus.predicted
 		});
 	}


### PR DESCRIPTION
## Problem

Two related bugs affected vehicle popup updates during the 30-second polling cycle:

**OSM provider:** `updateVehicleMarker` was assigning `vehicleData` (a plain object) directly to `marker.popupComponent`, which should always hold the Svelte mount instance. This meant:
- The open popup never received prop updates — content stayed frozen at first-open values
- On popup close, `unmount(marker.popupComponent)` received the plain data object instead of the component instance, silently leaking the real mounted component and its effects

**Google provider:** `updateVehicleMarker` called `marker.popupComponent.$set(updatedData)`. Since `VehiclePopupContent` uses `$props()` (runes mode), `$set` is not a supported update mechanism in Svelte 5 and was effectively a no-op — leaving open popups stale on poll.

## Fix

Both providers now follow the same pattern:

1. At marker creation, `marker.vehicleData` is initialized as a `$state({...})` reactive object
2. `mount(VehiclePopupContent, { target, props: marker.vehicleData })` passes that same reactive object, so Svelte tracks mutations to it
3. In `updateVehicleMarker`, `Object.assign(marker.vehicleData, {...})` mutates the existing object in place rather than replacing it, propagating updates reactively into any open popup

This keeps `marker.popupComponent` as a stable mount instance throughout the marker's lifetime, so `unmount` on popup close always receives the correct value.

Also aligns the `nextStopName` fallback between providers — OSM was returning `'N/A'` for missing stops while Google returned `undefined`. Both should behave the same; pick one and apply consistently.

## Follow-up suggestion

The vehicle data shape is currently duplicated between the creation block and the `Object.assign` block in both providers. If a new prop is added to `VehiclePopupContent` and only one path is updated, that field will show stale data silently. A small shared helper (`buildVehiclePopupData(vehicle, activeTrip, stopsMap)`) would eliminate this risk and keep both providers in sync automatically.

## Testing

- Set `PUBLIC_OBA_MAP_PROVIDER=osm`, select a route with live vehicles, open a vehicle popup, wait for the 30-second poll — popup content should update in place
- Close the popup — no console errors from `unmount`
- Repeat with Google provider