### PR TITLE
feat: add dark mode support to stop marker popup and fix related dark mode issues

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -61,6 +61,11 @@
 		@apply dark:bg-brand dark:text-brand-foreground dark:hover:bg-brand;
 	}
 
+	.close-button {
+		@apply rounded px-4 py-2;
+		@apply transition duration-300 ease-in-out hover:bg-neutral-200 dark:hover:bg-neutral-700;
+	}
+
 	.button {
 		@apply rounded-md bg-surface px-3 py-2 text-sm font-semibold text-surface-foreground shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50;
 	}

--- a/src/assets/styles/leaflet-map.css
+++ b/src/assets/styles/leaflet-map.css
@@ -25,3 +25,9 @@
 .leaflet-control {
 	background-color: #fff;
 }
+
+.dark .leaflet-popup-content-wrapper,
+.dark .leaflet-popup-tip {
+	background: #1f2937;
+	color: #f3f4f6;
+}

--- a/src/components/map/PopupContent.svelte
+++ b/src/components/map/PopupContent.svelte
@@ -10,7 +10,7 @@
 	{#if arrivalTime != null}
 		<p class="my-4 flex items-center text-gray-700 dark:text-gray-400">
 			<span class="mr-2 rounded-md bg-purple-600 px-2 py-1 text-white">Arrival time:</span>
-			<span>{formatSecondsFromMidnight(arrivalTime)}</span>
+			<span class="dark:text-gray-100">{formatSecondsFromMidnight(arrivalTime)}</span>
 		</p>
 	{/if}
 	<div class="mt-auto flex justify-center">

--- a/src/components/map/PopupContent.svelte
+++ b/src/components/map/PopupContent.svelte
@@ -4,11 +4,11 @@
 	let { stopName, arrivalTime, handleStopMarkerSelect } = $props();
 </script>
 
-<div class="transform rounded-lg bg-white p-4 shadow-lg">
-	<h3 class="text-xl font-bold text-gray-900">{stopName}</h3>
+<div class="transform rounded-lg bg-white p-4 shadow-lg dark:bg-gray-800">
+	<h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">{stopName}</h3>
 
 	{#if arrivalTime != null}
-		<p class="my-4 flex items-center text-gray-700">
+		<p class="my-4 flex items-center text-gray-700 dark:text-gray-400">
 			<span class="mr-2 rounded-md bg-purple-600 px-2 py-1 text-white">Arrival time:</span>
 			<span>{formatSecondsFromMidnight(arrivalTime)}</span>
 		</p>

--- a/src/components/map/PopupContent.svelte
+++ b/src/components/map/PopupContent.svelte
@@ -9,7 +9,7 @@
 
 	{#if arrivalTime != null}
 		<p class="my-4 flex items-center text-gray-700 dark:text-gray-400">
-			<span class="mr-2 rounded-md bg-purple-600 px-2 py-1 text-white">Arrival time:</span>
+			<span class="mr-2 rounded-md bg-purple-600 px-2 py-1 text-white">Arrival time</span>
 			<span class="dark:text-gray-100">{formatSecondsFromMidnight(arrivalTime)}</span>
 		</p>
 	{/if}

--- a/src/components/navigation/ModalPane.svelte
+++ b/src/components/navigation/ModalPane.svelte
@@ -46,9 +46,5 @@
 	</div>
 </div>
 
-<style lang="postcss">
-	.close-button {
-		@apply rounded px-4 py-2;
-		@apply transition duration-300 ease-in-out hover:bg-neutral-200 dark:hover:bg-neutral-200/50;
-	}
+<style>
 </style>

--- a/src/components/navigation/ModalPane.svelte
+++ b/src/components/navigation/ModalPane.svelte
@@ -45,6 +45,3 @@
 		</div>
 	</div>
 </div>
-
-<style>
-</style>

--- a/src/routes/stops/[stopID]/schedule/+page.svelte
+++ b/src/routes/stops/[stopID]/schedule/+page.svelte
@@ -152,7 +152,7 @@
 
 	<div class="flex flex-col">
 		<div class="flex flex-1 flex-col">
-			<h2 class="mb-4 text-2xl font-bold text-gray-800">
+			<h2 class="mb-4 text-2xl font-bold text-gray-800 dark:text-gray-100">
 				{$isLoading ? '' : $t('schedule_for_stop.route_schedules')}
 			</h2>
 


### PR DESCRIPTION
## Summary
- Add dark mode support to `PopupContent.svelte` (stop marker popup) [closes #443]
- Add dark mode overrides for Leaflet popup wrapper and tip (`.leaflet-popup-content-wrapper`, `.leaflet-popup-tip`)
- Fix close button hover in `ModalPane` showing white background in dark mode
- Add dark mode text color to "Route Schedules" heading on the schedule page

## Screenshots

### PopupContent (stop popup)
| Before | After |
|--------|-------|
|<img width="1440" height="776" alt="PopupContent pre-edit" src="https://github.com/user-attachments/assets/9538083a-b53b-4a55-b2a5-3a743f191d4f" />|<img width="1440" height="779" alt="PopupContent" src="https://github.com/user-attachments/assets/8e60b0c2-8d72-4301-98bf-c253ad8d5f07" />|

### Leaflet popup wrapper (impacts both stop popup and vehicle popup)
| Before | After |
|--------|-------|
|<img width="1440" height="778" alt="VehiclePopupContent pre-edit" src="https://github.com/user-attachments/assets/e6a69bdd-ebdc-4c26-be8b-d464491ae6fb" />|<img width="1440" height="777" alt="VehiclePopupContent" src="https://github.com/user-attachments/assets/adf55c4d-4720-4a1d-9cac-a2d306e359a5" />|

### ModalPane close button hover
| Before | After |
|--------|-------|
|<img width="393" height="709" alt="Modal Pane close button hover pre-edit" src="https://github.com/user-attachments/assets/c8754a70-2c47-4e25-a3c5-62c0c395992d" />|<img width="387" height="706" alt="Modal Pane close button hover" src="https://github.com/user-attachments/assets/63a09ec2-a7e6-4bbe-a96e-f03d1304d447" />|

### Route Schedules heading
| Before | After |
|--------|-------|
|<img width="1440" height="779" alt="Schedule Page pre-edit" src="https://github.com/user-attachments/assets/7a595d3d-5c15-4e62-883c-264e27ffbf87" />|<img width="1440" height="778" alt="Schedule Page" src="https://github.com/user-attachments/assets/b1b33ab1-3fe6-4747-a2fc-b0b9b26bb354" />|

## Additional Questions
The stop popup currently shows `Arrival time:` inside a purple badge. Since the badge already visually separates it from the time value, should the trailing colon be removed (i.e. just `Arrival time`)? I left it unchanged for now.

## Test plan
  - [x] Toggle dark mode and click a stop marker on a route map. Popup should have dark background with readable text
  - [x] Verify Leaflet popup wrapper matches the dark background (no white border)
  - [x] Hover over the close (X) button on any sidebar pane in dark mode and it should show subtle dark highlight, not white
  - [x] Navigate to a stop's schedule page in dark mode and the "Route Schedules" heading should be readable
  - [x] Verify all above still look correct in light mode
  - [x] `npm run lint` passes