### PR TITLE
fix: add alt for vehicle markers in osm for a11y

### DIFF
--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -278,7 +278,7 @@ export default class OpenStreetMapProvider {
 
 		const vehicleIconSvg = createVehicleIconSvg(vehicle?.orientation, color, routeType);
 		const customIcon = this.L.divIcon({
-			html: `<img src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(vehicleIconSvg)}" />`,
+			html: `<img src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(vehicleIconSvg)}" alt="" />`,
 			iconSize: [iconWidth, iconHeight],
 			iconAnchor: [iconWidth / 2, iconHeight / 2],
 			className: '',
@@ -335,7 +335,7 @@ export default class OpenStreetMapProvider {
 
 		const updatedIconSvg = createVehicleIconSvg(vehicleStatus.orientation, color, routeType);
 		const updatedIcon = this.L.divIcon({
-			html: `<img src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(updatedIconSvg)}" />`,
+			html: `<img src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(updatedIconSvg)}" alt="" />`,
 			iconSize: [iconWidth, iconHeight],
 			iconAnchor: [iconWidth / 2, iconHeight / 2],
 			className: '',


### PR DESCRIPTION
Fixed #483 

Add alt="" to mark the image as decorative (since the popup on click already conveys vehicle info)

SS:
<img width="837" height="513" alt="Image" src="https://github.com/user-attachments/assets/9c0347a6-bba6-4908-9a19-c716197d2fb0" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated vehicle marker rendering to include proper accessibility attributes for improved HTML compliance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/wayfinder/pull/484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->