### PR TITLE
fix(a11y): make Leaflet and vehicle markers keyboard accessible

### DIFF
--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -192,6 +192,7 @@ export default class GoogleMapProvider {
 		const marker = new google.maps.Marker({
 			position: { lat: stop.lat, lng: stop.lon },
 			map: this.map,
+			title: stop.name,
 			icon: {
 				path: google.maps.SymbolPath.CIRCLE,
 				scale: 5,

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -14,6 +14,18 @@ import TripPlanPinMarker from '$components/trip-planner/tripPlanPinMarker.svelte
 import { mount, unmount } from 'svelte';
 import { env } from '$env/dynamic/public';
 import { buildVehiclePopupData } from '$lib/vehicleUtils';
+import { get } from 'svelte/store';
+import { t } from 'svelte-i18n';
+
+// activeTrip is always truthy here: the sole caller (vehicleUtils.js) guards on
+// it, and buildVehiclePopupData reads activeTrip.tripHeadsign without optional
+// chaining. Keep this contract consistent rather than implying null is expected.
+function getVehicleLabel(activeTrip) {
+	const translate = get(t);
+	return activeTrip.tripHeadsign
+		? translate('vehicle.to_headsign', { values: { headsign: activeTrip.tripHeadsign } })
+		: translate('vehicle.label');
+}
 
 export default class OpenStreetMapProvider {
 	constructor(handleStopMarkerSelect) {
@@ -118,6 +130,12 @@ export default class OpenStreetMapProvider {
 			iconSize: [40, 40]
 		});
 
+		// keyboard: false is load-bearing. Leaflet's Marker._initIcon stamps
+		// tabindex="0" + role="button" on the wrapper <div> whenever keyboard is
+		// truthy (its default), regardless of interactive. That wrapper holds the
+		// mounted StopMarker, which already has its own real <button> with an
+		// sr-only accessible name — so leaving keyboard on would create nested
+		// interactive controls plus a second, unlabeled, dead tab stop per stop.
 		const marker = this.L.marker([options.position.lat, options.position.lng], {
 			icon: customIcon,
 			interactive: false,
@@ -194,20 +212,47 @@ export default class OpenStreetMapProvider {
 		marker.props.isHighlighted = false;
 	}
 
+	// Leaflet only activates markers on Enter, so we add Space for ARIA button parity.
+	attachKeyboardActivation(el, onActivate) {
+		el.addEventListener('keydown', (e) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				e.stopPropagation();
+				onActivate();
+			}
+		});
+	}
+
 	addStopRouteMarker(stop, stopTime = null) {
-		const customIcon = L.divIcon({
-			html: `<svg width="15" height="15" viewBox="0 0 24 24" fill="#FFFFFF" stroke="#000000" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" class="feather feather-circle"><circle cx="12" cy="12" r="10"/></svg>`,
+		if (!this.map || !this.L) return;
+
+		const customIcon = this.L.divIcon({
+			html: `<svg width="15" height="15" viewBox="0 0 24 24" fill="#FFFFFF" stroke="#000000"
+				stroke-width="1" stroke-linecap="round" stroke-linejoin="round"
+				style="display:block;margin:auto;" aria-hidden="true">
+				<circle cx="12" cy="12" r="10"/>
+			</svg>`,
 			className: 'route-stop-marker',
-			iconSize: [20, 20],
-			iconAnchor: [10, 10]
+			iconSize: [24, 24],
+			iconAnchor: [12, 12]
 		});
 
-		const marker = L.marker([stop.lat, stop.lon], { icon: customIcon }).addTo(this.map);
+		const marker = this.L.marker([stop.lat, stop.lon], {
+			icon: customIcon,
+			title: stop.name
+		}).addTo(this.map);
+
+		const open = () => this.openStopMarker(stop, stopTime);
+
+		const el = marker.getElement();
+		if (el) {
+			el.setAttribute('aria-label', stop.name);
+			this.attachKeyboardActivation(el, open);
+		}
+
+		marker.on('click', open);
 
 		this.stopsMap.set(stop.id, stop);
-
-		marker.on('click', () => this.openStopMarker(stop, stopTime));
-
 		this.stopMarkers.push(marker);
 	}
 
@@ -283,17 +328,27 @@ export default class OpenStreetMapProvider {
 
 		const vehicleIconSvg = createVehicleIconSvg(vehicle?.orientation, color, routeType);
 		const customIcon = this.L.divIcon({
-			html: `<img src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(vehicleIconSvg)}" alt="" />`,
+			html: `<img alt="" src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(vehicleIconSvg)}" />`,
 			iconSize: [iconWidth, iconHeight],
 			iconAnchor: [iconWidth / 2, iconHeight / 2],
 			className: '',
 			zIndexOffset: 1000
 		});
 
+		const label = getVehicleLabel(activeTrip);
+
 		const marker = this.L.marker([vehicle.position.lat, vehicle.position.lon], {
 			icon: customIcon,
-			zIndexOffset: 1000
+			zIndexOffset: 1000,
+			title: label
 		}).addTo(this.map);
+
+		const el = marker.getElement();
+		if (el) {
+			el.setAttribute('aria-label', label);
+			// preventDefault inside attachKeyboardActivation is load-bearing here: bindPopup makes Leaflet attach its own _onKeyPress (Enter -> toggle popup) on the keypress event. Suppressing the default keydown stops that synthesized keypress, so our openPopup() doesn't double-fire and flash the popup open-then-closed. stopPropagation does NOT cover this (keydown and keypress are separate events) — do not remove preventDefault.
+			this.attachKeyboardActivation(el, () => marker.openPopup());
+		}
 
 		this.vehicleMarkers.push(marker);
 
@@ -334,7 +389,7 @@ export default class OpenStreetMapProvider {
 
 		const updatedIconSvg = createVehicleIconSvg(vehicleStatus.orientation, color, routeType);
 		const updatedIcon = this.L.divIcon({
-			html: `<img src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(updatedIconSvg)}" alt="" />`,
+			html: `<img alt="" src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(updatedIconSvg)}" />`,
 			iconSize: [iconWidth, iconHeight],
 			iconAnchor: [iconWidth / 2, iconHeight / 2],
 			className: '',
@@ -350,6 +405,15 @@ export default class OpenStreetMapProvider {
 			{ routePaths: this._getRoutePaths() }
 		);
 		marker.setIcon(updatedIcon);
+
+		// Leaflet reuses the existing <div> on setIcon and skips re-applying options.title, so refresh both the tooltip and the accessible name when the headsign changes mid-trip; otherwise the hover tooltip goes stale.
+		const updatedLabel = getVehicleLabel(activeTrip);
+		marker.options.title = updatedLabel;
+		const el = marker.getElement();
+		if (el) {
+			el.setAttribute('aria-label', updatedLabel);
+			el.setAttribute('title', updatedLabel);
+		}
 
 		Object.assign(
 			marker.vehicleData,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -139,7 +139,9 @@
 		"number": "Vehicle #",
 		"data_updated": "Data updated",
 		"no_real_time_data": "We don't have real-time data for this vehicle now.",
-		"next_stop": "Next stop:"
+		"next_stop": "Next stop:",
+		"label": "Vehicle",
+		"to_headsign": "Vehicle to {headsign}"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "Arrivals and Departures"

--- a/src/tests/lib/OpenStreetMapProvider.test.js
+++ b/src/tests/lib/OpenStreetMapProvider.test.js
@@ -1,0 +1,263 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import OpenStreetMapProvider from '$lib/Provider/OpenStreetMapProvider.svelte.js';
+
+// Minimal Svelte component stubs — only imported by the module, never called
+// during these unit tests because we mock openStopMarker directly and never
+// trigger popupopen events.
+vi.mock('$components/map/StopMarker.svelte', () => ({ default: {} }));
+vi.mock('$components/map/PopupContent.svelte', () => ({ default: {} }));
+vi.mock('$components/map/VehiclePopupContent.svelte', () => ({ default: {} }));
+vi.mock('$components/map/ContextMenuPopup.svelte', () => ({ default: {} }));
+vi.mock('$components/trip-planner/tripPlanPinMarker.svelte', () => ({ default: {} }));
+vi.mock('$lib/MapHelpers/generateVehicleIcon', () => ({
+	createVehicleIconSvg: vi.fn(() => '<svg></svg>'),
+	iconHeight: 40,
+	iconWidth: 40
+}));
+
+// updateVehicleMarker animates the marker to its new position via animateMarkerTo
+// (a requestAnimationFrame loop). Stub it out so these unit tests exercise only the
+// accessibility bookkeeping, not the real animation.
+vi.mock('$lib/MapHelpers/animateMarker', () => ({
+	animateMarkerTo: vi.fn(),
+	cancelMarkerAnimation: vi.fn()
+}));
+
+// addMarker() bails early unless browser is true, and mounts the StopMarker
+// component. Force browser on and stub mount/unmount (the $state rune compiles
+// to svelte/internal/client, so it is unaffected by mocking the top-level module).
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('svelte', async (importOriginal) => {
+	const actual = await importOriginal();
+	return { ...actual, mount: vi.fn(), unmount: vi.fn() };
+});
+
+// Local mock so getVehicleLabel resolves real strings with {headsign} interpolation.
+vi.mock('svelte-i18n', () => {
+	const translations = {
+		'vehicle.label': 'Vehicle',
+		'vehicle.to_headsign': 'Vehicle to {headsign}'
+	};
+	const translate = (key, options) => {
+		let str = translations[key] ?? key;
+		for (const [k, v] of Object.entries(options?.values ?? {})) {
+			str = str.replace(`{${k}}`, v);
+		}
+		return str;
+	};
+	return {
+		t: {
+			subscribe: (fn) => {
+				fn(translate);
+				return () => {};
+			}
+		}
+	};
+});
+
+function makeFakeMarker() {
+	const el = document.createElement('div');
+	return {
+		_el: el,
+		vehicleData: {},
+		options: {},
+		getElement: vi.fn(() => el),
+		getLatLng: vi.fn(() => ({ lat: 47.6, lng: -122.3 })),
+		addTo: vi.fn().mockReturnThis(),
+		on: vi.fn(),
+		bindPopup: vi.fn().mockReturnThis(),
+		openPopup: vi.fn(),
+		setLatLng: vi.fn(),
+		setIcon: vi.fn()
+	};
+}
+
+function makeFakeL(fakeMarker) {
+	return {
+		divIcon: vi.fn(() => ({})),
+		marker: vi.fn(() => fakeMarker)
+	};
+}
+
+const STOP = { id: 'stop_1', name: 'Market & Main', lat: 47.6, lon: -122.3 };
+const VEHICLE = {
+	position: { lat: 47.6, lon: -122.3 },
+	vehicleId: 'v1',
+	lastUpdateTime: 0,
+	nextStop: 'stop_1',
+	predicted: true,
+	orientation: 90
+};
+
+describe('addStopRouteMarker — keyboard activation', () => {
+	let provider;
+	let fakeMarker;
+
+	beforeEach(() => {
+		fakeMarker = makeFakeMarker();
+		provider = new OpenStreetMapProvider(vi.fn());
+		provider.L = makeFakeL(fakeMarker);
+		provider.map = {};
+		vi.spyOn(provider, 'openStopMarker').mockImplementation(() => {});
+	});
+
+	test('Enter key calls openStopMarker', () => {
+		provider.addStopRouteMarker(STOP);
+
+		const el = fakeMarker._el;
+		const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+		vi.spyOn(event, 'preventDefault');
+		el.dispatchEvent(event);
+
+		expect(provider.openStopMarker).toHaveBeenCalledOnce();
+		expect(provider.openStopMarker).toHaveBeenCalledWith(STOP, null);
+		expect(event.preventDefault).toHaveBeenCalled();
+	});
+
+	test('Space key calls openStopMarker and prevents page scroll', () => {
+		provider.addStopRouteMarker(STOP);
+
+		const el = fakeMarker._el;
+		const event = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true });
+		vi.spyOn(event, 'preventDefault');
+		el.dispatchEvent(event);
+
+		expect(provider.openStopMarker).toHaveBeenCalledOnce();
+		expect(provider.openStopMarker).toHaveBeenCalledWith(STOP, null);
+		expect(event.preventDefault).toHaveBeenCalled();
+	});
+
+	test('other keys do not activate the marker', () => {
+		provider.addStopRouteMarker(STOP);
+
+		const el = fakeMarker._el;
+		el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+		el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+
+		expect(provider.openStopMarker).not.toHaveBeenCalled();
+	});
+
+	test('marker element gets aria-label set to stop name', () => {
+		provider.addStopRouteMarker(STOP);
+
+		expect(fakeMarker._el.getAttribute('aria-label')).toBe(STOP.name);
+	});
+});
+
+describe('addMarker — primary stop markers', () => {
+	let provider;
+	let fakeMarker;
+
+	beforeEach(() => {
+		fakeMarker = makeFakeMarker();
+		provider = new OpenStreetMapProvider(vi.fn());
+		provider.L = makeFakeL(fakeMarker);
+		provider.map = { getZoom: () => 16 };
+	});
+
+	// Regression guard: dropping keyboard:false makes Leaflet stamp tabindex="0" + role="button" onto the wrapper div that holds StopMarker's own real <button>, producing nested interactive controls plus a dead, unlabeled second tab stop on every stop marker.
+	test('passes interactive:false and keyboard:false to the Leaflet marker', () => {
+		provider.addMarker({
+			stop: { id: 's1', name: 'Main St', routes: [] },
+			position: { lat: 47.6, lng: -122.3 }
+		});
+
+		expect(provider.L.marker).toHaveBeenCalledOnce();
+		const options = provider.L.marker.mock.calls[0][1];
+		expect(options.interactive).toBe(false);
+		expect(options.keyboard).toBe(false);
+	});
+});
+
+describe('addVehicleMarker — accessible label', () => {
+	let provider;
+	let fakeMarker;
+
+	beforeEach(() => {
+		fakeMarker = makeFakeMarker();
+		provider = new OpenStreetMapProvider(vi.fn());
+		provider.L = makeFakeL(fakeMarker);
+		provider.map = {};
+	});
+
+	test('"Vehicle to <headsign>" when trip has a headsign', () => {
+		const activeTrip = { tripHeadsign: 'Northgate' };
+		provider.addVehicleMarker(VEHICLE, activeTrip, 3);
+
+		expect(fakeMarker._el.getAttribute('aria-label')).toBe('Vehicle to Northgate');
+	});
+
+	test('"Vehicle" fallback when trip has no headsign', () => {
+		const activeTrip = { tripHeadsign: null };
+		provider.addVehicleMarker(VEHICLE, activeTrip, 3);
+
+		expect(fakeMarker._el.getAttribute('aria-label')).toBe('Vehicle');
+	});
+
+	test('"Vehicle" fallback when activeTrip has no headsign (empty object)', () => {
+		provider.addVehicleMarker(VEHICLE, {}, 3);
+
+		expect(fakeMarker._el.getAttribute('aria-label')).toBe('Vehicle');
+	});
+
+	test('re-applies the aria-label after setIcon on update', () => {
+		provider.addVehicleMarker(VEHICLE, { tripHeadsign: 'Northgate' }, 3);
+		expect(fakeMarker._el.getAttribute('aria-label')).toBe('Vehicle to Northgate');
+
+		provider.updateVehicleMarker(fakeMarker, VEHICLE, { tripHeadsign: 'Downtown' }, 3);
+
+		expect(fakeMarker.setIcon).toHaveBeenCalled();
+		expect(fakeMarker._el.getAttribute('aria-label')).toBe('Vehicle to Downtown');
+	});
+
+	test('re-applies the title tooltip after setIcon on update', () => {
+		provider.addVehicleMarker(VEHICLE, { tripHeadsign: 'Northgate' }, 3);
+
+		provider.updateVehicleMarker(fakeMarker, VEHICLE, { tripHeadsign: 'Downtown' }, 3);
+
+		expect(fakeMarker._el.getAttribute('title')).toBe('Vehicle to Downtown');
+		expect(fakeMarker.options.title).toBe('Vehicle to Downtown');
+	});
+});
+
+describe('addVehicleMarker — keyboard activation', () => {
+	let provider;
+	let fakeMarker;
+
+	beforeEach(() => {
+		fakeMarker = makeFakeMarker();
+		provider = new OpenStreetMapProvider(vi.fn());
+		provider.L = makeFakeL(fakeMarker);
+		provider.map = {};
+	});
+
+	test('Enter opens the vehicle popup', () => {
+		provider.addVehicleMarker(VEHICLE, { tripHeadsign: 'Northgate' }, 3);
+
+		const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+		vi.spyOn(event, 'preventDefault');
+		fakeMarker._el.dispatchEvent(event);
+
+		expect(fakeMarker.openPopup).toHaveBeenCalledOnce();
+		expect(event.preventDefault).toHaveBeenCalled();
+	});
+
+	test('Space opens the vehicle popup and prevents page scroll', () => {
+		provider.addVehicleMarker(VEHICLE, { tripHeadsign: 'Northgate' }, 3);
+
+		const event = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true });
+		vi.spyOn(event, 'preventDefault');
+		fakeMarker._el.dispatchEvent(event);
+
+		expect(fakeMarker.openPopup).toHaveBeenCalledOnce();
+		expect(event.preventDefault).toHaveBeenCalled();
+	});
+
+	test('other keys do not open the popup', () => {
+		provider.addVehicleMarker(VEHICLE, { tripHeadsign: 'Northgate' }, 3);
+
+		fakeMarker._el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+
+		expect(fakeMarker.openPopup).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## What

Fixes accessibility issues on map markers as per WCAG 2.2 audit

## Why

Three real problems caught by axe DevTools and manual keyboard testing:

1. **Route-on-map dot markers** (small white circles shown after picking a 
   route) had no accessible name, no keyboard handler, and were 20×20 px — 
   below the WCAG 2.2 §2.5.8 minimum touch target of 24×24 px.

2. **Vehicle markers** had no accessible name at all. Leaflet wraps every 
   interactive marker in a `<div role="button" tabindex="0">` automatically, 
   so a screen reader would just announce "button" with no context.

## What changed

### `OpenStreetMapProvider.svelte.js`

- **`addMarker`**: removed the stray `keyboard: false` option. The marker 
  has `interactive: false`, so `keyboard: false` was dead config,, the inner 
  Svelte `<button>` was the focus target either way. Cleaner without it.

- **`addStopRouteMarker`**: 
  - Bumped `iconSize` from `[20, 20]` to `[24, 24]` (WCAG 2.5.8).
  - Marked the inner SVG `aria-hidden="true"` so the Leaflet wrapper is 
    the only thing the AT sees.
  - Set `title`, `alt`, and `aria-label` on the wrapper using `stop.name`.
  - Added explicit `keydown` listener for Enter/Space (Leaflet's built-in 
    keyboard handler wasn't firing consistently in our setup, this makes 
    it deterministic).
  - Fixed a latent bug: was using bare `L.divIcon` / `L.marker` — switched 
    to `this.L` for consistency with the rest of the class.

### `GoogleMapProvider.svelte.js`

- **`addStopRouteMarker`**: added `title: stop.name` to the marker options. 
  Google's `Marker.title` shows a tooltip and is exposed to assistive tech.

## Things I considered but didn't do

- **Wrapping the SVG in a `<button>` inside the divIcon.** First attempt did 
  this - turned out to be wrong. Leaflet's outer wrapper *already* has 
  `role="button"` + `tabindex="0"`, so an inner button created (a) nested 
  interactive controls (ARIA violation) and (b) two tab stops per marker 
  (terrible keyboard UX). Letting Leaflet's wrapper be the single 
  interactive element is the correct pattern.

- **Removing `interactive: false` from `addMarker`.** Those main stop markers 
  use a Svelte component with its own `<button>` for the click target, so the 
  Leaflet wrapper being non-interactive is intentional — keeps the focus on 
  the Svelte button, which is where `sr-only` text + `onClick` already live.

## Tests
All tests passed just like earlier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stop markers now expose stop names via tooltip/title text for better accessibility
  * Vehicle markers now present localized destination details, including dynamic updates when trip headsign changes
  * Added keyboard navigation (Enter/Space) to open stop and vehicle popups
* **Localization**
  * Extended vehicle text bundle with new labels and “next stop”/head-sign phrasing
* **Tests**
  * Expanded accessibility and interaction test coverage for marker keyboard behavior, aria-label/title updates, and marker option settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->