### PR TITLE
fix(a11y): avoid rendering empty h2 in trip details pane

### DIFF
--- a/src/components/oba/TripDetailsPane.svelte
+++ b/src/components/oba/TripDetailsPane.svelte
@@ -106,7 +106,8 @@
 	{:else if tripDetails}
 		{#if routeInfo}
 			<h2 class="h2">
-				{$_('trip_details.route')} {routeInfo.shortName}
+				{$_('trip_details.route')}
+				{routeInfo.shortName}
 			</h2>
 		{/if}
 		{#if tripDetails.schedule?.stopTimes.length > 0}

--- a/src/components/oba/TripDetailsPane.svelte
+++ b/src/components/oba/TripDetailsPane.svelte
@@ -104,11 +104,11 @@
 	{#if error}
 		<p>{error}</p>
 	{:else if tripDetails}
-		<h2 class="h2">
-			{#if routeInfo}
-				{$_('trip_details.route')} {routeInfo.shortName} -
-			{/if}
-		</h2>
+		{#if routeInfo}
+			<h2 class="h2">
+				{$_('trip_details.route')} {routeInfo.shortName}
+			</h2>
+		{/if}
 		{#if tripDetails.schedule?.stopTimes.length > 0}
 			<div class="relative">
 				<div class="absolute bottom-0 left-3.5 top-0 w-[1px] bg-neutral-400"></div>


### PR DESCRIPTION
## What
Fixes accessibility issue- an empty `<h2>` 
was being rendered in `TripDetailsPane.svelte` whenever route info wasn't 
available yet.

## Why
The `<h2>` tag was unconditional but its content sat inside `{#if routeInfo}`, 
so before the API returned (or when it didn't include route references) the 
DOM contained `<h2 class="h2"><!----></h2>`. Axe flagged this as a 
"Headings should not be empty" violation, and screen reader users lose 
their place when navigating by headings.

## Changes
- Moved the `{#if routeInfo}` block to wrap the entire `<h2>`, so either 
  the heading renders with content or it doesn't render at all.
- Removed a trailing ` -` from the heading text. It was a dangling dash with 
  nothing after it, leftover from older code.

## Verify
1. Open a stop, click an arrival to expand the trip details pane.
2. While loading — no empty heading in the DOM.
3. After loading, the heading reads "Route X" (no trailing dash).
4. Re-run axe DevTools,, the violation on `.trip-details-pane > h2` is gone.