### PR TITLE
fix: refactored direction icons in route schedule

### DIFF
--- a/src/components/controls/CompassArrow.svelte
+++ b/src/components/controls/CompassArrow.svelte
@@ -1,10 +1,9 @@
 <!--
-
     This Svelte component renders a FontAwesome arrow icon that rotates based on the provided `stopDirection` prop.
 
     Props:
-    - `stopDirection` (string): The direction in which the arrow should point. 
-      Possible values are 'N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'. 
+    - `stopDirection` (string): The direction in which the arrow should point.
+      Possible values are 'N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'.
       If the value is not one of these, the arrow will be hidden.
 -->
 
@@ -20,28 +19,25 @@
 	/** @type {Props} */
 	let { stopDirection = '' } = $props();
 
-	function rotationAngleClass() {
-		switch (stopDirection) {
-			case 'N':
-				return '-rotate-90';
-			case 'NE':
-				return '-rotate-45';
-			case 'E':
-				return 'rotate-0';
-			case 'SE':
-				return 'rotate-45';
-			case 'S':
-				return 'rotate-90';
-			case 'SW':
-				return 'rotate-135';
-			case 'W':
-				return 'rotate-180';
-			case 'NW':
-				return 'rotate-225';
-			default:
-				return 'hidden';
-		}
-	}
+	// Rotation classes keyed by compass direction. `rotate-135` and `rotate-225`
+	// are registered via `theme.extend.rotate` in tailwind.config.js.
+	const ROTATION_CLASS_BY_DIRECTION = {
+		N: '-rotate-90',
+		NE: '-rotate-45',
+		E: 'rotate-0',
+		SE: 'rotate-45',
+		S: 'rotate-90',
+		SW: 'rotate-135',
+		W: 'rotate-180',
+		NW: 'rotate-225'
+	};
+
+	// Wrapping the icon in a span we control means the rotation class re-applies
+	// reactively when `stopDirection` changes, independent of how the
+	// FontAwesome component forwards its own `class` prop to the rendered SVG.
+	let rotationClass = $derived(ROTATION_CLASS_BY_DIRECTION[stopDirection] ?? 'hidden');
 </script>
 
-<FontAwesomeIcon icon={faArrowRight} class={rotationAngleClass()} />
+<span class="inline-block {rotationClass}" data-testid="compass-arrow">
+	<FontAwesomeIcon icon={faArrowRight} />
+</span>

--- a/src/components/controls/__tests__/CompassArrow.test.js
+++ b/src/components/controls/__tests__/CompassArrow.test.js
@@ -1,0 +1,68 @@
+import { render } from '@testing-library/svelte';
+import { describe, expect, test } from 'vitest';
+import CompassArrow from '../CompassArrow.svelte';
+
+function getArrowSpan(container) {
+	return container.querySelector('[data-testid="compass-arrow"]');
+}
+
+describe('CompassArrow', () => {
+	const cases = [
+		['N', '-rotate-90'],
+		['NE', '-rotate-45'],
+		['E', 'rotate-0'],
+		['SE', 'rotate-45'],
+		['S', 'rotate-90'],
+		['SW', 'rotate-135'],
+		['W', 'rotate-180'],
+		['NW', 'rotate-225']
+	];
+
+	test.each(cases)('applies %s rotation class', (direction, expectedClass) => {
+		const { container } = render(CompassArrow, { props: { stopDirection: direction } });
+		const span = getArrowSpan(container);
+
+		expect(span).toBeInTheDocument();
+		expect(span).toHaveClass(expectedClass);
+		expect(span).not.toHaveClass('hidden');
+	});
+
+	test('hides the arrow when direction is missing', () => {
+		const { container } = render(CompassArrow, { props: { stopDirection: '' } });
+		const span = getArrowSpan(container);
+
+		expect(span).toHaveClass('hidden');
+	});
+
+	test('hides the arrow when direction is unrecognized', () => {
+		const { container } = render(CompassArrow, { props: { stopDirection: 'X' } });
+		const span = getArrowSpan(container);
+
+		expect(span).toHaveClass('hidden');
+	});
+
+	// Regression: prior to wrapping the icon in a span we control, the
+	// rotation class could become stale after `stopDirection` updated
+	// (icon visible but pointing in the wrong direction on the Route
+	// Schedules tab once the async stop data resolved).
+	test('updates the rotation class when stopDirection changes', async () => {
+		const { container, rerender } = render(CompassArrow, {
+			props: { stopDirection: '' }
+		});
+
+		expect(getArrowSpan(container)).toHaveClass('hidden');
+
+		await rerender({ stopDirection: 'S' });
+
+		const updatedSpan = getArrowSpan(container);
+		expect(updatedSpan).toHaveClass('rotate-90');
+		expect(updatedSpan).not.toHaveClass('hidden');
+	});
+
+	test('renders the FontAwesome arrow SVG inside the wrapper', () => {
+		const { container } = render(CompassArrow, { props: { stopDirection: 'N' } });
+		const span = getArrowSpan(container);
+
+		expect(span.querySelector('svg')).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
Fixes #492 

**The Fix**
Previously, the rotation class was applied directly on <FontAwesomeIcon> via its class prop. In @fortawesome/svelte-fontawesome 0.2.2 that prop ends up baked into the rendered SVG on first mount and doesn't reliably re-apply when the parent's reactive state changes, which is exactly the case on the Route Schedules page where stopDirection starts as '' and updates after the schedule API resolves. By moving the class onto a plain <span> we own, Svelte's reactivity always re-applies the right class on the DOM element.

Also replaced the switch with a small lookup table (ROTATION_CLASS_BY_DIRECTION) which is easier to read and the same logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized compass arrow component's directional rotation logic for improved performance and maintainability.

* **Tests**
  * Added comprehensive test coverage for the compass arrow component, verifying correct rotation behavior across all compass directions.
  * Added regression tests ensuring rotation updates properly when the compass direction changes.
  * Added tests verifying proper rendering and visibility handling for valid and invalid directions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/wayfinder/pull/493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->