### PR TITLE
Fix trip planner timezone: use agency timezone instead of browser/system timezone

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,9 +35,8 @@ PUBLIC_OBA_SERVER_URL="https://api.pugetsound.onebusaway.org/"
 PUBLIC_OTP_SERVER_URL=""
 
 # IANA timezone for the transit region (e.g. "America/Los_Angeles").
-# Recommended when the server runs in a different timezone than the transit agency (e.g. cloud hosting).
-# Falls back to the server's default timezone if not set.
-PUBLIC_OBA_TIMEZONE=""
+# Required so that all dates and times in the UI are expressed in the transit agency's timezone.
+PUBLIC_OBA_TIMEZONE="America/Los_Angeles"
 
 # Distance unit: "metric" or "imperial" (auto-detects from browser if not set)
 PUBLIC_DISTANCE_UNIT=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,4 +119,5 @@ See `.env.example` for full list. Key variables:
 - `PUBLIC_OBA_REGION_CENTER_LAT/LNG` - Region center coordinates
 - `PUBLIC_OBA_MAP_PROVIDER` - "osm" or "google"
 - `PUBLIC_OTP_SERVER_URL` - OpenTripPlanner server (optional, for trip planning)
+- `PUBLIC_OBA_TIMEZONE` - IANA timezone for the transit region (e.g. "America/Los_Angeles"), required
 - `PRIVATE_OBA_GEOCODER_PROVIDER` - Geocoding provider (currently "google" only)

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Use these in Tailwind classes: `bg-primary-500`, `text-primary-700`, `border-pri
 ### Trip Planner
 
 - `PUBLIC_OTP_SERVER_URL` - string: (optional) Your OpenTripPlanner 1.x-compatible trip planner server URL.
+- `PUBLIC_OBA_TIMEZONE` - string: (required) IANA timezone for the transit region (e.g. `"America/Los_Angeles"`). Dates and times in the trip planner are expressed in this timezone so they match the transit agency's schedule, regardless of the user's or server's local timezone.
 - `PUBLIC_DISTANCE_UNIT` - string: (optional) Default distance unit for the trip planner. Use "metric" for kilometers/meters or "imperial" for miles/feet. If not set, auto-detects from the user's browser locale (US browsers get imperial, others get metric). Users can override this in Trip Options.
 
 ## URL Parameters

--- a/env-schema.json
+++ b/env-schema.json
@@ -127,10 +127,10 @@
 		"description": "Base URL of the OpenTripPlanner server for trip planning"
 	},
 	"PUBLIC_OBA_TIMEZONE": {
-		"required": false,
+		"required": true,
 		"type": "string",
-		"allowEmpty": true,
-		"description": "IANA timezone for the transit region (e.g. 'America/Los_Angeles'). Recommended when the server runs in a different timezone than the transit agency. Falls back to the server's default timezone if not set."
+		"allowEmpty": false,
+		"description": "IANA timezone for the transit region (e.g. 'America/Los_Angeles'). Required so that dates and times in the trip planner are expressed in the transit agency's timezone, regardless of the user's or server's local timezone."
 	},
 	"PUBLIC_DISTANCE_UNIT": {
 		"required": true,

--- a/src/components/trip-planner/TripOptionsModal.svelte
+++ b/src/components/trip-planner/TripOptionsModal.svelte
@@ -10,8 +10,11 @@
 		UNIT_IMPERIAL
 	} from '$stores/tripOptionsStore';
 	import { getTodayDateForInput, getCurrentTimeForInput } from '$lib/dateTimeInput';
+	import { env } from '$env/dynamic/public';
 
 	let { onClose, onDone } = $props();
+
+	const regionTz = env.PUBLIC_OBA_TIMEZONE || undefined;
 
 	// Local state for editing (copy from store)
 	let departureType = $state($tripOptions.departureType);
@@ -66,8 +69,8 @@
 		departureType = type;
 		// Set default time/date when switching from 'now'
 		if (type !== 'now' && !departureTime) {
-			departureTime = getCurrentTimeForInput();
-			departureDate = getTodayDateForInput();
+			departureTime = getCurrentTimeForInput(regionTz);
+			departureDate = getTodayDateForInput(regionTz);
 		}
 	}
 </script>
@@ -197,7 +200,7 @@
 						<input
 							type="date"
 							bind:value={departureDate}
-							min={getTodayDateForInput()}
+							min={getTodayDateForInput(regionTz)}
 							class="flex-1 rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
 						/>
 					</div>

--- a/src/components/trip-planner/TripPlan.svelte
+++ b/src/components/trip-planner/TripPlan.svelte
@@ -15,10 +15,13 @@
 		DEFAULT_WALK_DISTANCE_METERS
 	} from '$stores/tripOptionsStore';
 	import { formatDepartureDisplay } from '$lib/dateTimeFormat';
+	import { env } from '$env/dynamic/public';
 	import { createRequestFromTripOptions, buildOTPParams, validateCoordinates } from '$lib/otp';
 	import { swapTripLocations } from '$lib/tripPlanUtils';
 	import { recentTrips } from '$stores/recentTripsStore';
 	import RecentTripsList from './RecentTripsList.svelte';
+
+	const regionTz = env.PUBLIC_OBA_TIMEZONE || undefined;
 
 	let { handleTripPlan, mapProvider, clearTripItineraries } = $props();
 
@@ -377,7 +380,7 @@
 	{#if $tripOptions.departureType !== 'now' || $tripOptions.wheelchair || $tripOptions.optimize === 'fewestTransfers' || $tripOptions.maxWalkDistance !== DEFAULT_WALK_DISTANCE_METERS}
 		<div class="mt-4 flex flex-wrap gap-1.5">
 			{#if $tripOptions.departureType !== 'now'}
-				<OptionsPill icon="🕐" label={formatDepartureDisplay($tripOptions, $t)} />
+				<OptionsPill icon="🕐" label={formatDepartureDisplay($tripOptions, $t, regionTz)} />
 			{/if}
 			{#if $tripOptions.wheelchair}
 				<OptionsPill icon="♿" label={$t('trip-planner.wheelchair')} />

--- a/src/lib/dateTimeFormat.js
+++ b/src/lib/dateTimeFormat.js
@@ -140,13 +140,14 @@ export function formatSecondsFromMidnight(secondsSinceMidnight) {
  * @param {string} [opts.departureTime] - Departure time in 'HH:mm' format
  * @param {string} [opts.departureDate] - Departure date in 'YYYY-MM-DD' format
  * @param {Function} [translator] - Optional translator function for i18n support
+ * @param {string} [timeZone] - IANA timezone (e.g. "America/Los_Angeles") for Today/Tomorrow logic. Defaults to browser's local timezone.
  * @returns {string|null} Formatted departure time string, or null if departureType is 'now'
  *
  * @example
  * formatDepartureDisplay({ departureType: 'departAt', departureTime: '09:00', departureDate: null })  // Returns 'Depart 9:00 AM'
  * formatDepartureDisplay({ departureType: 'arriveBy', departureTime: '17:00', departureDate: '2025-06-15' }, translator)  // Returns 'Arrive 5:00 PM, Today' (assuming today is 2025-06-15)
  */
-export function formatDepartureDisplay(opts, translator = null) {
+export function formatDepartureDisplay(opts, translator = null, timeZone = undefined) {
 	if (opts.departureType === 'now') return null;
 
 	const timeStr = opts.departureTime || '';
@@ -168,7 +169,19 @@ export function formatDepartureDisplay(opts, translator = null) {
 
 		let dateSuffix = '';
 		if (dateStr) {
-			const today = Temporal.Now.plainDateISO();
+			let today;
+			try {
+				today = Temporal.Now.plainDateISO(timeZone);
+			} catch (err) {
+				if (err instanceof RangeError) {
+					console.error(
+						`formatDepartureDisplay: invalid timezone "${timeZone}", falling back to local`
+					);
+					today = Temporal.Now.plainDateISO();
+				} else {
+					throw err;
+				}
+			}
 			const tomorrow = today.add({ days: 1 });
 
 			if (dateStr === today.toJSON()) {

--- a/src/lib/dateTimeInput.js
+++ b/src/lib/dateTimeInput.js
@@ -9,18 +9,40 @@ const fourDigit24HourTimeFormat = new Intl.DateTimeFormat(undefined, {
 /**
  * Get today's date in YYYY-MM-DD format for date input
  *
+ * @param {string} [timeZone] - IANA timezone (e.g. "America/Los_Angeles"). Defaults to browser's local timezone.
  * @returns {string} Today's date in YYYY-MM-DD format
  */
-export function getTodayDateForInput() {
-	return Temporal.Now.plainDateISO().toJSON();
+export function getTodayDateForInput(timeZone) {
+	try {
+		return Temporal.Now.plainDateISO(timeZone).toJSON();
+	} catch (err) {
+		if (err instanceof RangeError) {
+			console.error(`getTodayDateForInput: invalid timezone "${timeZone}", falling back to local`);
+			return Temporal.Now.plainDateISO().toJSON();
+		}
+		throw err;
+	}
 }
 
 /**
  * Get current time in HH:MM format for time input
  *
+ * @param {string} [timeZone] - IANA timezone (e.g. "America/Los_Angeles"). Defaults to browser's local timezone.
  * @returns {string} Current time in HH:MM format
  */
-export function getCurrentTimeForInput() {
-	const now = Temporal.Now.plainTimeISO();
+export function getCurrentTimeForInput(timeZone) {
+	let now;
+	try {
+		now = Temporal.Now.plainTimeISO(timeZone);
+	} catch (err) {
+		if (err instanceof RangeError) {
+			console.error(
+				`getCurrentTimeForInput: invalid timezone "${timeZone}", falling back to local`
+			);
+			now = Temporal.Now.plainTimeISO();
+		} else {
+			throw err;
+		}
+	}
 	return fourDigit24HourTimeFormat.format(plainTimeToDate(now));
 }

--- a/src/routes/api/otp/plan/+server.js
+++ b/src/routes/api/otp/plan/+server.js
@@ -8,10 +8,11 @@ let regionTimeZone;
 
 /**
  * Returns the IANA timezone for this transit region (e.g. "America/Los_Angeles").
- * Falls back to the server's local timezone when PUBLIC_OBA_TIMEZONE is not set.
- * Valid timezones and the "not set" default are cached for the lifetime of the
- * process. Invalid values are NOT cached, so fixing the env var takes effect
- * on the next request without a restart.
+ * PUBLIC_OBA_TIMEZONE is required; falls back to the server's local timezone
+ * only as a safety net if the variable is missing or invalid.
+ * Valid timezones are cached for the lifetime of the process. Invalid values
+ * are NOT cached, so fixing the env var takes effect on the next request
+ * without a restart.
  */
 function getRegionTimeZone() {
 	if (regionTimeZone) return regionTimeZone;
@@ -31,8 +32,11 @@ function getRegionTimeZone() {
 			return getLocalTimeZone();
 		}
 	}
-	regionTimeZone = getLocalTimeZone();
-	return regionTimeZone;
+	console.error(
+		'PUBLIC_OBA_TIMEZONE is not set. This variable is required. Falling back to server timezone.'
+	);
+	// Don't cache — let the operator add the env var without a restart
+	return getLocalTimeZone();
 }
 
 /**

--- a/src/tests/lib/dateTimeFormat.test.js
+++ b/src/tests/lib/dateTimeFormat.test.js
@@ -451,6 +451,40 @@ describe('formatDepartureDisplay', () => {
 		});
 		expect(result).toBe('Depart');
 	});
+
+	it('uses agency timezone for Today/Tomorrow when timeZone is provided', () => {
+		// System time: 2025-06-16T02:00:00Z (UTC date is June 16)
+		// In America/Los_Angeles (PDT, UTC-7): still June 15 at 7 PM
+		vi.setSystemTime(new Date('2025-06-16T02:00:00Z'));
+
+		const result = formatDepartureDisplay(
+			{
+				departureType: 'departAt',
+				departureTime: '19:00',
+				departureDate: '2025-06-15'
+			},
+			null,
+			'America/Los_Angeles'
+		);
+		expect(result).toBe('Depart 7:00 PM, Today');
+	});
+
+	it('shows Tomorrow using agency timezone', () => {
+		// System time: 2025-06-16T02:00:00Z
+		// In America/Los_Angeles (PDT): still June 15 → June 16 is "Tomorrow"
+		vi.setSystemTime(new Date('2025-06-16T02:00:00Z'));
+
+		const result = formatDepartureDisplay(
+			{
+				departureType: 'departAt',
+				departureTime: '09:00',
+				departureDate: '2025-06-16'
+			},
+			null,
+			'America/Los_Angeles'
+		);
+		expect(result).toBe('Depart 9:00 AM, Tomorrow');
+	});
 });
 
 describe('formatLastUpdated', () => {

--- a/src/tests/lib/dateTimeInput.test.js
+++ b/src/tests/lib/dateTimeInput.test.js
@@ -14,6 +14,12 @@ describe('getTodayDateForInput', () => {
 	it("returns today's date in YYYY-MM-DD format", () => {
 		expect(getTodayDateForInput()).toBe('2024-01-16');
 	});
+
+	it('returns agency-local date when timeZone is provided', () => {
+		// 2 AM UTC on Jan 16 = 6 PM PST on Jan 15
+		vi.setSystemTime(new Date('2024-01-16T02:00:00Z'));
+		expect(getTodayDateForInput('America/Los_Angeles')).toBe('2024-01-15');
+	});
 });
 
 describe('getCurrentTimeForInput', () => {
@@ -34,5 +40,11 @@ describe('getCurrentTimeForInput', () => {
 	it('returns current time in HH:MM format in 24-hour format', () => {
 		vi.setSystemTime(new Date('2024-01-16T15:00:00Z'));
 		expect(getCurrentTimeForInput()).toBe('15:00');
+	});
+
+	it('returns agency-local time when timeZone is provided', () => {
+		// 4:52 AM UTC = 8:52 PM PST (previous day, UTC-8 in January)
+		vi.setSystemTime(new Date('2024-01-16T04:52:00Z'));
+		expect(getCurrentTimeForInput('America/Los_Angeles')).toBe('20:52');
 	});
 });


### PR DESCRIPTION
The trip planner captured dates and times using Temporal.Now.plainTimeISO() and Temporal.Now.plainDateISO() without specifying a timezone, causing the temporal-polyfill to fall back to UTC instead of the transit agency's configured timezone. This resulted in incorrect departure times being sent to the OTP API and wrong Today/Tomorrow labels in the UI.

- Add timeZone parameter to getCurrentTimeForInput() and getTodayDateForInput()
- Add timeZone parameter to formatDepartureDisplay() for Today/Tomorrow logic
- Pass PUBLIC_OBA_TIMEZONE from Svelte components to all time/date functions
- Make PUBLIC_OBA_TIMEZONE required in env-schema.json
- Add console.warn on server when PUBLIC_OBA_TIMEZONE is missing
- Update .env.example, README.md, and CLAUDE.md documentation
- Add cross-timezone tests for all modified functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trip planner now respects the transit agency's timezone for all date and time operations, ensuring departure times and date constraints align with agency schedules regardless of user or server location.

* **Documentation**
  * Added environment variable documentation for timezone configuration with examples.

* **Tests**
  * Added test coverage for timezone-aware date and time formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/wayfinder/pull/466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->