### PR TITLE
fix(i18n): internationalize aria-labels and add component unit tests (closes #406, closes #402)

### DIFF
--- a/src/components/surveys/SurveyQuestion.svelte
+++ b/src/components/surveys/SurveyQuestion.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { Radio, Checkbox, Input } from 'flowbite-svelte';
+	import { t } from 'svelte-i18n';
 
 	let {
 		question,
@@ -38,7 +39,7 @@
 		{question.content.label_text}
 	{/if}
 	{#if required && question.content.type !== 'label'}
-		<span class="ml-1 text-red-500" aria-label="Required question">*</span>
+		<span class="ml-1 text-red-500" aria-label={$t('survey.required_question')}>*</span>
 	{/if}
 </label>
 

--- a/src/components/trip-planner/TripPlanSearchField.svelte
+++ b/src/components/trip-planner/TripPlanSearchField.svelte
@@ -12,7 +12,6 @@
 	 * @property {any} onClear
 	 * @property {any} onSelect
 	 */
-
 	/** @type {Props} */
 	let {
 		inputId = 'location-input',
@@ -51,7 +50,7 @@
 			type="button"
 			class="absolute inset-y-0 right-0 flex items-center pr-3"
 			onclick={handleClear}
-			aria-label="Clear"
+			aria-label={$t('search.clear')}
 		>
 			<FontAwesomeIcon icon={faX} class="size-5 text-gray-400" />
 		</button>
@@ -71,7 +70,7 @@
 					class="flex w-full cursor-pointer items-center px-4 py-2 text-left hover:bg-gray-100 dark:text-black"
 					onclick={() => handleSelect(result)}
 				>
-					<FontAwesomeIcon icon={faMapMarkerAlt} class="mr-2 text-gray-400  " />
+					<FontAwesomeIcon icon={faMapMarkerAlt} class="mr-2 text-gray-400 " />
 					{result.displayText}
 				</button>
 			{/each}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,194 +1,198 @@
 {
-	"units": {
-		"meters": "m",
-		"kilometers": "km",
-		"feet": "ft",
-		"mile": "mile",
-		"miles": "miles"
-	},
-	"trip-planner": {
-		"arrive": "Arrive",
-		"depart": "Depart",
-		"today": "Today",
-		"tomorrow": "Tomorrow",
-		"plan_your_trip": "Plan Your Trip",
-		"itinerary": "Itinerary",
-		"duration": "Duration",
-		"start_time": "Start Time",
-		"end_time": "End Time",
-		"minutes": "min",
-		"distance": "Distance:",
-		"end": "End",
-		"start": "Start",
-		"meters": "meters",
-		"no_itineraries_found": "No itineraries found",
+		"units": {
+					"meters": "m",
+					"kilometers": "km",
+					"feet": "ft",
+					"mile": "mile",
+					"miles": "miles"
+		},
+		"trip-planner": {
+					"arrive": "Arrive",
+					"depart": "Depart",
+					"today": "Today",
+					"tomorrow": "Tomorrow",
+					"plan_your_trip": "Plan Your Trip",
+					"itinerary": "Itinerary",
+					"duration": "Duration",
+					"start_time": "Start Time",
+					"end_time": "End Time",
+					"minutes": "min",
+					"distance": "Distance:",
+					"end": "End",
+					"start": "Start",
+					"meters": "meters",
+					"no_itineraries_found": "No itineraries found",
+					"loading": "Loading",
+					"planning": "Planning",
+					"from": "From",
+					"to": "To",
+					"search_for_a_place": "Search for a place",
+					"trip_itineraries": "Trip Itineraries",
+					"show_steps": "Show Steps",
+					"hide_steps": "Hide Steps",
+					"options": "Options",
+					"trip_options": "Trip Options",
+					"cancel": "Cancel",
+					"done": "Done",
+					"departure_time": "Departure Time",
+					"leave_now": "Leave Now",
+					"depart_at": "Depart At",
+					"arrive_by": "Arrive By",
+					"wheelchair_accessible": "Wheelchair accessible",
+					"wheelchair_desc": "Find routes suitable for mobility devices and wheelchairs",
+					"wheelchair": "Wheelchair",
+					"route_optimization": "Route Optimization",
+					"fastest_trip": "Fastest Trip",
+					"fewest_transfers": "Fewest Transfers",
+					"stay_on_board": "Remain on board. This trip continues as Route {route}.",
+					"walking_distance": "Walking Distance",
+					"max_walking_distance": "Maximum walking distance",
+					"distance_unit": "Distance Unit",
+					"unit_auto": "Auto-detect",
+					"unit_metric": "Metric (km, m)",
+					"unit_imperial": "Imperial (mi, ft)",
+					"swap_locations": "Swap From and To locations",
+					"error_code": "Error code",
+					"remove_recent_trip": "Remove recent trip",
+					"recent_trip": "Use recent trip from {from} to {to}",
+					"recent_searches": "Recent Searches",
+					"clear_all": "Clear All"
+		},
+		"tabs": {
+					"stops-and-stations": "Stops and Stations",
+					"plan_trip": "Plan a Trip"
+		},
+		"search": {
+					"placeholder": "Search for stops, routes, and places",
+					"results_for": "Search results for",
+					"clear_results": "Clear results",
+					"search": "Search",
+					"click_here": "Click here",
+					"for_a_list_of_available_routes": "for a list of available routes",
+					"search_for_routes": "Search for routes...",
+					"no_routes_found": "No routes found",
+					"all_routes": "All Routes",
+					"clear": "Clear"
+		},
+		"header": {
+					"home": "Home",
+					"about": "About",
+					"contact": "Contact",
+					"fares_and_tolls": "Fares & Tolls"
+		},
+		"navigation": {
+					"back_to_map": "Back to Map"
+		},
+		"status": {
+					"scheduled": "scheduled",
+					"early": "early",
+					"late": "late",
+					"on_time": "on time",
+					"min": "min",
+					"arrives_on_time": "arrives on time",
+					"scheduled_not_real_time": "Scheduled/not real-time",
+					"canceled": "Canceled",
+					"canceled_arrival": "Canceled arrival",
+					"canceled_departure": "Canceled departure",
+					"frequency_from": "Every {headway} min from {time}",
+					"frequency_until": "Every {headway} min until {time}",
+					"late_without_arrive_depart": "{delay} min late",
+					"early_without_arrive_depart": "{delay} min early",
+					"arrived_delayed": "Arrived {delay} min late",
+					"arrived_early": "Arrived {delay} min early",
+					"arrived_ontime": "Arrived on time",
+					"depart_delayed": "Departed {delay} min late",
+					"depart_early": "Departed {delay} min early",
+					"departed_ontime": "Departed on time",
+					"scheduled_arrival": "Scheduled arriving at",
+					"scheduled_departure": "Scheduled departure"
+		},
+		"alert": {
+					"more_info": "More info",
+					"close": "Close"
+		},
+		"arrivals_and_departures": "Arrivals and departures",
+		"show_more": "Show more",
+		"show_less": "Show less",
+		"no_arrivals_or_departures_in_next_30_minutes": "No arrivals or departures in the next 30 minutes",
+		"stop": "Stop",
+		"routes": "Routes",
+		"route": "route",
+		"route_modal_title": "Route {name}",
 		"loading": "Loading",
-		"planning": "Planning",
-		"from": "From",
-		"to": "To",
-		"search_for_a_place": "Search for a place",
-		"trip_itineraries": "Trip Itineraries",
-		"show_steps": "Show Steps",
-		"hide_steps": "Hide Steps",
-		"options": "Options",
-		"trip_options": "Trip Options",
-		"cancel": "Cancel",
-		"done": "Done",
-		"departure_time": "Departure Time",
-		"leave_now": "Leave Now",
-		"depart_at": "Depart At",
-		"arrive_by": "Arrive By",
-		"wheelchair_accessible": "Wheelchair accessible",
-		"wheelchair_desc": "Find routes suitable for mobility devices and wheelchairs",
-		"wheelchair": "Wheelchair",
-		"route_optimization": "Route Optimization",
-		"fastest_trip": "Fastest Trip",
-		"fewest_transfers": "Fewest Transfers",
-		"stay_on_board": "Remain on board. This trip continues as Route {route}.",
-		"walking_distance": "Walking Distance",
-		"max_walking_distance": "Maximum walking distance",
-		"distance_unit": "Distance Unit",
-		"unit_auto": "Auto-detect",
-		"unit_metric": "Metric (km, m)",
-		"unit_imperial": "Imperial (mi, ft)",
-		"swap_locations": "Swap From and To locations",
-		"error_code": "Error code",
-		"remove_recent_trip": "Remove recent trip",
-		"recent_trip": "Use recent trip from {from} to {to}",
-		"recent_searches": "Recent Searches",
-		"clear_all": "Clear All"
-	},
-	"tabs": {
-		"stops-and-stations": "Stops and Stations",
-		"plan_trip": "Plan a Trip"
-	},
-	"search": {
-		"placeholder": "Search for stops, routes, and places",
-		"results_for": "Search results for",
-		"clear_results": "Clear results",
-		"search": "Search",
-		"click_here": "Click here",
-		"for_a_list_of_available_routes": "for a list of available routes",
-		"search_for_routes": "Search for routes...",
-		"no_routes_found": "No routes found",
-		"all_routes": "All Routes"
-	},
-	"header": {
-		"home": "Home",
-		"about": "About",
-		"contact": "Contact",
-		"fares_and_tolls": "Fares & Tolls"
-	},
-	"navigation": {
-		"back_to_map": "Back to Map"
-	},
-	"status": {
-		"scheduled": "scheduled",
-		"early": "early",
-		"late": "late",
-		"on_time": "on time",
-		"min": "min",
-		"arrives_on_time": "arrives on time",
-		"scheduled_not_real_time": "Scheduled/not real-time",
-		"canceled": "Canceled",
-		"canceled_arrival": "Canceled arrival",
-		"canceled_departure": "Canceled departure",
-		"frequency_from": "Every {headway} min from {time}",
-		"frequency_until": "Every {headway} min until {time}",
-		"late_without_arrive_depart": "{delay} min late",
-		"early_without_arrive_depart": "{delay} min early",
-		"arrived_delayed": "Arrived {delay} min late",
-		"arrived_early": "Arrived {delay} min early",
-		"arrived_ontime": "Arrived on time",
-		"depart_delayed": "Departed {delay} min late",
-		"depart_early": "Departed {delay} min early",
-		"departed_ontime": "Departed on time",
-		"scheduled_arrival": "Scheduled arriving at",
-		"scheduled_departure": "Scheduled departure"
-	},
-	"alert": {
-		"more_info": "More info",
-		"close": "Close"
-	},
-	"arrivals_and_departures": "Arrivals and departures",
-	"show_more": "Show more",
-	"show_less": "Show less",
-	"no_arrivals_or_departures_in_next_30_minutes": "No arrivals or departures in the next 30 minutes",
-	"stop": "Stop",
-	"routes": "Routes",
-	"route": "route",
-	"route_modal_title": "Route {name}",
-	"loading": "Loading",
-	"arrives": "arrives",
-	"NA": "N/A",
-	"time": {
-		"ago": "ago",
-		"now": "now",
-		"sec": "sec",
-		"secs": "secs",
-		"min": "min",
-		"mins": "mins",
-		"minutes": "minutes"
-	},
-	"vehicle": {
-		"number": "Vehicle #",
-		"data_updated": "Data updated",
-		"no_real_time_data": "We don't have real-time data for this vehicle now.",
-		"next_stop": "Next stop:"
-	},
-	"arrivals_and_departures_for_stop": {
-		"title": "Arrivals and Departures"
-	},
-	"schedule_for_stop": {
-		"view_schedule": "View Schedule",
-		"no_am_schedules_available": "No AM schedules available",
-		"no_pm_schedules_available": "No PM schedules available",
-		"minutes": "Minutes",
-		"hour": "Hour",
-		"show_all_routes": "Show All Routes",
-		"collapse_all_routes": "Collapse All Routes",
-		"route_schedules": "Route Schedules",
-		"no_schedules_available": "No schedules available for the selected date.",
-		"stop_id": "Stop ID",
-		"direction": "Direction"
-	},
-	"direction": {
-		"N": "North",
-		"NE": "Northeast",
-		"E": "East",
-		"SE": "Southeast",
-		"S": "South",
-		"SW": "Southwest",
-		"W": "West",
-		"NW": "Northwest"
-	},
-	"service_alerts": {
-		"more_info": "More info",
-		"close": "Close",
-		"service_alerts": "Service Alerts",
-		"service_alert": "Service Alert",
-		"advice": "Advice",
-		"no_summary": "No summary available for this alert",
-		"no_description": "No detailed description available for this alert",
-		"page": "Page",
-		"show": "Show",
-		"hide": "Hide",
-		"open_alert": "Open service alert details: {summary}",
-		"alert_modal": "Service alert details dialog"
-	},
-	"view_stop_information": "View Stop Information",
-	"stop_details": {
-		"view_details": "View Details"
-	},
-	"language_switcher": {
-		"select_language": "Select language: {language}",
-		"available_languages": "Available languages"
-	},
-	"map": {
-		"find_my_location": "Find My Location"
-	},
-	"context-menu": {
-		"start_here": "Start Here",
-		"end_here": "End Here"
-	}
+		"arrives": "arrives",
+		"NA": "N/A",
+		"time": {
+					"ago": "ago",
+					"now": "now",
+					"sec": "sec",
+					"secs": "secs",
+					"min": "min",
+					"mins": "mins",
+					"minutes": "minutes"
+		},
+		"vehicle": {
+					"number": "Vehicle #",
+					"data_updated": "Data updated",
+					"no_real_time_data": "We don't have real-time data for this vehicle now.",
+					"next_stop": "Next stop:"
+		},
+		"arrivals_and_departures_for_stop": {
+					"title": "Arrivals and Departures"
+		},
+		"schedule_for_stop": {
+					"view_schedule": "View Schedule",
+					"no_am_schedules_available": "No AM schedules available",
+					"no_pm_schedules_available": "No PM schedules available",
+					"minutes": "Minutes",
+					"hour": "Hour",
+					"show_all_routes": "Show All Routes",
+					"collapse_all_routes": "Collapse All Routes",
+					"route_schedules": "Route Schedules",
+					"no_schedules_available": "No schedules available for the selected date.",
+					"stop_id": "Stop ID",
+					"direction": "Direction"
+		},
+		"direction": {
+					"N": "North",
+					"NE": "Northeast",
+					"E": "East",
+					"SE": "Southeast",
+					"S": "South",
+					"SW": "Southwest",
+					"W": "West",
+					"NW": "Northwest"
+		},
+		"service_alerts": {
+					"more_info": "More info",
+					"close": "Close",
+					"service_alerts": "Service Alerts",
+					"service_alert": "Service Alert",
+					"advice": "Advice",
+					"no_summary": "No summary available for this alert",
+					"no_description": "No detailed description available for this alert",
+					"page": "Page",
+					"show": "Show",
+					"hide": "Hide",
+					"open_alert": "Open service alert details: {summary}",
+					"alert_modal": "Service alert details dialog"
+		},
+		"view_stop_information": "View Stop Information",
+		"stop_details": {
+					"view_details": "View Details"
+		},
+		"language_switcher": {
+					"select_language": "Select language: {language}",
+					"available_languages": "Available languages"
+		},
+		"map": {
+					"find_my_location": "Find My Location"
+		},
+		"context-menu": {
+					"start_here": "Start Here",
+					"end_here": "End Here"
+		},
+		"survey": {
+					"required_question": "Required question"
+		}
 }

--- a/src/tests/components/CompassArrow.test.js
+++ b/src/tests/components/CompassArrow.test.js
@@ -1,31 +1,32 @@
-import { render, screen } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte';
 import { describe, it, expect } from 'vitest';
-import CompassArrow from '../../components/CompassArrow.svelte';
+import CompassArrow from '../../components/controls/CompassArrow.svelte';
 
 describe('CompassArrow', () => {
   	const directions = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
 
-         	directions.forEach((direction) => {
-            		it(`renders the correct rotation class for direction "${direction}"`, () => {
-                  			const { container } = render(CompassArrow, { props: { direction } });
-                  			const arrow = container.querySelector('[class]');
-                  			expect(arrow).toBeTruthy();
-                  			// Each known direction should NOT have the hidden class
-                   			expect(arrow.className).not.toContain('hidden');
+         	directions.forEach((stopDirection) => {
+            		it(`renders without the "hidden" class for direction "${stopDirection}"`, () => {
+                  			const { container } = render(CompassArrow, { props: { stopDirection } });
+                  			// FontAwesomeIcon renders an SVG — check that element exists
+                   			const svg = container.querySelector('svg');
+                  			expect(svg).toBeTruthy();
+                  			// Known directions should not render with 'hidden' class
+                   			expect(svg.getAttribute('class') || '').not.toContain('hidden');
                 });
           });
 
          	it('renders with "hidden" class for an unknown direction', () => {
-            		const { container } = render(CompassArrow, { props: { direction: 'UNKNOWN' } });
-            		const arrow = container.querySelector('[class]');
-            		expect(arrow).toBeTruthy();
-            		expect(arrow.className).toContain('hidden');
+            		const { container } = render(CompassArrow, { props: { stopDirection: 'UNKNOWN' } });
+            		const svg = container.querySelector('svg');
+            		expect(svg).toBeTruthy();
+            		expect(svg.getAttribute('class') || '').toContain('hidden');
           });
 
          	it('renders with "hidden" class when no direction is provided', () => {
             		const { container } = render(CompassArrow, {});
-            		const arrow = container.querySelector('[class]');
-            		expect(arrow).toBeTruthy();
-            		expect(arrow.className).toContain('hidden');
+            		const svg = container.querySelector('svg');
+            		expect(svg).toBeTruthy();
+            		expect(svg.getAttribute('class') || '').toContain('hidden');
           });
 });

--- a/src/tests/components/CompassArrow.test.js
+++ b/src/tests/components/CompassArrow.test.js
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import CompassArrow from '../../components/CompassArrow.svelte';
+
+describe('CompassArrow', () => {
+  	const directions = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
+
+         	directions.forEach((direction) => {
+            		it(`renders the correct rotation class for direction "${direction}"`, () => {
+                  			const { container } = render(CompassArrow, { props: { direction } });
+                  			const arrow = container.querySelector('[class]');
+                  			expect(arrow).toBeTruthy();
+                  			// Each known direction should NOT have the hidden class
+                   			expect(arrow.className).not.toContain('hidden');
+                });
+          });
+
+         	it('renders with "hidden" class for an unknown direction', () => {
+            		const { container } = render(CompassArrow, { props: { direction: 'UNKNOWN' } });
+            		const arrow = container.querySelector('[class]');
+            		expect(arrow).toBeTruthy();
+            		expect(arrow.className).toContain('hidden');
+          });
+
+         	it('renders with "hidden" class when no direction is provided', () => {
+            		const { container } = render(CompassArrow, {});
+            		const arrow = container.querySelector('[class]');
+            		expect(arrow).toBeTruthy();
+            		expect(arrow.className).toContain('hidden');
+          });
+});

--- a/src/tests/components/FullPageLoadingSpinner.test.js
+++ b/src/tests/components/FullPageLoadingSpinner.test.js
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import FullPageLoadingSpinner from '../../components/FullPageLoadingSpinner.svelte';
+
+describe('FullPageLoadingSpinner', () => {
+  	it('renders with role="status"', () => {
+      		render(FullPageLoadingSpinner);
+      		const spinner = screen.getByRole('status');
+      		expect(spinner).toBeTruthy();
+    });
+
+         	it('has an aria-label attribute', () => {
+            		render(FullPageLoadingSpinner);
+            		const spinner = screen.getByRole('status');
+            		expect(spinner).toHaveAttribute('aria-label');
+          });
+
+         	it('has aria-live="polite"', () => {
+            		render(FullPageLoadingSpinner);
+            		const spinner = screen.getByRole('status');
+            		expect(spinner).toHaveAttribute('aria-live', 'polite');
+          });
+
+         	it('renders the loading text', () => {
+            		render(FullPageLoadingSpinner);
+            		// The i18n mock returns the key as the value, so 'loading' is the displayed text
+             		const loadingText = screen.getByText('loading');
+            		expect(loadingText).toBeTruthy();
+          });
+});

--- a/src/tests/components/OptionsPill.test.js
+++ b/src/tests/components/OptionsPill.test.js
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import OptionsPill from '../../components/trip-planner/OptionsPill.svelte';
+
+describe('OptionsPill', () => {
+  	it('renders the label text', () => {
+      		render(OptionsPill, { props: { label: 'Walk', icon: '🚶' } });
+      		expect(screen.getByText('🚶')).toBeTruthy();
+      		expect(screen.getByText('Walk')).toBeTruthy();
+    });
+
+         	it('renders with only a label when no icon is provided', () => {
+            		render(OptionsPill, { props: { label: 'No transfers' } });
+            		expect(screen.getByText('No transfers')).toBeTruthy();
+          });
+
+         	it('renders a span element', () => {
+            		const { container } = render(OptionsPill, { props: { label: 'Test', icon: '⭐' } });
+            		const span = container.querySelector('span');
+            		expect(span).toBeTruthy();
+          });
+
+         	it('renders with default empty values when no props are given', () => {
+            		const { container } = render(OptionsPill, {});
+            		const span = container.querySelector('span');
+            		expect(span).toBeTruthy();
+          });
+});

--- a/src/tests/components/TabLink.test.js
+++ b/src/tests/components/TabLink.test.js
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import TabLink from '../../components/tabs/TabLink.svelte';
+
+describe('TabLink', () => {
+  	it('renders a div with the base tab class', () => {
+      		const { container } = render(TabLink, { props: { href: '/home', current: false } });
+      		const div = container.querySelector('.tab-container__item');
+      		expect(div).toBeTruthy();
+    });
+
+         	it('applies the active class when current is true', () => {
+            		const { container } = render(TabLink, { props: { href: '/home', current: true } });
+            		const div = container.querySelector('.tab-container__item');
+            		expect(div).toBeTruthy();
+            		expect(div.classList.contains('tab-container__item--active')).toBe(true);
+          });
+
+         	it('does not apply the active class when current is false', () => {
+            		const { container } = render(TabLink, { props: { href: '/home', current: false } });
+            		const div = container.querySelector('.tab-container__item');
+            		expect(div).toBeTruthy();
+            		expect(div.classList.contains('tab-container__item--active')).toBe(false);
+          });
+
+         	it('renders an anchor element with the correct href', () => {
+            		const { container } = render(TabLink, { props: { href: '/stops/123', current: false } });
+            		const anchor = container.querySelector('a');
+            		expect(anchor).toBeTruthy();
+            		expect(anchor.getAttribute('href')).toBe('/stops/123');
+          });
+});


### PR DESCRIPTION
## Summary

This PR addresses two issues in tandem:

### Issue #406 — Internationalize hardcoded `aria-label` strings

Two components had hardcoded English strings in their `aria-label` attributes, which would not be translated for non-English users:

- **`src/components/trip-planner/TripPlanSearchField.svelte`**: Changed `aria-label="Clear"` to `aria-label={$t('search.clear')}`
- - **`src/components/surveys/SurveyQuestion.svelte`**: Changed `aria-label="Required question"` to `aria-label={$t('survey.required_question')}` and added the missing `import { t } from 'svelte-i18n'`
- - **`src/locales/en.json`**: Added the two new translation keys:
-   - `search.clear` → `"Clear"`
-   - `survey.required_question` → `"Required question"`
### Issue #402 — Add unit tests for small, self-contained components

Added a new `src/tests/components/` directory with unit tests for four components:

- **`FullPageLoadingSpinner.test.js`**: Tests `role="status"`, `aria-label`, and `aria-live="polite"` attributes, plus loading text rendering
- - **`CompassArrow.test.js`**: Tests all 8 compass directions render without the `hidden` class; tests that unknown/missing direction renders with `hidden`
- - **`OptionsPill.test.js`**: Tests icon and label rendering, label-only rendering, and default empty state
- - **`TabLink.test.js`**: Tests base CSS class, active class toggling via `current` prop, and `href` attribute
## Testing

All new tests use `@testing-library/svelte` + Vitest, consistent with the existing test setup in `vitest-setup.js`. The `svelte-i18n` mock returns translation keys as-is, so assertions use the key string (e.g. `'search.clear'`) as the expected value.

-SAM