### PR TITLE
Internationalize hardcoded aria-label strings

### DIFF
--- a/src/components/surveys/SurveyQuestion.svelte
+++ b/src/components/surveys/SurveyQuestion.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { Radio, Checkbox, Input } from 'flowbite-svelte';
+	import { t } from 'svelte-i18n';
 
 	let {
 		question,
@@ -38,7 +39,7 @@
 		{question.content.label_text}
 	{/if}
 	{#if required && question.content.type !== 'label'}
-		<span class="ml-1 text-red-500" aria-label="Required question">*</span>
+		<span class="ml-1 text-red-500" aria-label={$t('survey.required_question')}>*</span>
 	{/if}
 </label>
 

--- a/src/components/trip-planner/TripPlanSearchField.svelte
+++ b/src/components/trip-planner/TripPlanSearchField.svelte
@@ -51,7 +51,7 @@
 			type="button"
 			class="absolute inset-y-0 right-0 flex items-center pr-3"
 			onclick={handleClear}
-			aria-label="Clear"
+			aria-label={$t('trip-planner.clear')}
 		>
 			<FontAwesomeIcon icon={faX} class="size-5 text-gray-400" />
 		</button>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -51,6 +51,7 @@
 		"unit_metric": "Metric (km, m)",
 		"unit_imperial": "Imperial (mi, ft)",
 		"swap_locations": "Swap From and To locations",
+		"clear": "Clear",
 		"error_code": "Error code",
 		"remove_recent_trip": "Remove recent trip",
 		"recent_searches": "Recent Searches",
@@ -171,6 +172,9 @@
 		"page": "Page",
 		"show": "Show",
 		"hide": "Hide"
+	},
+	"survey": {
+		"required_question": "Required question"
 	},
 	"view_stop_information": "View Stop Information",
 	"stop_details": {


### PR DESCRIPTION
## Summary
- replace hardcoded `aria-label="Clear"` in `TripPlanSearchField.svelte` with `$t('trip-planner.clear')`
- replace hardcoded `aria-label="Required question"` in `SurveyQuestion.svelte` with `$t('survey.required_question')`
- add translation keys to `src/locales/en.json`

## Validation
- `git diff --check`
- attempted `npm run lint`
  - blocked in this environment because local tooling install is incomplete (`prettier` binary missing)

Closes #406