### PR TITLE
test: Add unit tests for skipSurvey() function (#444)

### DIFF
--- a/src/tests/lib/surveysUtils.test.js
+++ b/src/tests/lib/surveysUtils.test.js
@@ -1,4 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('$stores/surveyStore', () => ({
+	showSurveyModal: {
+		set: vi.fn()
+	},
+	markSurveyAnswered: vi.fn(),
+	surveyStore: {
+		update: vi.fn()
+	}
+}));
+
 import {
 	getValidSurveys,
 	getValidStopSurvey,
@@ -6,7 +17,8 @@ import {
 	getMapSurvey,
 	submitHeroQuestion,
 	updateSurveyResponse,
-	getPrioritySurvey
+	getPrioritySurvey,
+	skipSurvey
 } from '../../lib/Surveys/surveyUtils';
 
 beforeEach(() => {
@@ -316,5 +328,49 @@ describe('Survey Visibility and Multiple Responses', () => {
 		const selectedSurvey = await getPrioritySurvey(surveys, null);
 
 		expect(selectedSurvey).toEqual(surveys[2]);
+	});
+});
+
+describe('skipSurvey', () => {
+	it('should set only _skipped_timestamp for recurring surveys', () => {
+		const survey = {
+			id: '123',
+			allows_multiple_responses: true,
+			always_visible: true
+		};
+
+		skipSurvey(survey);
+
+		expect(localStorage.getItem('survey_123_skipped_timestamp')).toBeDefined();
+		expect(localStorage.getItem('survey_123_skipped')).toBeNull();
+	});
+
+	it('should set only _skipped for one-time surveys', () => {
+		const survey = {
+			id: '456',
+			allows_multiple_responses: false,
+			always_visible: false
+		};
+
+		skipSurvey(survey);
+
+		expect(localStorage.getItem('survey_456_skipped')).toBeDefined();
+		expect(localStorage.getItem('survey_456_skipped_timestamp')).toBeNull();
+	});
+
+	it('should remove stale _skipped flag when skipping a recurring survey', () => {
+		const survey = {
+			id: '789',
+			allows_multiple_responses: true,
+			always_visible: true
+		};
+
+		// Simulate stale flag from old buggy behavior
+		localStorage.setItem('survey_789_skipped', 'true');
+
+		skipSurvey(survey);
+
+		expect(localStorage.getItem('survey_789_skipped')).toBeNull();
+		expect(localStorage.getItem('survey_789_skipped_timestamp')).toBeDefined();
 	});
 });

--- a/src/tests/lib/surveysUtils.test.js
+++ b/src/tests/lib/surveysUtils.test.js
@@ -341,7 +341,7 @@ describe('skipSurvey', () => {
 
 		skipSurvey(survey);
 
-		expect(localStorage.getItem('survey_123_skipped_timestamp')).toBeDefined();
+		expect(localStorage.getItem('survey_123_skipped_timestamp')).not.toBeNull();
 		expect(localStorage.getItem('survey_123_skipped')).toBeNull();
 	});
 
@@ -354,7 +354,7 @@ describe('skipSurvey', () => {
 
 		skipSurvey(survey);
 
-		expect(localStorage.getItem('survey_456_skipped')).toBeDefined();
+		expect(localStorage.getItem('survey_456_skipped')).not.toBeNull();
 		expect(localStorage.getItem('survey_456_skipped_timestamp')).toBeNull();
 	});
 
@@ -371,6 +371,6 @@ describe('skipSurvey', () => {
 		skipSurvey(survey);
 
 		expect(localStorage.getItem('survey_789_skipped')).toBeNull();
-		expect(localStorage.getItem('survey_789_skipped_timestamp')).toBeDefined();
+		expect(localStorage.getItem('survey_789_skipped_timestamp')).not.toBeNull();
 	});
 });


### PR DESCRIPTION
 Overview

Adds unit tests for the `skipSurvey()` function to improve coverage for the fix introduced in #420.

Covered

* Recurring surveys: ensures `_skipped_timestamp` is set when `allows_multiple_responses: true`
* One-time surveys: ensures `_skipped` flag is set correctly
* Legacy cleanup: verifies removal of stale `_skipped` flag when `_skipped_timestamp` is used

 Testing

* All tests passing (24 total: 3 new, 21 existing)
* Run using: `npm run test -- --run`
* No lint or build issues

Closes #444
