### PR TITLE
Fix malformed Tailwind dark mode class in StopItem

### DIFF
--- a/src/components/StopItem.svelte
+++ b/src/components/StopItem.svelte
@@ -4,7 +4,7 @@
 
 <button
 	type="button"
-	class="stop-item dark:bg[#000000] flex w-full items-center justify-between border-b border-gray-200 bg-[#f9f9f9] p-4 text-left hover:bg-[#e9e9e9] focus:outline-none dark:border-[#313135] dark:bg-[#1c1c1c] dark:hover:bg-[#363636]"
+	class="stop-item dark:bg-black flex w-full items-center justify-between border-b border-gray-200 bg-[#f9f9f9] p-4 text-left hover:bg-[#e9e9e9] focus:outline-none dark:border-[#313135] dark:bg-[#1c1c1c] dark:hover:bg-[#363636]"
 	onclick={() => handleStopItemClick(stop)}
 >
 	<div class="text-lg font-semibold text-[#000000] dark:text-white">


### PR DESCRIPTION
## Summary
- replace invalid Tailwind class `dark:bg[#000000]` in `src/components/StopItem.svelte`
- use valid dark mode class `dark:bg-black` so dark background styling is applied

## Validation
- `git diff --check`
- attempted `npm run lint`
  - blocked in this environment because npm install fails with internal npm error (`Exit handler never called`) and no local `prettier` binary is available

Closes #400