### PR TITLE
fix: prevent i18n crash for non-English initial locales

### DIFF
--- a/src/lib/__tests__/i18n.locale-init.test.js
+++ b/src/lib/__tests__/i18n.locale-init.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+// This file exercises the REAL svelte-i18n (the global vitest-setup mock is
+// bypassed) to verify how the i18n module sets the initial locale.
+vi.unmock('$lib/i18n');
+vi.mock('$app/environment', () => ({ browser: true }));
+
+// Use the real svelte-i18n implementation, but force the "navigator" locale to a
+// lazy-registered, non-English locale to mimic a Sound Transit visitor whose
+// browser language is, e.g., Spanish.
+vi.mock('svelte-i18n', async () => {
+	const actual = await vi.importActual('svelte-i18n');
+	return { ...actual, getLocaleFromNavigator: vi.fn(() => 'es') };
+});
+
+describe('i18n initial locale with a lazy-loaded locale', () => {
+	it('bootstraps synchronously and applies the preferred lazy locale without a null-locale window', async () => {
+		// No saved preference, so getInitialLocale() falls back to the (mocked)
+		// navigator locale 'es', which must be lazy-loaded.
+		vi.stubGlobal('localStorage', { getItem: () => null, setItem: () => {} });
+
+		// `_` is svelte-i18n's alias for the $format store.
+		const { locale, _ } = await import('svelte-i18n');
+		await import('../i18n'); // executes init() as an import side effect
+
+		// Crash guard: setting a lazy initial locale directly leaves $locale null
+		// until the dynamic import resolves, so the first format call throws
+		// "Cannot format a message without first setting the initial locale" and
+		// hydration dies. Bootstrapping on 'en' keeps $locale set synchronously.
+		expect(get(locale)).not.toBeNull();
+		expect(() => get(_)('stop')).not.toThrow();
+
+		// Second half of the fix: the preferred locale is actually applied once its
+		// dictionary loads. Guards against the client-side switch block being dropped
+		// (which would silently leave non-English visitors stuck on English).
+		await vi.waitFor(() => expect(get(locale)).toBe('es'));
+	});
+});

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -14,7 +14,7 @@
  *   Somali (so), Tigrinya (ti), Tagalog (tl), Ukrainian (uk),
  *   Vietnamese (vi), Chinese Simplified (zh-CN), Chinese Traditional (zh-TW)
  */
-import { init, addMessages, register, getLocaleFromNavigator } from 'svelte-i18n';
+import { init, addMessages, register, getLocaleFromNavigator, locale } from 'svelte-i18n';
 import { browser } from '$app/environment';
 
 // Language metadata - single source of truth
@@ -48,7 +48,10 @@ export const languages = [
 
 // English loaded synchronously as the fallback locale
 import english from '../locales/en.json';
-addMessages('en', english);
+
+// Named because init() below must bootstrap on this synchronously-loaded locale.
+const FALLBACK_LOCALE = 'en';
+addMessages(FALLBACK_LOCALE, english);
 
 // Other locales registered with lazy loaders
 register('am', () => import('../locales/am.json').then((m) => m.default));
@@ -94,10 +97,33 @@ export function getInitialLocale() {
 	return getLocaleFromNavigator();
 }
 
+// Initialize synchronously with the fallback locale, the only dictionary loaded
+// up front (via addMessages above). Every other locale is lazy-registered, and
+// svelte-i18n defers setting $locale until a lazy dictionary's dynamic import
+// resolves — leaving $locale null in the meantime. Any $t()/$format() call
+// during that window throws "Cannot format a message without first setting the
+// initial locale", crashing hydration for visitors whose initial locale is not
+// English. Bootstrapping on the fallback guarantees $locale is set before
+// anything renders.
 init({
-	fallbackLocale: 'en',
-	initialLocale: getInitialLocale()
+	fallbackLocale: FALLBACK_LOCALE,
+	initialLocale: FALLBACK_LOCALE
 });
+
+// Client-only: switch to the visitor's preferred locale. locale.set() leaves the
+// store at its current value ('en', set synchronously by init above) until the
+// lazy dictionary resolves, so there's no null-locale window.
+if (browser) {
+	const preferredLocale = getInitialLocale();
+	if (preferredLocale && preferredLocale !== FALLBACK_LOCALE) {
+		// locale.set() returns the dictionary-load promise; on failure svelte-i18n
+		// keeps $locale on the fallback, so the app stays usable in English. Catch
+		// so the failure is logged instead of becoming an unhandled rejection.
+		locale.set(preferredLocale).catch((e) => {
+			console.warn(`Unable to load locale "${preferredLocale}":`, e?.message);
+		});
+	}
+}
 
 /**
  * Determines if a given language uses right-to-left (RTL) text direction.


### PR DESCRIPTION
## Summary

- Fixes a production blank-page crash: visitors whose browser/`localStorage` locale was **non-English** got `Uncaught (in promise) Error: [svelte-i18n] Cannot format a message without first setting the initial locale.` and a blank page (reported on `wayfinder.soundtransit.onebusawaycloud.com`).
- **Root cause:** `init({ initialLocale: getInitialLocale() })` set a locale that is lazy-`register`ed (everything except `en`, which is the only dictionary loaded synchronously via `addMessages`). For a lazy locale, svelte-i18n's `$locale.set()` defers actually setting `$locale` until the locale's dynamic `import()` resolves — leaving `$locale` null in the meantime. The first `$t()`/`$format()` any component evaluated during that window threw and killed client hydration. English-browser developers never hit it, so it only surfaced in production.
- **Fix:** bootstrap `init()` synchronously on the `en` fallback, then on the client switch to the visitor's preferred locale via `locale.set()`. svelte-i18n keeps the current (`en`) locale during the async dictionary load, so formatting never sees null; the UI renders in English first and re-renders once translations arrive. A `.catch` on `locale.set()` logs a dictionary load failure instead of leaving an unhandled rejection.

This supersedes the earlier per-component `$isLoading ? '' : $t(...)` band-aid (commit 861f8b5), which only guarded a few stop-page components and never fixed the root cause, so the homepage stayed broken.

## Test plan

- [x] New regression test `src/lib/__tests__/i18n.locale-init.test.js` (uses the real svelte-i18n): fails on the old code, passes on the fix. Verified it guards **both** halves — the no-crash bootstrap (fails if reverted to `initialLocale: getInitialLocale()`) and the locale actually being applied (fails with `expected 'en' to be 'es'` if the client switch block is removed).
- [x] Full suite: 1260/1260 pass; `prettier --check` clean.
- [x] Production build (`npm run build`) succeeds.
- [x] End-to-end: ran the real `build/index.js` server, loaded `/` with `localStorage.locale="es"` — page renders fully in Spanish (`html lang="es"`, "Paradas y estaciones", "Planificar un viaje") with **no** i18n error, instead of the previous blank page.

## Review notes (non-blocking)

- **Unvalidated navigator locale (pre-existing).** `getInitialLocale()` returns `getLocaleFromNavigator()` without validating it against the supported `languages` list, so an unsupported browser language (e.g. `de`) results in `locale.set('de')` — a dictionary-less locale that svelte-i18n then falls back to English per-key (with a `console.warn` per missing key). This is unchanged from before this PR, and an existing test (`i18n.test.js` → "falls back to navigator when localStorage.getItem throws" expects `'de'`) documents the current contract. Whitelisting the navigator value (with base-subtag matching) would be cleaner but changes that contract and the test — flagging for a separate decision rather than expanding scope here.
- **Test coverage of the `en`/`en-US` skip path.** The `preferredLocale !== 'en'` guard (which avoids a redundant `locale.set` for English visitors) isn't directly unit-tested; doing so cleanly needs `vi.resetModules` gymnastics due to module-load caching. Left as a possible follow-up.