### PR TITLE
test: map i18n keys to translated strings in TripPlanSearchField

### DIFF
--- a/src/components/trip-planner/__tests__/TripPlanSearchField.test.js
+++ b/src/components/trip-planner/__tests__/TripPlanSearchField.test.js
@@ -12,7 +12,8 @@ vi.mock('@fortawesome/svelte-fontawesome', () => ({
 vi.mock('svelte-i18n', () => {
 	const translations = {
 		'trip-planner.search_for_a_place': 'Search for a place',
-		'trip-planner.loading': 'Loading'
+		'trip-planner.loading': 'Loading',
+		'search.clear': 'Clear'
 	};
 
 	return {
@@ -70,14 +71,14 @@ describe('TripPlanSearchField', () => {
 			const props = { ...defaultProps, place: 'Capitol Hill' };
 			render(TripPlanSearchField, { props });
 
-			const clearButton = screen.getByLabelText('search.clear');
+			const clearButton = screen.getByLabelText('Clear');
 			expect(clearButton).toBeInTheDocument();
 		});
 
 		it('hides clear button when place is empty', () => {
 			render(TripPlanSearchField, { props: defaultProps });
 
-			const clearButton = screen.queryByLabelText('search.clear');
+			const clearButton = screen.queryByLabelText('Clear');
 			expect(clearButton).not.toBeInTheDocument();
 		});
 
@@ -128,7 +129,7 @@ describe('TripPlanSearchField', () => {
 			const props = { ...defaultProps, place: 'Capitol Hill' };
 			render(TripPlanSearchField, { props });
 
-			const clearButton = screen.getByLabelText('search.clear');
+			const clearButton = screen.getByLabelText('Clear');
 			await user.click(clearButton);
 
 			expect(mockOnClear).toHaveBeenCalledOnce();
@@ -201,8 +202,8 @@ describe('TripPlanSearchField', () => {
 			const props = { ...defaultProps, place: 'Capitol Hill' };
 			render(TripPlanSearchField, { props });
 
-			const clearButton = screen.getByLabelText('search.clear');
-			expect(clearButton).toHaveAttribute('aria-label', 'search.clear');
+			const clearButton = screen.getByLabelText('Clear');
+			expect(clearButton).toHaveAttribute('aria-label', 'Clear');
 			expect(clearButton).toHaveAttribute('type', 'button');
 		});
 


### PR DESCRIPTION
### Description
Closes #472 

This PR resolves the fit-and-finish unit testing issue by mapping the `search.clear` internationalization key in the mock translations and updating all corresponding assertions in the component test to check against the user-facing translated string (`'Clear'`) instead of the raw i18n key (`'search.clear'`). 

This keeps our tests representative of what a screen reader user actually hears in the DOM.

### Technical Changes
- Added `'search.clear': 'Clear'` to the `translations` object inside the `svelte-i18n` mock in `TripPlanSearchField.test.js`.
- Updated search clear button assertions on lines 73, 80, 131, 204, and 205 from `'search.clear'` to `'Clear'`.

### Verification Results
I ran the tests and the linter locally:

- **Component Tests**: All 24 unit tests pass successfully.
  ```bash
  npx vitest run src/components/trip-planner/__tests__/TripPlanSearchField.test.js

### Output

RUN  v2.1.8 V:/Desktop//wayfinder

✓ src/components/trip-planner/__tests__/TripPlanSearchField.test.js (24 tests) 1017ms

Test Files  1 passed (1)
Tests  24 passed (24)
Duration  10.49s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced internationalization and accessibility support for the trip planner search field's clear button with proper labeling and ARIA support for screen readers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/wayfinder/pull/482?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->