### PR TITLE
Add dark mode support to VehiclePopupContent

### DIFF
--- a/src/components/map/VehiclePopupContent.svelte
+++ b/src/components/map/VehiclePopupContent.svelte
@@ -12,26 +12,28 @@
 	});
 </script>
 
-<div class="max-w-xs rounded-lg bg-white p-4 text-gray-800 shadow-md">
+<div class="max-w-xs rounded-lg bg-white p-4 text-gray-800 shadow-md dark:bg-gray-800 dark:text-gray-100">
 	<div class="mb-2 flex items-center">
-		<div class="rounded bg-green-100 px-2 py-1 text-lg font-bold text-brand-accent">
+		<div
+			class="rounded bg-green-100 px-2 py-1 text-lg font-bold text-brand-accent dark:bg-green-900/40 dark:text-green-300"
+		>
 			{nextDestination}
 		</div>
 	</div>
-	<div class="text-sm text-gray-600">
+	<div class="text-sm text-gray-600 dark:text-gray-300">
 		{#if predicted}
 			<span>{$t('vehicle.number')}</span>
 			<span class="font-semibold text-blue-500">{vehicleId || $t('NA')}</span> |
 			<span>{$t('vehicle.data_updated')}</span>
 			<span class="font-semibold text-blue-500">{lastUpdatedText}</span>
 		{:else}
-			<span class="font-semibold text-gray-500">{$t('vehicle.no_real_time_data')}</span>
+			<span class="font-semibold text-gray-500 dark:text-gray-400">{$t('vehicle.no_real_time_data')}</span>
 		{/if}
 	</div>
-	<hr class="my-2" />
-	<div class="text-sm font-bold text-gray-800">{$t('vehicle.next_stop')}</div>
-	<div class="text-sm text-gray-600">
+	<hr class="my-2 dark:border-gray-700" />
+	<div class="text-sm font-bold text-gray-800 dark:text-gray-100">{$t('vehicle.next_stop')}</div>
+	<div class="text-sm text-gray-600 dark:text-gray-300">
 		<strong class="font-semibold text-blue-500">{nextStopName || $t('NA')}</strong>
 	</div>
-	<hr class="my-2" />
+	<hr class="my-2 dark:border-gray-700" />
 </div>


### PR DESCRIPTION
## Summary
- add Tailwind `dark:` variants to `VehiclePopupContent.svelte` colors
- update popup container, secondary text, muted message text, and divider borders for dark mode readability
- keep existing visual hierarchy while improving contrast in dark theme

## Validation
- `git diff --check`
- attempted `npm run lint`
  - blocked in this environment because local tooling install is incomplete (`prettier` binary missing)

Closes #401