### PR TITLE
Add styled error pages for 404 and 5xx responses.

### DIFF
--- a/src/components/errors/ErrorPage.svelte
+++ b/src/components/errors/ErrorPage.svelte
@@ -1,0 +1,45 @@
+<script>
+	import { t } from 'svelte-i18n';
+	import { getCustomErrorDetail, getErrorTranslationKeys } from '$lib/errors.js';
+
+	/**
+	 * @typedef {Object} Props
+	 * @property {number} status
+	 * @property {App.Error | null | undefined} [error]
+	 */
+
+	/** @type {Props} */
+	let { status, error = null } = $props();
+
+	const { titleKey, messageKey } = $derived(getErrorTranslationKeys(status));
+	const customDetail = $derived(getCustomErrorDetail(error, status));
+</script>
+
+<section
+	class="flex h-full min-h-0 flex-col items-center justify-center overflow-y-auto px-4 py-12 text-center sm:px-6"
+	aria-labelledby="error-title"
+>
+	<p
+		class="text-7xl font-bold tabular-nums tracking-tight text-brand-accent dark:text-brand sm:text-8xl"
+		aria-hidden="true"
+	>
+		{status}
+	</p>
+	<p class="sr-only">{$t('errors.status_label', { values: { status } })}</p>
+
+	<h1 id="error-title" class="h1 mt-6 max-w-lg">
+		{$t(titleKey)}
+	</h1>
+
+	<p class="mt-3 max-w-md text-base text-gray-600 dark:text-gray-400">
+		{#if customDetail}
+			{customDetail}
+		{:else}
+			{$t(messageKey)}
+		{/if}
+	</p>
+
+	<a href="/" class="button--primary mt-8 inline-flex min-h-11 items-center justify-center px-6">
+		{$t('errors.go_home')}
+	</a>
+</section>

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -1,0 +1,49 @@
+/** @type {ReadonlySet<string>} */
+const GENERIC_ERROR_MESSAGES = new Set(['Not Found', 'Internal Error']);
+
+/**
+ * Translation keys for common HTTP error statuses.
+ *
+ * @param {number} status
+ * @returns {{ titleKey: string; messageKey: string }}
+ */
+export function getErrorTranslationKeys(status) {
+	if (status === 404) {
+		return {
+			titleKey: 'errors.not_found_title',
+			messageKey: 'errors.not_found_message'
+		};
+	}
+
+	if (status >= 500) {
+		return {
+			titleKey: 'errors.server_error_title',
+			messageKey: 'errors.server_error_message'
+		};
+	}
+
+	return {
+		titleKey: 'errors.generic_title',
+		messageKey: 'errors.generic_message'
+	};
+}
+
+/**
+ * Returns a user-facing detail message when the thrown error carries a custom message.
+ *
+ * @param {App.Error | null | undefined} error
+ * @param {number} status
+ * @returns {string | null}
+ */
+export function getCustomErrorDetail(error, status) {
+	if (!error?.message || status >= 500) {
+		return null;
+	}
+
+	const message = error.message.trim();
+	if (!message || GENERIC_ERROR_MESSAGES.has(message)) {
+		return null;
+	}
+
+	return message;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -194,5 +194,15 @@
 	"context-menu": {
 		"start_here": "Start Here",
 		"end_here": "End Here"
+	},
+	"errors": {
+		"status_label": "Error {status}",
+		"not_found_title": "Page not found",
+		"not_found_message": "The page you're looking for doesn't exist or may have been moved.",
+		"server_error_title": "Something went wrong",
+		"server_error_message": "We're having trouble loading this page. Please try again in a moment.",
+		"generic_title": "Something went wrong",
+		"generic_message": "An unexpected error occurred. Please try again.",
+		"go_home": "Go to map"
 	}
 }

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,16 @@
+<script>
+	import ErrorPage from '$components/errors/ErrorPage.svelte';
+	import { getErrorTranslationKeys } from '$lib/errors.js';
+	import { t } from 'svelte-i18n';
+
+	/** @type {{ error: App.Error; status: number }} */
+	let { error, status } = $props();
+
+	const { titleKey } = $derived(getErrorTranslationKeys(status));
+</script>
+
+<svelte:head>
+	<title>{status} – {$t(titleKey)}</title>
+</svelte:head>
+
+<ErrorPage {status} {error} />

--- a/src/tests/lib/errors.test.js
+++ b/src/tests/lib/errors.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { getCustomErrorDetail, getErrorTranslationKeys } from '$lib/errors.js';
+
+describe('getErrorTranslationKeys', () => {
+	it('returns not found keys for 404', () => {
+		expect(getErrorTranslationKeys(404)).toEqual({
+			titleKey: 'errors.not_found_title',
+			messageKey: 'errors.not_found_message'
+		});
+	});
+
+	it('returns server error keys for 5xx', () => {
+		expect(getErrorTranslationKeys(500)).toEqual({
+			titleKey: 'errors.server_error_title',
+			messageKey: 'errors.server_error_message'
+		});
+	});
+
+	it('returns generic keys for other statuses', () => {
+		expect(getErrorTranslationKeys(403)).toEqual({
+			titleKey: 'errors.generic_title',
+			messageKey: 'errors.generic_message'
+		});
+	});
+});
+
+describe('getCustomErrorDetail', () => {
+	it('returns null for generic SvelteKit messages', () => {
+		expect(getCustomErrorDetail({ message: 'Not Found' }, 404)).toBeNull();
+		expect(getCustomErrorDetail({ message: 'Internal Error' }, 500)).toBeNull();
+	});
+
+	it('returns null for 5xx even with a custom message', () => {
+		expect(getCustomErrorDetail({ message: 'Database unavailable' }, 503)).toBeNull();
+	});
+
+	it('returns trimmed custom messages for non-5xx errors', () => {
+		expect(getCustomErrorDetail({ message: '  Stop not found  ' }, 404)).toBe('Stop not found');
+	});
+});


### PR DESCRIPTION
Replace SvelteKit's plain default error UI with a centered, accessible layout that matches app styling and i18n.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom error pages displaying HTTP status codes with localized, user-friendly messages
  * Enhanced error display with support for custom error details for non-server errors
  * Integrated internationalization for error messaging across multiple languages
  * Error pages include convenient navigation link back to home page

* **Tests**
  * Added comprehensive test coverage for error handling and localization logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/wayfinder/pull/473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->