### PR TITLE
test(surveys): add unit tests for `skipSurvey()` function

### DIFF
--- a/src/tests/lib/surveysUtils.test.js
+++ b/src/tests/lib/surveysUtils.test.js
@@ -15,7 +15,7 @@ beforeEach(() => {
 	vi.stubGlobal('localStorage', {
 		getItem: vi.fn((key) => store[key] || null),
 		setItem: vi.fn((key, value) => {
-			store[key] = value;
+			store[key] = String(value);
 		}),
 		removeItem: vi.fn((key) => {
 			delete store[key];
@@ -335,7 +335,7 @@ describe('skipSurvey', () => {
 
 		skipSurvey(survey);
 
-		expect(localStorage.getItem('survey_2_skipped')).toBeTruthy();
+		expect(localStorage.getItem('survey_2_skipped')).toBe('true');
 		expect(localStorage.getItem('survey_2_skipped_timestamp')).toBeNull();
 	});
 

--- a/src/tests/lib/surveysUtils.test.js
+++ b/src/tests/lib/surveysUtils.test.js
@@ -6,7 +6,8 @@ import {
 	getMapSurvey,
 	submitHeroQuestion,
 	updateSurveyResponse,
-	getPrioritySurvey
+	getPrioritySurvey,
+	skipSurvey
 } from '../../lib/Surveys/surveyUtils';
 
 beforeEach(() => {
@@ -316,5 +317,37 @@ describe('Survey Visibility and Multiple Responses', () => {
 		const selectedSurvey = await getPrioritySurvey(surveys, null);
 
 		expect(selectedSurvey).toEqual(surveys[2]);
+	});
+});
+
+describe('skipSurvey', () => {
+	it('should set only _skipped_timestamp for recurring surveys', () => {
+		const survey = { id: 1, allows_multiple_responses: true, always_visible: true };
+
+		skipSurvey(survey);
+
+		expect(localStorage.getItem('survey_1_skipped_timestamp')).not.toBeNull();
+		expect(localStorage.getItem('survey_1_skipped')).toBeNull();
+	});
+
+	it('should set only _skipped for one-time surveys', () => {
+		const survey = { id: 2, allows_multiple_responses: false, always_visible: false };
+
+		skipSurvey(survey);
+
+		expect(localStorage.getItem('survey_2_skipped')).toBeTruthy();
+		expect(localStorage.getItem('survey_2_skipped_timestamp')).toBeNull();
+	});
+
+	it('should remove stale _skipped flag when skipping a recurring survey', () => {
+		const survey = { id: 3, allows_multiple_responses: true, always_visible: true };
+
+		localStorage.setItem('survey_3_skipped', 'true');
+		expect(localStorage.getItem('survey_3_skipped')).toBe('true');
+
+		skipSurvey(survey);
+
+		expect(localStorage.getItem('survey_3_skipped')).toBeNull();
+		expect(localStorage.getItem('survey_3_skipped_timestamp')).not.toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary
Adds unit tests for `skipSurvey()` covering the three cases outlined in #444:

- Recurring survey skip (`allows_multiple_responses: true, always_visible: true`): verifies only `_skipped_timestamp` is set
- One-time survey skip: verifies only `_skipped` is set
- Stale flag cleanup: verifies `_skipped` is removed when a recurring survey is skipped again

Closes #444

## Test plan
- [x] `npm run test` passes