### PR TITLE
Fix: standardize /obaSdk imports (remove .js extension) to avoid modu…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -319,7 +319,6 @@
 					"url": "https://opencollective.com/csstools"
 				}
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -342,7 +341,6 @@
 					"url": "https://opencollective.com/csstools"
 				}
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -945,7 +943,6 @@
 			"integrity": "sha512-8dBIHbfsKlCk2jHQ9PoRBg2Z+4TwyE3vZICSnoDlnsHA6SiMlTwfmW6yX0lHsRmWJugkeb92sA0hZdkXJhuz+g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@fortawesome/fontawesome-common-types": "6.7.1"
 			},
@@ -1291,6 +1288,7 @@
 			"resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
 			"integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"get-stream": "^6.0.1",
 				"minimist": "^1.2.6"
@@ -1303,6 +1301,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
 			"integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -1311,25 +1310,29 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
 			"integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/@mapbox/tiny-sdf": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.6.tgz",
 			"integrity": "sha512-qMqa27TLw+ZQz5Jk+RcwZGH7BQf5G/TrutJhspsca/3SHwmgKQ1iq+d3Jxz5oysPVYTGP6aXxCo5Lk9Er6YBAA==",
-			"license": "BSD-2-Clause"
+			"license": "BSD-2-Clause",
+			"peer": true
 		},
 		"node_modules/@mapbox/unitbezier": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
 			"integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
-			"license": "BSD-2-Clause"
+			"license": "BSD-2-Clause",
+			"peer": true
 		},
 		"node_modules/@mapbox/vector-tile": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
 			"integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"@mapbox/point-geometry": "~0.1.0"
 			}
@@ -1339,6 +1342,7 @@
 			"resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
 			"integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
 			"license": "ISC",
+			"peer": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -1359,6 +1363,7 @@
 			"resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz",
 			"integrity": "sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==",
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"@mapbox/jsonlint-lines-primitives": "~2.0.2",
 				"@mapbox/unitbezier": "^0.0.1",
@@ -1378,7 +1383,8 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
 			"integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/@mswjs/interceptors": {
 			"version": "0.39.2",
@@ -1934,7 +1940,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/cookie": "^0.6.0",
 				"cookie": "^0.6.0",
@@ -1967,7 +1972,6 @@
 			"integrity": "sha512-Y9r/fWy539XlAC7+5wfNJ4zH6TygUYoQ0Eegzp0zDDqhJ54+92gOyOX1l4MO1cJSx0O+Gp13YePT5XEa3+kX0w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^3.0.0-next.0||^3.0.0",
 				"debug": "^4.3.7",
@@ -2171,13 +2175,15 @@
 			"version": "7946.0.14",
 			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
 			"integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/geojson-vt": {
 			"version": "3.2.5",
 			"resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
 			"integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/geojson": "*"
 			}
@@ -2209,13 +2215,15 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
 			"integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/mapbox__vector-tile": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
 			"integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/geojson": "*",
 				"@types/mapbox__point-geometry": "*",
@@ -2227,7 +2235,6 @@
 			"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
 			"integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/linkify-it": "^5",
 				"@types/mdurl": "^2"
@@ -2262,7 +2269,8 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
 			"integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/resolve": {
 			"version": "1.20.2",
@@ -2283,6 +2291,7 @@
 			"resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
 			"integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/geojson": "*"
 			}
@@ -2474,7 +2483,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
 			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2792,7 +2800,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"caniuse-lite": "^1.0.30001669",
 				"electron-to-chromium": "^1.5.41",
@@ -3330,7 +3337,8 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.0.tgz",
 			"integrity": "sha512-41Fs7Q/PLq1SDbqjsgcY7GA42T0jvaCNGXgGtsNdvg+Yv8eIu06bxv4/PoREkZ9nMDNwnUSG9OFB9+yv8eKhDg==",
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
@@ -3570,7 +3578,6 @@
 			"integrity": "sha512-7CrWySmIibCgT1Os28lUU6upBshZ+GxybLOrmRzi08kS8MBuO8QA7pXEgYgY5W8vK3e74xv0lpjo9DbaGU9Rkw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -4155,7 +4162,8 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
 			"integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
@@ -4172,6 +4180,7 @@
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
 			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -4183,7 +4192,8 @@
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
 			"integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/glob": {
 			"version": "8.1.0",
@@ -4243,6 +4253,7 @@
 			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
 			"integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ini": "^4.1.3",
 				"kind-of": "^6.0.3",
@@ -4257,6 +4268,7 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
 			"integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
 			"license": "ISC",
+			"peer": true,
 			"engines": {
 				"node": ">=16"
 			}
@@ -4266,6 +4278,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
 			"integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"isexe": "^3.1.1"
 			},
@@ -4438,7 +4451,8 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
@@ -4520,6 +4534,7 @@
 			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
 			"integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
 			"license": "ISC",
+			"peer": true,
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
@@ -4718,7 +4733,6 @@
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
 			"integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"jiti": "bin/jiti.js"
 			}
@@ -4889,13 +4903,15 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
 			"integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/kdbush": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
 			"integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
@@ -4912,6 +4928,7 @@
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
 			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -4946,8 +4963,7 @@
 			"version": "1.9.4",
 			"resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
 			"integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-			"license": "BSD-2-Clause",
-			"peer": true
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/leaflet-polylinedecorator": {
 			"version": "1.6.0",
@@ -5159,7 +5175,6 @@
 			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
 			"integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1",
 				"entities": "^4.4.0",
@@ -5368,7 +5383,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@bundled-es-modules/cookie": "^2.0.1",
 				"@bundled-es-modules/statuses": "^1.0.1",
@@ -5411,7 +5425,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
 			"integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/mute-stream": {
 			"version": "2.0.0",
@@ -5736,6 +5751,7 @@
 			"resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
 			"integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"ieee754": "^1.1.12",
 				"resolve-protobuf-schema": "^2.1.0"
@@ -5756,7 +5772,6 @@
 			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -5807,7 +5822,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.7",
 				"picocolors": "^1.1.1",
@@ -5975,7 +5989,8 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
 			"integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw==",
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
@@ -5993,7 +6008,6 @@
 			"integrity": "sha512-G+YdqtITVZmOJje6QkXQWzl3fSfMxFwm1tjTyo9exhkmWSqC4Yhd1+lug++IlR2mvRVAxEDDWYkQdeSztajqgg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -6010,7 +6024,6 @@
 			"integrity": "sha512-kRPjH8wSj2iu+dO+XaUv4vD8qr5mdDmlak3IT/7AOgGIMRG86z/EHOLauFcClKEnOUf4A4nOA7sre5KrJD4Raw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"prettier": "^3.0.0",
 				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
@@ -6139,7 +6152,6 @@
 			"integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
@@ -6219,7 +6231,8 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
 			"integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/psl": {
 			"version": "1.15.0",
@@ -6284,7 +6297,8 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
 			"integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/react-is": {
 			"version": "17.0.2",
@@ -6398,6 +6412,7 @@
 			"resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
 			"integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"protocol-buffers-schema": "^3.3.1"
 			}
@@ -6418,7 +6433,6 @@
 			"integrity": "sha512-RLKxqHEMjh/RGLsDxAEsaLO3mWgyoU6x9w6n1ikAzet4B3gI2/3yP6PWY2p9QzRTh6MfEIXB3MwsOY0Iv3vNrw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.6"
 			},
@@ -6484,7 +6498,8 @@
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
 			"integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/sade": {
 			"version": "1.8.1",
@@ -6832,6 +6847,7 @@
 			"resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
 			"integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"kdbush": "^4.0.2"
 			}
@@ -6865,7 +6881,6 @@
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.2.8.tgz",
 			"integrity": "sha512-VU7a01XwnFi6wXVkH5QY3FYXRZWrhsWZhaE8AYU6UeYZdslE3TFgQq6+HLrbMjOLkVhdKt74NGHYbhFeErQQ6g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.3.0",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -7105,7 +7120,6 @@
 			"integrity": "sha512-0LXunzzAZzo0tEPxV3I297ffKZPlKDrjj7NXphC8V5ak9yHC5zRmxnOe2m/Rd/7ivsOMJe3JZ2JVocoDdQTRBA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/dcastil"
@@ -7116,7 +7130,6 @@
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.15.tgz",
 			"integrity": "sha512-r4MeXnfBmSOuKUWmXe6h2CcyfzJCEk4F0pptO5jlnYSIViUkVmsawj80N5h2lO3gwcmSb4n3PuN+e+GC1Guylw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@alloc/quick-lru": "^5.2.0",
 				"arg": "^5.0.2",
@@ -7357,7 +7370,8 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
 			"integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/tinyrainbow": {
 			"version": "1.2.0",
@@ -7594,7 +7608,6 @@
 			"integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",
@@ -8127,7 +8140,6 @@
 			"integrity": "sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "2.1.8",
 				"@vitest/mocker": "2.1.8",
@@ -8193,6 +8205,7 @@
 			"resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
 			"integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@mapbox/point-geometry": "0.1.0",
 				"@mapbox/vector-tile": "^1.3.1",

--- a/src/lib/serverCache.js
+++ b/src/lib/serverCache.js
@@ -1,4 +1,4 @@
-import oba from '$lib/obaSdk.js';
+import oba from '$lib/obaSdk';
 import { calculateBoundsFromAgencies } from '$lib/mathUtils.js';
 import { getAgencyFilter } from '$lib/agencyFilter.js';
 

--- a/src/routes/api/oba/arrivals-and-departures-for-stop/[id]/+server.js
+++ b/src/routes/api/oba/arrivals-and-departures-for-stop/[id]/+server.js
@@ -1,4 +1,4 @@
-import oba, { handleOBAResponse } from '$lib/obaSdk.js';
+import oba, { handleOBAResponse } from '$lib/obaSdk';
 import { getAgencyFilter, filterByRouteId } from '$lib/agencyFilter.js';
 
 /** @type {import('./$types').RequestHandler} */

--- a/src/routes/api/oba/shape/[shapeId]/+server.js
+++ b/src/routes/api/oba/shape/[shapeId]/+server.js
@@ -1,4 +1,4 @@
-import oba, { handleOBAResponse } from '$lib/obaSdk.js';
+import oba, { handleOBAResponse } from '$lib/obaSdk';
 
 /** @type {import('./$types').RequestHandler} */
 export async function GET({ params }) {

--- a/src/routes/api/oba/stops-for-route/[routeId]/+server.js
+++ b/src/routes/api/oba/stops-for-route/[routeId]/+server.js
@@ -1,4 +1,4 @@
-import oba, { handleOBAResponse } from '$lib/obaSdk.js';
+import oba, { handleOBAResponse } from '$lib/obaSdk';
 
 export async function GET({ params }) {
 	const routeId = params.routeId;

--- a/src/routes/api/oba/trip-details/[tripId]/+server.js
+++ b/src/routes/api/oba/trip-details/[tripId]/+server.js
@@ -1,4 +1,4 @@
-import oba, { handleOBAResponse } from '$lib/obaSdk.js';
+import oba, { handleOBAResponse } from '$lib/obaSdk';
 
 export async function GET({ params, url }) {
 	const { tripId } = params;

--- a/src/routes/stops/[stopID]/+page.server.js
+++ b/src/routes/stops/[stopID]/+page.server.js
@@ -1,4 +1,4 @@
-import oba, { handleOBAResponse } from '$lib/obaSdk.js';
+import oba, { handleOBAResponse } from '$lib/obaSdk';
 import { getAgencyFilter, filterByRouteId } from '$lib/agencyFilter.js';
 
 export async function load({ params }) {


### PR DESCRIPTION
Fixes #458 

Short description of what this resolves:

This PR fixes server-side 500 errors caused by inconsistent module imports of the OBA SDK. Standardizing the import pattern ensures reliable module resolution during SSR.

Changes proposed in this pull request:

* Fixed inconsistent imports of the OBA SDK across server-side files
* Replaced usages of `$lib/obaSdk.js` with `$lib/obaSdk` to align with Vite/SvelteKit module resolution
* Eliminated runtime import failures that were causing intermittent server 500 errors
* Improved consistency and reliability of server-side code

Files updated:

* src/lib/serverCache.js
* src/routes/stops/[stopID]/+page.server.js
* Multiple API route files under src/routes/api/oba/*/*/+server.js

Checklist

[x] I have read the Contribution & Best practices Guide
[x] My branch is up-to-date with the upstream branch
[x] Changes tested locally and server runs without errors
[ ] Tests can be added for further validation if required
[ ] Documentation updates can be added if needed

Additional Notes:

This change ensures consistent module resolution across the codebase and prevents SSR-related runtime failures. Happy to verify further or extend with tests if required.
