### PR TITLE
Fix build failure when PUBLIC_OTP_SERVER_URL is not set

### DIFF
--- a/src/lib/otpServerCache.js
+++ b/src/lib/otpServerCache.js
@@ -1,4 +1,4 @@
-import { PUBLIC_OTP_SERVER_URL } from '$env/static/public';
+import { env } from '$env/dynamic/public';
 
 /** @type {'graphql' | 'rest' | null} */
 let otpApiType = null;
@@ -25,7 +25,7 @@ async function detectOtpVersion() {
 	const ac = new AbortController();
 	const timer = setTimeout(() => ac.abort(), DETECT_TIMEOUT);
 	try {
-		const response = await fetch(PUBLIC_OTP_SERVER_URL, { signal: ac.signal });
+		const response = await fetch(env.PUBLIC_OTP_SERVER_URL, { signal: ac.signal });
 
 		if (!response.ok) {
 			throw new Error(`OTP server returned HTTP ${response.status}`);
@@ -59,7 +59,7 @@ async function detectOtpVersion() {
  * @returns {Promise<void>}
  */
 export async function preloadOtpVersion(forceRefresh = false) {
-	if (!PUBLIC_OTP_SERVER_URL) {
+	if (!env.PUBLIC_OTP_SERVER_URL) {
 		return;
 	}
 

--- a/src/tests/lib/otpServerCache.test.js
+++ b/src/tests/lib/otpServerCache.test.js
@@ -2,9 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 let mockOtpServerUrl = 'https://otp.test.example.com';
 
-vi.mock('$env/static/public', () => ({
-	get PUBLIC_OTP_SERVER_URL() {
-		return mockOtpServerUrl;
+vi.mock('$env/dynamic/public', () => ({
+	env: {
+		get PUBLIC_OTP_SERVER_URL() {
+			return mockOtpServerUrl;
+		}
 	}
 }));
 


### PR DESCRIPTION
## Summary
- Switch `otpServerCache.js` from `$env/static/public` to `$env/dynamic/public` so that an unset `PUBLIC_OTP_SERVER_URL` returns `undefined` at runtime instead of causing a build-time error
- Update test mock to match the new import

## Test plan
- [x] All 16 existing `otpServerCache.test.js` tests pass
- [ ] Deploy without `PUBLIC_OTP_SERVER_URL` set and verify build succeeds