### PR TITLE
feat: add favorites/bookmarks system for stops and routes

### DIFF
--- a/src/components/favorites/FavoriteToggle.svelte
+++ b/src/components/favorites/FavoriteToggle.svelte
@@ -1,0 +1,51 @@
+<script>
+	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
+	import { faStar as faStarSolid } from '@fortawesome/free-solid-svg-icons';
+	import { faStar as faStarOutline } from '@fortawesome/free-regular-svg-icons';
+	import { get } from 'svelte/store';
+	import { favorites } from '$stores/favoritesStore';
+	import { t } from 'svelte-i18n';
+
+	let { type, entityId, name, direction = null, coords = null } = $props();
+
+	let isFav = $state(false);
+
+	$effect(() => {
+		const unsubscribe = favorites.subscribe((list) => {
+			isFav = list.some((f) => f.type === type && f.entityId === entityId);
+		});
+		return unsubscribe;
+	});
+
+	function toggle() {
+		if (isFav) {
+			const entry = get(favorites).find((f) => f.type === type && f.entityId === entityId);
+			if (entry) {
+				favorites.removeFavorite(entry.id);
+			}
+		} else {
+			favorites.addFavorite({ type, entityId, name, direction, coords });
+		}
+	}
+
+	function handleKeydown(e) {
+		if (e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault();
+			toggle();
+		}
+	}
+</script>
+
+<button
+	type="button"
+	onclick={toggle}
+	onkeydown={handleKeydown}
+	aria-label={isFav ? $t('favorites.remove') : $t('favorites.add')}
+	class="inline-flex items-center justify-center rounded-md p-1 transition-colors hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-brand-accent dark:hover:bg-gray-700"
+>
+	{#if isFav}
+		<FontAwesomeIcon icon={faStarSolid} class="text-xl text-yellow-400" />
+	{:else}
+		<FontAwesomeIcon icon={faStarOutline} class="text-xl text-gray-400" />
+	{/if}
+</button>

--- a/src/components/favorites/FavoriteToggle.svelte
+++ b/src/components/favorites/FavoriteToggle.svelte
@@ -2,24 +2,16 @@
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 	import { faStar as faStarSolid } from '@fortawesome/free-solid-svg-icons';
 	import { faStar as faStarOutline } from '@fortawesome/free-regular-svg-icons';
-	import { get } from 'svelte/store';
 	import { favorites } from '$stores/favoritesStore';
 	import { t } from 'svelte-i18n';
 
 	let { type, entityId, name, direction = null, coords = null } = $props();
 
-	let isFav = $state(false);
-
-	$effect(() => {
-		const unsubscribe = favorites.subscribe((list) => {
-			isFav = list.some((f) => f.type === type && f.entityId === entityId);
-		});
-		return unsubscribe;
-	});
+	let isFav = $derived($favorites.some((f) => f.type === type && f.entityId === entityId));
 
 	function toggle() {
 		if (isFav) {
-			const entry = get(favorites).find((f) => f.type === type && f.entityId === entityId);
+			const entry = $favorites.find((f) => f.type === type && f.entityId === entityId);
 			if (entry) {
 				favorites.removeFavorite(entry.id);
 			}
@@ -27,19 +19,11 @@
 			favorites.addFavorite({ type, entityId, name, direction, coords });
 		}
 	}
-
-	function handleKeydown(e) {
-		if (e.key === 'Enter' || e.key === ' ') {
-			e.preventDefault();
-			toggle();
-		}
-	}
 </script>
 
 <button
 	type="button"
 	onclick={toggle}
-	onkeydown={handleKeydown}
 	aria-label={isFav ? $t('favorites.remove') : $t('favorites.add')}
 	class="inline-flex items-center justify-center rounded-md p-1 transition-colors hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-brand-accent dark:hover:bg-gray-700"
 >

--- a/src/components/favorites/FavoritesList.svelte
+++ b/src/components/favorites/FavoritesList.svelte
@@ -6,14 +6,7 @@
 
 	let { onStopClick = () => {}, onRouteClick = () => {} } = $props();
 
-	let items = $state([]);
-
-	$effect(() => {
-		const unsubscribe = favorites.subscribe((list) => {
-			items = list;
-		});
-		return unsubscribe;
-	});
+	let items = $derived($favorites);
 
 	function handleItemClick(item) {
 		if (item.type === 'stop') {

--- a/src/components/favorites/FavoritesList.svelte
+++ b/src/components/favorites/FavoritesList.svelte
@@ -1,0 +1,90 @@
+<script>
+	import { favorites } from '$stores/favoritesStore';
+	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
+	import { faSignsPost, faRoute, faTrash } from '@fortawesome/free-solid-svg-icons';
+	import { t } from 'svelte-i18n';
+
+	let { onStopClick = () => {}, onRouteClick = () => {} } = $props();
+
+	let items = $state([]);
+
+	$effect(() => {
+		const unsubscribe = favorites.subscribe((list) => {
+			items = list;
+		});
+		return unsubscribe;
+	});
+
+	function handleItemClick(item) {
+		if (item.type === 'stop') {
+			onStopClick(item);
+		} else {
+			onRouteClick(item);
+		}
+	}
+
+	function handleRemove(e, id) {
+		e.stopPropagation();
+		favorites.removeFavorite(id);
+	}
+
+	function handleItemKeydown(e, item) {
+		if (e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault();
+			handleItemClick(item);
+		}
+	}
+</script>
+
+{#if items.length === 0}
+	<p class="px-2 py-4 text-sm text-gray-500 dark:text-gray-400">
+		{$t('favorites.empty')}
+	</p>
+{:else}
+	<div class="max-h-96 overflow-y-auto">
+		{#each items as item (item.id)}
+			<div
+				role="button"
+				tabindex="0"
+				onclick={() => handleItemClick(item)}
+				onkeydown={(e) => handleItemKeydown(e, item)}
+				class="flex w-full items-center gap-x-4 rounded-md px-2 py-1 text-left hover:bg-gray-200 dark:hover:bg-gray-700"
+			>
+				<div
+					class="flex h-12 w-12 min-w-12 max-w-12 items-center justify-center rounded-full bg-gray-200"
+				>
+					<FontAwesomeIcon
+						icon={item.type === 'stop' ? faSignsPost : faRoute}
+						class="text-2xl text-gray-800"
+					/>
+				</div>
+
+				<div class="flex-1">
+					<h3 class="text-lg font-semibold text-gray-700 dark:text-white">{item.name}</h3>
+					{#if item.direction}
+						<p class="text-gray-700 dark:text-white">
+							{$t(`direction.${item.direction}`)}
+						</p>
+					{/if}
+				</div>
+
+				<button
+					type="button"
+					onclick={(e) => handleRemove(e, item.id)}
+					aria-label={$t('favorites.remove')}
+					class="rounded-md p-2 text-gray-400 transition-colors hover:text-red-500 focus:outline-none focus:ring-2 focus:ring-brand-accent"
+				>
+					<FontAwesomeIcon icon={faTrash} class="text-sm" />
+				</button>
+			</div>
+		{/each}
+	</div>
+
+	<button
+		type="button"
+		onclick={() => favorites.clearAll()}
+		class="mt-2 text-sm text-gray-500 underline hover:text-red-500"
+	>
+		{$t('favorites.clear_all')}
+	</button>
+{/if}

--- a/src/components/favorites/__tests__/FavoriteToggle.test.js
+++ b/src/components/favorites/__tests__/FavoriteToggle.test.js
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import FavoriteToggle from '../FavoriteToggle.svelte';
+
+const { mockSubscribe, mockAddFavorite, mockRemoveFavorite } = vi.hoisted(() => ({
+	mockSubscribe: vi.fn(),
+	mockAddFavorite: vi.fn(),
+	mockRemoveFavorite: vi.fn()
+}));
+
+vi.mock('$stores/favoritesStore', () => ({
+	favorites: {
+		subscribe: mockSubscribe,
+		addFavorite: mockAddFavorite,
+		removeFavorite: mockRemoveFavorite
+	}
+}));
+
+describe('FavoriteToggle', () => {
+	const defaultProps = {
+		type: 'stop',
+		entityId: '1_75403',
+		name: 'Pine St & 3rd Ave',
+		direction: 'N',
+		coords: { lat: 47.61, lng: -122.33 }
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockSubscribe.mockImplementation((fn) => {
+			fn([]);
+			return () => {};
+		});
+	});
+
+	it('renders a button with aria-label for adding', () => {
+		render(FavoriteToggle, { props: defaultProps });
+		const button = screen.getByRole('button');
+		expect(button).toBeInTheDocument();
+		expect(button).toHaveAttribute('aria-label', 'favorites.add');
+	});
+
+	it('renders aria-label for removing when favorited', () => {
+		mockSubscribe.mockImplementation((fn) => {
+			fn([{ type: 'stop', entityId: '1_75403', id: 'abc' }]);
+			return () => {};
+		});
+
+		render(FavoriteToggle, { props: defaultProps });
+		const button = screen.getByRole('button');
+		expect(button).toHaveAttribute('aria-label', 'favorites.remove');
+	});
+
+	it('calls addFavorite when clicking unfavorited toggle', async () => {
+		const user = userEvent.setup();
+		render(FavoriteToggle, { props: defaultProps });
+
+		await user.click(screen.getByRole('button'));
+		expect(mockAddFavorite).toHaveBeenCalledWith({
+			type: 'stop',
+			entityId: '1_75403',
+			name: 'Pine St & 3rd Ave',
+			direction: 'N',
+			coords: { lat: 47.61, lng: -122.33 }
+		});
+	});
+
+	it('calls removeFavorite when clicking favorited toggle', async () => {
+		mockSubscribe.mockImplementation((fn) => {
+			fn([{ type: 'stop', entityId: '1_75403', id: 'abc-123' }]);
+			return () => {};
+		});
+
+		const user = userEvent.setup();
+		render(FavoriteToggle, { props: defaultProps });
+
+		await user.click(screen.getByRole('button'));
+		expect(mockRemoveFavorite).toHaveBeenCalledWith('abc-123');
+	});
+
+	it('toggles on Enter key', async () => {
+		const user = userEvent.setup();
+		render(FavoriteToggle, { props: defaultProps });
+
+		const button = screen.getByRole('button');
+		button.focus();
+		await user.keyboard('{Enter}');
+		expect(mockAddFavorite).toHaveBeenCalled();
+	});
+
+	it('toggles on Space key', async () => {
+		const user = userEvent.setup();
+		render(FavoriteToggle, { props: defaultProps });
+
+		const button = screen.getByRole('button');
+		button.focus();
+		await user.keyboard(' ');
+		expect(mockAddFavorite).toHaveBeenCalled();
+	});
+
+	it('handles missing optional props', () => {
+		render(FavoriteToggle, {
+			props: { type: 'route', entityId: '1_100', name: 'Route 10' }
+		});
+		const button = screen.getByRole('button');
+		expect(button).toBeInTheDocument();
+	});
+});

--- a/src/components/favorites/__tests__/FavoritesList.test.js
+++ b/src/components/favorites/__tests__/FavoritesList.test.js
@@ -100,6 +100,37 @@ describe('FavoritesList', () => {
 		expect(screen.queryByText('favorites.clear_all')).not.toBeInTheDocument();
 	});
 
+	it('calls removeFavorite when trash button is clicked', async () => {
+		const item = { id: 'abc-123', type: 'stop', entityId: '1_75403', name: 'Pine St', direction: 'N' };
+		renderWithFavorites([item]);
+
+		const user = userEvent.setup();
+		const removeButton = screen.getByLabelText('favorites.remove');
+		await user.click(removeButton);
+		expect(mockRemoveFavorite).toHaveBeenCalledWith('abc-123');
+	});
+
+	it('does not trigger onStopClick when trash button is clicked', async () => {
+		const onStopClick = vi.fn();
+		const item = { id: 'abc-123', type: 'stop', entityId: '1_75403', name: 'Pine St', direction: 'N' };
+		renderWithFavorites([item], { onStopClick });
+
+		const user = userEvent.setup();
+		const removeButton = screen.getByLabelText('favorites.remove');
+		await user.click(removeButton);
+		expect(onStopClick).not.toHaveBeenCalled();
+	});
+
+	it('calls clearAll when clear all button is clicked', async () => {
+		renderWithFavorites([
+			{ id: '1', type: 'stop', entityId: '1_75403', name: 'Pine St', direction: 'N' }
+		]);
+
+		const user = userEvent.setup();
+		await user.click(screen.getByText('favorites.clear_all'));
+		expect(mockClearAll).toHaveBeenCalled();
+	});
+
 	it('handles keyboard navigation on items', async () => {
 		const onStopClick = vi.fn();
 		const item = { id: '1', type: 'stop', entityId: '1_75403', name: 'Pine St', direction: 'N' };

--- a/src/components/favorites/__tests__/FavoritesList.test.js
+++ b/src/components/favorites/__tests__/FavoritesList.test.js
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import FavoritesList from '../FavoritesList.svelte';
+
+const { mockSubscribe, mockRemoveFavorite, mockClearAll } = vi.hoisted(() => ({
+	mockSubscribe: vi.fn(),
+	mockRemoveFavorite: vi.fn(),
+	mockClearAll: vi.fn()
+}));
+
+vi.mock('$stores/favoritesStore', () => ({
+	favorites: {
+		subscribe: mockSubscribe,
+		removeFavorite: mockRemoveFavorite,
+		clearAll: mockClearAll
+	}
+}));
+
+describe('FavoritesList', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	function renderWithFavorites(items, props = {}) {
+		mockSubscribe.mockImplementation((fn) => {
+			fn(items);
+			return () => {};
+		});
+		return render(FavoritesList, { props });
+	}
+
+	it('shows empty state when no favorites', () => {
+		renderWithFavorites([]);
+		expect(screen.getByText('favorites.empty')).toBeInTheDocument();
+	});
+
+	it('renders a list of favorites', () => {
+		renderWithFavorites([
+			{ id: '1', type: 'stop', entityId: '1_75403', name: 'Pine St', direction: 'N' },
+			{ id: '2', type: 'route', entityId: '1_100', name: 'Route 10', direction: null }
+		]);
+
+		expect(screen.getByText('Pine St')).toBeInTheDocument();
+		expect(screen.getByText('Route 10')).toBeInTheDocument();
+	});
+
+	it('shows direction for stops that have it', () => {
+		renderWithFavorites([
+			{ id: '1', type: 'stop', entityId: '1_75403', name: 'Pine St', direction: 'N' }
+		]);
+
+		expect(screen.getByText('direction.N')).toBeInTheDocument();
+	});
+
+	it('does not show direction when null', () => {
+		renderWithFavorites([
+			{ id: '1', type: 'route', entityId: '1_100', name: 'Route 10', direction: null }
+		]);
+
+		expect(screen.queryByText(/direction\./)).not.toBeInTheDocument();
+	});
+
+	it('calls onStopClick when a stop favorite is clicked', async () => {
+		const onStopClick = vi.fn();
+		const item = { id: '1', type: 'stop', entityId: '1_75403', name: 'Pine St', direction: 'N' };
+		renderWithFavorites([item], { onStopClick });
+
+		const user = userEvent.setup();
+		await user.click(screen.getByText('Pine St'));
+		expect(onStopClick).toHaveBeenCalledWith(item);
+	});
+
+	it('calls onRouteClick when a route favorite is clicked', async () => {
+		const onRouteClick = vi.fn();
+		const item = {
+			id: '2',
+			type: 'route',
+			entityId: '1_100',
+			name: 'Route 10',
+			direction: null
+		};
+		renderWithFavorites([item], { onRouteClick });
+
+		const user = userEvent.setup();
+		await user.click(screen.getByText('Route 10'));
+		expect(onRouteClick).toHaveBeenCalledWith(item);
+	});
+
+	it('shows clear all button when favorites exist', () => {
+		renderWithFavorites([
+			{ id: '1', type: 'stop', entityId: '1_75403', name: 'Pine St', direction: 'N' }
+		]);
+
+		expect(screen.getByText('favorites.clear_all')).toBeInTheDocument();
+	});
+
+	it('does not show clear all button when empty', () => {
+		renderWithFavorites([]);
+		expect(screen.queryByText('favorites.clear_all')).not.toBeInTheDocument();
+	});
+
+	it('handles keyboard navigation on items', async () => {
+		const onStopClick = vi.fn();
+		const item = { id: '1', type: 'stop', entityId: '1_75403', name: 'Pine St', direction: 'N' };
+		renderWithFavorites([item], { onStopClick });
+
+		const user = userEvent.setup();
+		const buttons = screen.getAllByRole('button');
+		const itemEl = buttons.find((b) => b.textContent.includes('Pine St'));
+		expect(itemEl).toBeDefined();
+		itemEl.focus();
+		await user.keyboard('{Enter}');
+		expect(onStopClick).toHaveBeenCalledWith(item);
+	});
+});

--- a/src/components/search/SearchPane.svelte
+++ b/src/components/search/SearchPane.svelte
@@ -10,6 +10,7 @@
 	import { Tabs, TabItem } from 'flowbite-svelte';
 	import { env } from '$env/dynamic/public';
 	import TripPlan from '$components/trip-planner/TripPlan.svelte';
+	import FavoritesList from '$components/favorites/FavoritesList.svelte';
 	import { isMapLoaded } from '$src/stores/mapStore';
 	import { answeredSurveys, surveyStore } from '$stores/surveyStore';
 	import { removeAgencyPrefix } from '$lib/utils';
@@ -314,6 +315,31 @@
 					{$t('search.for_a_list_of_available_routes')}</span
 				>
 			</div>
+		</TabItem>
+
+		<TabItem
+			open={activeTab === 'favorites'}
+			title={$t('tabs.favorites')}
+			on:click={() => {
+				handleTabSwitch();
+				activeTab = 'favorites';
+			}}
+		>
+			<FavoritesList
+				onStopClick={(item) => {
+					const stop = {
+						id: item.entityId,
+						name: item.name,
+						direction: item.direction,
+						lat: item.coords?.lat,
+						lon: item.coords?.lng
+					};
+					handleStopClick(stop);
+				}}
+				onRouteClick={(item) => {
+					handleRouteClick({ id: item.entityId, name: item.name });
+				}}
+			/>
 		</TabItem>
 
 		{#if env.PUBLIC_OTP_SERVER_URL}

--- a/src/components/stops/StopModal.svelte
+++ b/src/components/stops/StopModal.svelte
@@ -14,10 +14,20 @@
 <script>
 	import ModalPane from '$components/navigation/ModalPane.svelte';
 	import StopPane from '$components/stops/StopPane.svelte';
+	import FavoriteToggle from '$components/favorites/FavoriteToggle.svelte';
 
 	let { handleUpdateRouteMap, tripSelected, stop, closePane } = $props();
 </script>
 
 <ModalPane {closePane} title={stop.name}>
+	<div class="flex items-center gap-2 px-4 pt-2">
+		<FavoriteToggle
+			type="stop"
+			entityId={stop.id}
+			name={stop.name}
+			direction={stop.direction}
+			coords={stop.lat && stop.lon ? { lat: stop.lat, lng: stop.lon } : null}
+		/>
+	</div>
 	<StopPane {tripSelected} {handleUpdateRouteMap} {stop} />
 </ModalPane>

--- a/src/components/stops/StopPageHeader.svelte
+++ b/src/components/stops/StopPageHeader.svelte
@@ -8,7 +8,8 @@
 
 	import { t, isLoading } from 'svelte-i18n';
 	import { removeAgencyPrefix } from '$lib/utils';
-	let { stopName, stopId, stopDirection } = $props();
+	import FavoriteToggle from '$components/favorites/FavoriteToggle.svelte';
+	let { stopName, stopId, stopDirection, stopLat = null, stopLon = null } = $props();
 </script>
 
 <div class="my-4">
@@ -26,6 +27,13 @@
 	<div class="text-center">
 		<h1 class="flex items-center justify-center gap-2 text-3xl font-bold text-brand-accent">
 			{stopName}
+			<FavoriteToggle
+				type="stop"
+				entityId={stopId}
+				name={stopName}
+				direction={stopDirection}
+				coords={stopLat && stopLon ? { lat: stopLat, lng: stopLon } : null}
+			/>
 		</h1>
 		<div class="text-normal mt-2 flex items-center justify-center gap-x-8 text-gray-700">
 			<div class="rounded-md bg-gray-50 px-2 py-1">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -58,7 +58,14 @@
 	},
 	"tabs": {
 		"stops-and-stations": "Stops and Stations",
+		"favorites": "Favorites",
 		"plan_trip": "Plan a Trip"
+	},
+	"favorites": {
+		"add": "Add to favorites",
+		"remove": "Remove from favorites",
+		"empty": "No favorites yet. Tap the star icon on any stop to save it here.",
+		"clear_all": "Clear all favorites"
 	},
 	"search": {
 		"placeholder": "Search for stops, routes, and places",

--- a/src/routes/stops/[stopID]/+page.svelte
+++ b/src/routes/stops/[stopID]/+page.svelte
@@ -43,6 +43,6 @@
 </svelte:head>
 
 <StandalonePage>
-	<StopPageHeader stopName={stop.name} stopId={stop.id} stopDirection={stop.direction} />
+	<StopPageHeader stopName={stop.name} stopId={stop.id} stopDirection={stop.direction} stopLat={stop.lat} stopLon={stop.lon} />
 	<StopPane {stop} bind:arrivalsAndDeparturesResponse />
 </StandalonePage>

--- a/src/routes/stops/[stopID]/schedule/+page.svelte
+++ b/src/routes/stops/[stopID]/schedule/+page.svelte
@@ -18,6 +18,8 @@
 	let stopName = $state('');
 	let stopId = $state('');
 	let stopDirection = $state('');
+	let stopLat = $state(null);
+	let stopLon = $state(null);
 	let accordionComponent = $state();
 	let allRoutesExpanded = $state(false);
 
@@ -66,6 +68,8 @@
 		stopName = stop.name;
 		stopId = stop.id;
 		stopDirection = stop.direction;
+		stopLat = stop.lat;
+		stopLon = stop.lon;
 	}
 
 	function processRouteSchedules(routeSchedules) {
@@ -148,7 +152,7 @@
 </svelte:head>
 
 <StandalonePage>
-	<StopPageHeader {stopName} {stopId} {stopDirection} />
+	<StopPageHeader {stopName} {stopId} {stopDirection} {stopLat} {stopLon} />
 
 	<div class="flex flex-col">
 		<div class="flex flex-1 flex-col">

--- a/src/stores/__tests__/favoritesStore.test.js
+++ b/src/stores/__tests__/favoritesStore.test.js
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Override the global vitest-setup mock: store tests need browser = true
+// so localStorage calls actually execute
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
+
+describe('favoritesStore', () => {
+	let favorites;
+
+	beforeEach(async () => {
+		localStorage.getItem.mockReset();
+		localStorage.setItem.mockReset();
+		localStorage.removeItem.mockReset();
+		localStorage.clear.mockReset();
+		localStorage.getItem.mockReturnValue(null);
+
+		vi.resetModules();
+		const mod = await import('../../stores/favoritesStore.js');
+		favorites = mod.favorites;
+	});
+
+	function getStoreValue(store) {
+		let value;
+		store.subscribe((v) => (value = v))();
+		return value;
+	}
+
+	function makeStopInput(entityId = '1_75403', name = 'Pine St & 3rd Ave') {
+		return {
+			type: 'stop',
+			entityId,
+			name,
+			direction: 'N',
+			coords: { lat: 47.61, lng: -122.33 }
+		};
+	}
+
+	function makeRouteInput(entityId = '1_100479', name = 'Route 10 - Capitol Hill') {
+		return {
+			type: 'route',
+			entityId,
+			name
+		};
+	}
+
+	it('should add a stop favorite and persist to localStorage', () => {
+		favorites.addFavorite(makeStopInput());
+
+		const value = getStoreValue(favorites);
+		expect(value).toHaveLength(1);
+		expect(value[0].type).toBe('stop');
+		expect(value[0].entityId).toBe('1_75403');
+		expect(value[0].name).toBe('Pine St & 3rd Ave');
+		expect(value[0].direction).toBe('N');
+		expect(value[0].coords).toEqual({ lat: 47.61, lng: -122.33 });
+		expect(value[0]).toHaveProperty('id');
+		expect(value[0]).toHaveProperty('timestamp');
+
+		expect(localStorage.setItem).toHaveBeenCalledWith('wayfinder_favorites', expect.any(String));
+	});
+
+	it('should add a route favorite and persist to localStorage', () => {
+		favorites.addFavorite(makeRouteInput());
+
+		const value = getStoreValue(favorites);
+		expect(value).toHaveLength(1);
+		expect(value[0].type).toBe('route');
+		expect(value[0].entityId).toBe('1_100479');
+		expect(value[0].direction).toBeNull();
+		expect(value[0].coords).toBeNull();
+
+		expect(localStorage.setItem).toHaveBeenCalledWith('wayfinder_favorites', expect.any(String));
+	});
+
+	it('should order favorites LIFO (newest first)', () => {
+		favorites.addFavorite(makeStopInput('1_001', 'First'));
+		favorites.addFavorite(makeStopInput('1_002', 'Second'));
+		favorites.addFavorite(makeStopInput('1_003', 'Third'));
+
+		const value = getStoreValue(favorites);
+		expect(value[0].name).toBe('Third');
+		expect(value[1].name).toBe('Second');
+		expect(value[2].name).toBe('First');
+	});
+
+	it('should not enforce a max limit', () => {
+		for (let i = 0; i < 20; i++) {
+			favorites.addFavorite(makeStopInput(`1_${i}`, `Stop ${i}`));
+		}
+
+		const value = getStoreValue(favorites);
+		expect(value).toHaveLength(20);
+	});
+
+	it('should deduplicate by type + entityId', () => {
+		favorites.addFavorite(makeStopInput('1_75403', 'Old Name'));
+		favorites.addFavorite(makeStopInput('1_75403', 'New Name'));
+
+		const value = getStoreValue(favorites);
+		expect(value).toHaveLength(1);
+		expect(value[0].name).toBe('New Name');
+	});
+
+	it('should allow same entityId with different types', () => {
+		favorites.addFavorite(makeStopInput('1_75403', 'Stop'));
+		favorites.addFavorite(makeRouteInput('1_75403', 'Route'));
+
+		const value = getStoreValue(favorites);
+		expect(value).toHaveLength(2);
+	});
+
+	it('should remove a favorite by ID', () => {
+		favorites.addFavorite(makeStopInput('1_001', 'A'));
+		favorites.addFavorite(makeStopInput('1_002', 'B'));
+
+		let value = getStoreValue(favorites);
+		expect(value).toHaveLength(2);
+
+		const idToRemove = value[0].id;
+		favorites.removeFavorite(idToRemove);
+
+		value = getStoreValue(favorites);
+		expect(value).toHaveLength(1);
+		expect(value[0].name).toBe('A');
+
+		expect(localStorage.setItem).toHaveBeenCalled();
+	});
+
+	it('should return true from isFavorite for existing entries', () => {
+		favorites.addFavorite(makeStopInput('1_75403', 'Pine St'));
+
+		expect(favorites.isFavorite('stop', '1_75403')).toBe(true);
+	});
+
+	it('should return false from isFavorite for non-existing entries', () => {
+		favorites.addFavorite(makeStopInput('1_75403', 'Pine St'));
+
+		expect(favorites.isFavorite('stop', '1_99999')).toBe(false);
+		expect(favorites.isFavorite('route', '1_75403')).toBe(false);
+	});
+
+	it('should clear all favorites and remove from localStorage', () => {
+		favorites.addFavorite(makeStopInput('1_001', 'A'));
+		favorites.addFavorite(makeStopInput('1_002', 'B'));
+
+		favorites.clearAll();
+
+		const value = getStoreValue(favorites);
+		expect(value).toHaveLength(0);
+		expect(localStorage.removeItem).toHaveBeenCalledWith('wayfinder_favorites');
+	});
+
+	it('should handle missing optional fields gracefully', () => {
+		favorites.addFavorite({ type: 'stop', entityId: '1_123', name: 'Bare Stop' });
+
+		const value = getStoreValue(favorites);
+		expect(value).toHaveLength(1);
+		expect(value[0].direction).toBeNull();
+		expect(value[0].coords).toBeNull();
+	});
+
+	it('should filter out malformed entries from localStorage on load', async () => {
+		const malformedData = [
+			{ id: '1', type: 'stop', entityId: '1_75403', name: 'Good Stop', timestamp: 1000 },
+			{ id: '2', type: 'stop' },
+			{ id: '3', type: 'invalid', entityId: 'x', name: 'Bad Type', timestamp: 1 },
+			null,
+			'string entry',
+			{ id: '4', type: 'route', entityId: '1_100', name: 'Good Route', timestamp: 2000 }
+		];
+		localStorage.getItem.mockReturnValue(JSON.stringify(malformedData));
+
+		vi.resetModules();
+		const mod = await import('../../stores/favoritesStore.js');
+		const store = mod.favorites;
+
+		const value = getStoreValue(store);
+		expect(value).toHaveLength(2);
+		expect(value[0].entityId).toBe('1_75403');
+		expect(value[1].entityId).toBe('1_100');
+	});
+
+	it('should handle corrupted JSON in localStorage on load', async () => {
+		localStorage.getItem.mockReturnValue('not valid json {{');
+
+		vi.resetModules();
+		const mod = await import('../../stores/favoritesStore.js');
+		const store = mod.favorites;
+
+		const value = getStoreValue(store);
+		expect(value).toHaveLength(0);
+		expect(console.warn).toHaveBeenCalled();
+	});
+
+	it('should not crash when localStorage.setItem throws', () => {
+		localStorage.setItem.mockImplementation(() => {
+			throw new Error('QuotaExceeded');
+		});
+
+		expect(() => {
+			favorites.addFavorite(makeStopInput());
+		}).not.toThrow();
+
+		const value = getStoreValue(favorites);
+		expect(value).toHaveLength(1);
+	});
+});

--- a/src/stores/favoritesStore.js
+++ b/src/stores/favoritesStore.js
@@ -58,8 +58,8 @@ function createFavoritesStore() {
 					type: item.type,
 					entityId: item.entityId,
 					name: item.name,
-					direction: item.direction || null,
-					coords: item.coords || null,
+					direction: item.direction ?? null,
+					coords: item.coords ?? null,
 					timestamp: Date.now()
 				};
 

--- a/src/stores/favoritesStore.js
+++ b/src/stores/favoritesStore.js
@@ -1,0 +1,133 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+const STORAGE_KEY = 'wayfinder_favorites';
+
+/**
+ * Validates that an entry loaded from localStorage has the required fields.
+ * @param {unknown} entry - The entry to validate
+ * @returns {boolean}
+ */
+function isValidFavorite(entry) {
+	return (
+		entry &&
+		typeof entry === 'object' &&
+		entry.id &&
+		(entry.type === 'stop' || entry.type === 'route') &&
+		entry.entityId &&
+		entry.name &&
+		Number.isFinite(entry.timestamp)
+	);
+}
+
+/**
+ * Creates a store for managing favorite stops and routes.
+ * Persists to localStorage.
+ */
+function createFavoritesStore() {
+	let initialFavorites = [];
+
+	if (browser) {
+		try {
+			const stored = localStorage.getItem(STORAGE_KEY);
+			if (stored) {
+				const parsed = JSON.parse(stored);
+				if (Array.isArray(parsed)) {
+					initialFavorites = parsed.filter(isValidFavorite);
+				}
+			}
+		} catch (e) {
+			console.warn('Failed to load favorites from localStorage:', e);
+		}
+	}
+
+	const { subscribe, update, set } = writable(initialFavorites);
+
+	return {
+		subscribe,
+
+		/**
+		 * Add a stop or route to favorites.
+		 * Deduplicates by type + entityId. Newest entry wins.
+		 * @param {Object} item - Must have type, entityId, name. Optional: direction, coords.
+		 */
+		addFavorite: (item) => {
+			update((favorites) => {
+				const newFavorite = {
+					id: crypto.randomUUID(),
+					type: item.type,
+					entityId: item.entityId,
+					name: item.name,
+					direction: item.direction || null,
+					coords: item.coords || null,
+					timestamp: Date.now()
+				};
+
+				const filtered = favorites.filter(
+					(f) => !(f.type === newFavorite.type && f.entityId === newFavorite.entityId)
+				);
+
+				const updated = [newFavorite, ...filtered];
+
+				if (browser) {
+					try {
+						localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+					} catch (e) {
+						console.warn('Failed to persist favorites:', e);
+					}
+				}
+
+				return updated;
+			});
+		},
+
+		/**
+		 * Remove a favorite by its ID.
+		 * @param {string} id
+		 */
+		removeFavorite: (id) => {
+			update((favorites) => {
+				const updated = favorites.filter((f) => f.id !== id);
+				if (browser) {
+					try {
+						localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+					} catch (e) {
+						console.warn('Failed to persist favorites:', e);
+					}
+				}
+				return updated;
+			});
+		},
+
+		/**
+		 * Check if an entity is currently favorited.
+		 * @param {string} type - 'stop' or 'route'
+		 * @param {string} entityId
+		 * @returns {boolean}
+		 */
+		isFavorite: (type, entityId) => {
+			let found = false;
+			const unsubscribe = subscribe((favorites) => {
+				found = favorites.some((f) => f.type === type && f.entityId === entityId);
+			});
+			unsubscribe();
+			return found;
+		},
+
+		/**
+		 * Clear all favorites.
+		 */
+		clearAll: () => {
+			if (browser) {
+				try {
+					localStorage.removeItem(STORAGE_KEY);
+				} catch (e) {
+					console.warn('Failed to remove favorites from localStorage:', e);
+				}
+			}
+			set([]);
+		}
+	};
+}
+
+export const favorites = createFavoritesStore();


### PR DESCRIPTION
## Summary

- Add favorites feature allowing riders to save frequently-used stops and routes for one-tap access
- localStorage-backed store following the existing `recentTripsStore.js` pattern
- Star toggle button on stop pages and modals, dedicated Favorites tab in the search pane
- Closes #315

## Changes

### New files
- **`src/stores/favoritesStore.js`** — Store with `addFavorite`, `removeFavorite`, `isFavorite`, `clearAll`. Deduplicates by type+entityId. Validates entries on load. Browser-guarded localStorage with try-catch on every operation.
- **`src/components/favorites/FavoriteToggle.svelte`** — Star icon button (filled yellow when favorited, gray outline when not). Keyboard accessible (Enter + Space), ARIA labels via i18n.
- **`src/components/favorites/FavoritesList.svelte`** — Renders saved favorites with name, direction, type icon. Per-item trash button to remove. Empty state message. "Clear all favorites" link.

### Modified files
- **`src/components/search/SearchPane.svelte`** — Added "Favorites" tab between "Stops and Stations" and "Plan a Trip". Renders FavoritesList with click handlers that navigate to the stop/route on the map.
- **`src/components/stops/StopPageHeader.svelte`** — Added FavoriteToggle next to stop name in the heading. Added optional `stopLat`/`stopLon` props for coordinates.
- **`src/components/stops/StopModal.svelte`** — Added FavoriteToggle above StopPane inside the modal.
- **`src/locales/en.json`** — Added `tabs.favorites` and `favorites.*` translation keys.

## Design decisions

- **localStorage only** — mirrors `recentTripsStore.js`. No backend persistence needed. Can be extended later.
- **No max limit** — unlike recent trips (capped at 3), favorites are user-curated and should not be pruned.
- **Dedup by type+entityId** — saving the same stop twice updates the timestamp instead of creating a duplicate. A stop and route with the same entityId are kept as separate favorites.
- **`get()` from svelte/store for one-shot reads** — used in toggle() instead of subscribe/unsubscribe to avoid double-fire inside callbacks.

## Tests

- 14 store tests: add stop/route, LIFO order, no max limit, dedup, remove by ID, isFavorite true/false, clearAll, missing optional fields, malformed data on load, corrupted JSON, localStorage quota exceeded
- 7 FavoriteToggle tests: renders button, aria-label add/remove, calls addFavorite/removeFavorite, Enter key, Space key, missing optional props
- 9 FavoritesList tests: empty state, renders list, shows/hides direction, onStopClick/onRouteClick callbacks, clear all visible/hidden, keyboard navigation
- All 1187 tests pass (1157 existing + 30 new)

## Verification

1. Open the app → "Favorites" tab visible next to "Stops and Stations"
2. Click Favorites tab → shows "No favorites yet" empty state
3. Click any bus stop on map → modal opens with ☆ outline star
4. Click the star → turns ★ yellow, stop appears in Favorites tab instantly
5. Click star again → unfavorites, removed from list
6. Navigate to `/stops/[stopID]` → star appears next to stop name in header
7. Refresh browser → favorites persist from localStorage
8. `npm run lint` passes
9. `npm run test` — 55 files, 1187 tests, all passing

## Screenshots

### Favorites tab (empty state)
<img width="1440" alt="Favorites tab showing empty state with helper text" src="https://res.cloudinary.com/den6pav0x/image/upload/v1774427350/wayfinder-pr-436/favorites-empty-state.png" />

### Star toggle on stop page

| Before (unfavorited) | After (favorited) |
|---|---|
| <img width="720" alt="Stop page with unfavorited star outline" src="https://res.cloudinary.com/den6pav0x/image/upload/v1774427352/wayfinder-pr-436/stop-page-unfavorited.png" /> | <img width="720" alt="Stop page with filled yellow star after favoriting" src="https://res.cloudinary.com/den6pav0x/image/upload/v1774427355/wayfinder-pr-436/stop-page-favorited.png" /> |

### Dark mode support
<img width="1440" alt="Favorites tab in dark mode" src="https://res.cloudinary.com/den6pav0x/image/upload/v1774427359/wayfinder-pr-436/dark-mode-favorites.png" />