### PR TITLE
fix: Handle null orientation explicitly in generateVehicleIcon (#449)

### DIFF
--- a/src/lib/MapHelpers/__tests__/generateVehicleIcon.test.js
+++ b/src/lib/MapHelpers/__tests__/generateVehicleIcon.test.js
@@ -48,14 +48,14 @@ describe('createVehicleIconSvg', () => {
 		expect(svg).toContain('rotate(0)');
 	});
 
-	it('should include arrow pointing north when orientation is 0', () => {
+	it('should include arrow pointing east when orientation is 0 (OBA 0° = east)', () => {
 		const svg = createVehicleIconSvg(0);
 		expect(svg).toContain('<line');
 		expect(svg).toContain('<polygon');
 		expect(svg).toContain('rotate(90)');
 	});
 
-	it('should include arrow pointing south when orientation is 180', () => {
+	it('should include arrow pointing west when orientation is 180 (OBA 180° = west)', () => {
 		const svg = createVehicleIconSvg(180);
 		expect(svg).toContain('<line');
 		expect(svg).toContain('<polygon');

--- a/src/lib/MapHelpers/__tests__/generateVehicleIcon.test.js
+++ b/src/lib/MapHelpers/__tests__/generateVehicleIcon.test.js
@@ -2,14 +2,10 @@ import { describe, it, expect, vi } from 'vitest';
 import { createVehicleIconSvg } from '../generateVehicleIcon';
 import { RouteType } from '$config/routeConfig';
 
-vi.mock('$lib/mathUtils', () => ({
-	toDirection: vi.fn((val) => {
-		if (val === null || val === undefined || Number.isNaN(val) || !Number.isFinite(val)) {
-			return null;
-		}
-		return val;
-	})
-}));
+vi.mock('$lib/mathUtils', async () => {
+	const actual = await vi.importActual('$lib/mathUtils');
+	return { ...actual };
+});
 
 vi.mock('$config/routeConfig', () => ({
 	generateRouteTypeSvgForDisplay: vi.fn(() => '<path d="M0,0 L10,10"/>'),
@@ -24,7 +20,7 @@ describe('createVehicleIconSvg', () => {
 		const svg = createVehicleIconSvg(null);
 		expect(svg).not.toContain('<line');
 		expect(svg).not.toContain('<polygon');
-		expect(svg).toContain('<!-- Circle background (no directional arrow) -->');
+		expect(svg).toContain('<circle');
 	});
 
 	it('should not include arrow when orientation is NaN', () => {
@@ -49,21 +45,21 @@ describe('createVehicleIconSvg', () => {
 		const svg = createVehicleIconSvg(90);
 		expect(svg).toContain('<line');
 		expect(svg).toContain('<polygon');
-		expect(svg).toContain('rotate(90)');
+		expect(svg).toContain('rotate(0)');
 	});
 
 	it('should include arrow pointing north when orientation is 0', () => {
 		const svg = createVehicleIconSvg(0);
 		expect(svg).toContain('<line');
 		expect(svg).toContain('<polygon');
-		expect(svg).toContain('rotate(0)');
+		expect(svg).toContain('rotate(90)');
 	});
 
 	it('should include arrow pointing south when orientation is 180', () => {
 		const svg = createVehicleIconSvg(180);
 		expect(svg).toContain('<line');
 		expect(svg).toContain('<polygon');
-		expect(svg).toContain('rotate(180)');
+		expect(svg).toContain('rotate(270)');
 	});
 
 	it('should use custom color when provided', () => {

--- a/src/lib/MapHelpers/__tests__/generateVehicleIcon.test.js
+++ b/src/lib/MapHelpers/__tests__/generateVehicleIcon.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createVehicleIconSvg } from '../generateVehicleIcon';
+import { RouteType } from '$config/routeConfig';
+
+vi.mock('$lib/mathUtils', () => ({
+	toDirection: vi.fn((val) => {
+		if (val === null || val === undefined || Number.isNaN(val) || !Number.isFinite(val)) {
+			return null;
+		}
+		return val;
+	})
+}));
+
+vi.mock('$config/routeConfig', () => ({
+	generateRouteTypeSvgForDisplay: vi.fn(() => '<path d="M0,0 L10,10"/>'),
+	RouteType: {
+		BUS: 'bus',
+		LIGHT_RAIL: 'light-rail'
+	}
+}));
+
+describe('createVehicleIconSvg', () => {
+	it('should not include arrow when orientation is null', () => {
+		const svg = createVehicleIconSvg(null);
+		expect(svg).not.toContain('<line');
+		expect(svg).not.toContain('<polygon');
+		expect(svg).toContain('<!-- Circle background (no directional arrow) -->');
+	});
+
+	it('should not include arrow when orientation is NaN', () => {
+		const svg = createVehicleIconSvg(Number.NaN);
+		expect(svg).not.toContain('<line');
+		expect(svg).not.toContain('<polygon');
+	});
+
+	it('should not include arrow when orientation is undefined', () => {
+		const svg = createVehicleIconSvg(undefined);
+		expect(svg).not.toContain('<line');
+		expect(svg).not.toContain('<polygon');
+	});
+
+	it('should not include arrow when orientation is Infinity', () => {
+		const svg = createVehicleIconSvg(Infinity);
+		expect(svg).not.toContain('<line');
+		expect(svg).not.toContain('<polygon');
+	});
+
+	it('should include arrow when orientation is valid number (90 degrees)', () => {
+		const svg = createVehicleIconSvg(90);
+		expect(svg).toContain('<line');
+		expect(svg).toContain('<polygon');
+		expect(svg).toContain('rotate(90)');
+	});
+
+	it('should include arrow pointing north when orientation is 0', () => {
+		const svg = createVehicleIconSvg(0);
+		expect(svg).toContain('<line');
+		expect(svg).toContain('<polygon');
+		expect(svg).toContain('rotate(0)');
+	});
+
+	it('should include arrow pointing south when orientation is 180', () => {
+		const svg = createVehicleIconSvg(180);
+		expect(svg).toContain('<line');
+		expect(svg).toContain('<polygon');
+		expect(svg).toContain('rotate(180)');
+	});
+
+	it('should use custom color when provided', () => {
+		const customColor = '#FF0000';
+		const svg = createVehicleIconSvg(90, customColor);
+		expect(svg).toContain(`stroke="${customColor}"`);
+		expect(svg).toContain(`fill="${customColor}"`);
+	});
+
+	it('should use custom route type when provided', () => {
+		const svg = createVehicleIconSvg(45, '#007BFF', RouteType.LIGHT_RAIL);
+		expect(svg).toContain('viewBox="-28 -28 56 56"');
+	});
+
+	it('should always include circle background', () => {
+		const svgWithDirection = createVehicleIconSvg(90);
+		const svgWithoutDirection = createVehicleIconSvg(null);
+		expect(svgWithDirection).toContain('<circle');
+		expect(svgWithoutDirection).toContain('<circle');
+	});
+});

--- a/src/lib/MapHelpers/generateVehicleIcon.js
+++ b/src/lib/MapHelpers/generateVehicleIcon.js
@@ -23,26 +23,34 @@ function getDirectionFromOrientation(orientation) {
 }
 
 function createVehicleIconSvg(orientation, color = '#007BFF', routeType = RouteType.BUS) {
-	const direction = getDirectionFromOrientation(toDirection(orientation));
+	const resolvedDirection = toDirection(orientation);
+	
+	if (resolvedDirection === null) {
+		const vehicleSvg = generateRouteTypeSvgForDisplay(routeType);
+		return `
+        <svg width="${iconWidth}" height="${iconHeight}" viewBox="-28 -28 56 56" xmlns="http://www.w3.org/2000/svg">
+            <g stroke="${color}" fill="${color}">
+                <!-- Circle background (no directional arrow) -->
+                <circle cx="0" cy="0" r="13" stroke-width="2" fill="white"/>
+                ${vehicleSvg}
+            </g>
+        </svg>`;
+	}
+	
+	const direction = getDirectionFromOrientation(resolvedDirection);
 	const angle = DIRECTIONS.find((d) => d.icon === direction).angle;
 
 	const arrowPath = `
     <line x1="0" y1="0" x2="0" y2="-15" stroke-width="2" transform="rotate(${angle})"/>
     <polygon points="0,-25 5,-15 -5, -15" stroke="white" stroke-width="1" transform="rotate(${angle})"/>
 `;
-
 	const vehicleSvg = generateRouteTypeSvgForDisplay(routeType);
 
 	return `
         <svg width="${iconWidth}" height="${iconHeight}" viewBox="-28 -28 56 56" xmlns="http://www.w3.org/2000/svg">
             <g stroke="${color}" fill="${color}">
-                <!-- Directional arrow -->
                 ${arrowPath}
-
-                <!-- Circle background -->
                 <circle cx="0" cy="0" r="13" stroke-width="2" fill="white"/>
-
-                <!-- vehicle icon inside the circle -->
                 ${vehicleSvg}
             </g>
         </svg>`;

--- a/src/lib/MapHelpers/generateVehicleIcon.js
+++ b/src/lib/MapHelpers/generateVehicleIcon.js
@@ -24,26 +24,19 @@ function getDirectionFromOrientation(orientation) {
 
 function createVehicleIconSvg(orientation, color = '#007BFF', routeType = RouteType.BUS) {
 	const resolvedDirection = toDirection(orientation);
+	let direction = null;
+	let angle = null;
 	
-	if (resolvedDirection === null) {
-		const vehicleSvg = generateRouteTypeSvgForDisplay(routeType);
-		return `
-        <svg width="${iconWidth}" height="${iconHeight}" viewBox="-28 -28 56 56" xmlns="http://www.w3.org/2000/svg">
-            <g stroke="${color}" fill="${color}">
-                <!-- Circle background (no directional arrow) -->
-                <circle cx="0" cy="0" r="13" stroke-width="2" fill="white"/>
-                ${vehicleSvg}
-            </g>
-        </svg>`;
+	if (resolvedDirection !== null) {
+		direction = getDirectionFromOrientation(resolvedDirection);
+		angle = DIRECTIONS.find((d) => d.icon === direction).angle;
 	}
 	
-	const direction = getDirectionFromOrientation(resolvedDirection);
-	const angle = DIRECTIONS.find((d) => d.icon === direction).angle;
-
-	const arrowPath = `
+	const arrowPath = direction ? `
     <line x1="0" y1="0" x2="0" y2="-15" stroke-width="2" transform="rotate(${angle})"/>
-    <polygon points="0,-25 5,-15 -5, -15" stroke="white" stroke-width="1" transform="rotate(${angle})"/>
-`;
+    <polygon points="0,-25 5,-15 -5,-15" stroke="white" stroke-width="1" transform="rotate(${angle})"/>
+` : '';
+	
 	const vehicleSvg = generateRouteTypeSvgForDisplay(routeType);
 
 	return `


### PR DESCRIPTION
Handle null orientation explicitly in generateVehicleIcon , fixes #449 

 Description
When a vehicle has no orientation data (null/NaN/undefined), the icon 
now renders without a directional arrow, making it clear the direction 
is unknown. Previously, null values silently defaulted to north.

Changes
- Added explicit null check in `createVehicleIconSvg()`
- Returns SVG without arrow when orientation is invalid
- Added comprehensive unit tests (10 test cases)

 Testing
- All 10 new unit tests passing
- Full build test suite passing (1214 tests)