### PR TITLE
Add aria-live announcements to loading spinners

### DIFF
--- a/src/components/FullPageLoadingSpinner.svelte
+++ b/src/components/FullPageLoadingSpinner.svelte
@@ -3,6 +3,9 @@
 </script>
 
 <div
+	role="status"
+	aria-live="polite"
+	aria-label={$t('loading_status')}
 	class="flex h-full items-center justify-center bg-neutral-800 bg-gradient-to-br from-zinc-300 to-zinc-700 dark:from-zinc-500"
 >
 	<div class="flex items-center font-semibold text-white">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -117,6 +117,7 @@
 	"route": "route",
 	"route_modal_title": "Route {name}",
 	"loading": "Loading",
+	"loading_status": "Loading",
 	"arrives": "arrives",
 	"NA": "N/A",
 	"time": {


### PR DESCRIPTION
## Summary
- add `role="status"` and `aria-live="polite"` to `FullPageLoadingSpinner`
- add translated `aria-label` using `$t('loading_status')`
- add `loading_status` translation key to `src/locales/en.json`

## Validation
- `git diff --check`
- attempted `npm run lint`
  - blocked in this environment because local tooling install is incomplete (`prettier` binary missing)

Closes #405