### PR TITLE
fix(a11y): resolve WCAG AA color contrast violations on stop pages

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -21,15 +21,15 @@
 	}
 
 	.tab-container {
-		@apply flex border-b border-gray-300;
+		@apply flex border-b border-gray-300 dark:border-gray-700;
 	}
 
 	.tab-container__item {
-		@apply -mb-px px-4 py-2 font-semibold text-gray-500;
+		@apply -mb-px px-4 py-2 font-semibold text-gray-500 dark:text-gray-400;
 	}
 
 	.tab-container__item--active {
-		@apply border-b-2 border-brand-accent text-brand-accent;
+		@apply border-b-2 border-brand-accent text-brand-accent dark:border-brand dark:text-brand;
 	}
 
 	/* Pill-style itinerary tabs */

--- a/src/components/ArrivalDeparture.svelte
+++ b/src/components/ArrivalDeparture.svelte
@@ -16,18 +16,20 @@
 	let stopSequence = $derived(arrivalDeparture.stopSequence || 1); // Default to 1 if not provided
 
 	function computeColor(scheduledMins, predictedMins, isPredicted) {
-		// If this is a scheduled (non-real-time) arrival, always show in blue
+		// Each branch returns the 600 shade for light mode (passes WCAG AA on
+		// white) paired with 400 shade in dark mode (passes on gray-800)
+		// The 500 shade fails 4.5:1 in both modes for normal size status text
 		if (!isPredicted) {
-			return 'text-blue-500';
+			return 'text-blue-600 dark:text-blue-400';
 		}
 
 		const delay = predictedMins - scheduledMins;
 		if (delay > 0) {
-			return 'text-violet-600';
+			return 'text-violet-600 dark:text-violet-400';
 		} else if (delay < -1) {
-			return 'text-red-500';
+			return 'text-red-600 dark:text-red-400';
 		} else {
-			return 'text-green-500';
+			return 'text-green-600 dark:text-green-400';
 		}
 	}
 

--- a/src/components/navigation/Header.svelte
+++ b/src/components/navigation/Header.svelte
@@ -219,7 +219,7 @@
 </script>
 
 <header
-	class="relative z-[9999] flex items-center justify-between border-b border-gray-500 bg-brand/80 text-brand-foreground backdrop-blur-md dark:bg-surface-dark dark:text-surface-foreground-dark md:flex-row md:px-8"
+	class="relative z-[9999] flex items-center justify-between border-b border-gray-500 bg-brand-accent/80 text-brand-foreground backdrop-blur-md dark:bg-surface-dark dark:text-surface-foreground-dark md:flex-row md:px-8"
 	bind:this={navContainer}
 >
 	<div class="logo-container flex items-center gap-2 px-1 py-1 md:gap-4 md:px-2 md:py-2">

--- a/src/components/navigation/__tests__/Header.test.js
+++ b/src/components/navigation/__tests__/Header.test.js
@@ -125,7 +125,7 @@ describe('Header', () => {
 			'justify-between',
 			'border-b',
 			'border-gray-500',
-			'bg-brand/80',
+			'bg-brand-accent/80',
 			'text-brand-foreground',
 			'backdrop-blur-md',
 			'dark:bg-surface-dark',

--- a/src/components/oba/TripDetailsPane.svelte
+++ b/src/components/oba/TripDetailsPane.svelte
@@ -141,7 +141,7 @@
 							<div class="text-md font-semibold dark:text-white">
 								{stopInfo[tripStop.stopId] ? stopInfo[tripStop.stopId].name : tripStop.stopId}
 							</div>
-							<div class="whitespace-nowrap text-sm text-gray-500">
+							<div class="whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
 								{formatSecondsFromMidnight(tripStop.arrivalTime)}
 							</div>
 						</div>

--- a/src/components/search/SearchPane.svelte
+++ b/src/components/search/SearchPane.svelte
@@ -313,7 +313,7 @@
 			<div class="mt-0 sm:mt-0">
 				<button
 					type="button"
-					class="mt-3 text-sm font-medium text-brand-accent underline hover:text-brand focus:outline-none"
+					class="mt-3 text-sm font-medium text-brand-accent underline hover:text-brand focus:outline-none dark:text-brand dark:hover:text-white"
 					onclick={handleViewAllRoutes}
 				>
 					{$t('search.click_here')}

--- a/src/components/service-alerts/ServiceAlerts.svelte
+++ b/src/components/service-alerts/ServiceAlerts.svelte
@@ -62,7 +62,10 @@
 			<h3 class="font-medium text-gray-700 dark:text-white">
 				{$t('service_alerts.service_alerts')} ({serviceAlerts.length})
 			</h3>
-			<button class="text-sm font-medium text-brand-accent" onclick={toggleAlerts}>
+			<button
+				class="text-sm font-medium text-brand-accent hover:text-brand focus:outline-none dark:text-brand dark:hover:text-white"
+				onclick={toggleAlerts}
+			>
 				{isAlertsHidden ? $t('service_alerts.show') : $t('service_alerts.hide')}
 			</button>
 		</div>

--- a/src/components/stops/StopPageHeader.svelte
+++ b/src/components/stops/StopPageHeader.svelte
@@ -15,7 +15,7 @@
 	<div class="mb-4 flex justify-start">
 		<a
 			href="/"
-			class="inline-flex items-center gap-2 rounded-md bg-brand px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-brand-accent focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2"
+			class="inline-flex items-center gap-2 rounded-md bg-brand-accent px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-brand focus:outline-none focus:ring-2 focus:ring-brand-accent focus:ring-offset-2"
 		>
 			<FontAwesomeIcon icon={faArrowLeft} class="h-4 w-4" />
 			<FontAwesomeIcon icon={faMap} class="h-4 w-4" />

--- a/src/components/stops/StopPane.svelte
+++ b/src/components/stops/StopPane.svelte
@@ -181,7 +181,7 @@
 		{#if arrivalsAndDepartures}
 			<div class="space-y-4">
 				<div>
-					<div class="relative flex flex-col gap-y-1 rounded-lg bg-brand-accent bg-opacity-80 p-4">
+					<div class="relative flex flex-col gap-y-1 rounded-lg bg-brand-accent p-4">
 						<h1 class="h1 mb-0 text-white">{stop.name}</h1>
 						<h2 class="h2 mb-0 text-white">
 							{$isLoading ? '' : $t('stop')} #{removeAgencyPrefix(stop.id)}

--- a/src/components/stops/StopPane.svelte
+++ b/src/components/stops/StopPane.svelte
@@ -196,13 +196,13 @@
 							<div class="mt-auto flex justify-end gap-2">
 								<a
 									href={`/stops/${stop.id}`}
-									class="inline-block rounded-lg border border-brand bg-brand px-3 py-1 text-sm font-medium text-white shadow-md transition duration-200 ease-in-out hover:bg-brand-accent"
+									class="inline-block rounded-lg border border-brand-accent bg-brand-accent px-3 py-1 text-sm font-medium text-white shadow-md transition duration-200 ease-in-out hover:bg-brand"
 								>
 									{$isLoading ? '' : $t('stop_details.view_details')}
 								</a>
 								<a
 									href={`/stops/${stop.id}/schedule`}
-									class="inline-block rounded-lg border border-brand bg-brand px-3 py-1 text-sm font-medium text-white shadow-md transition duration-200 ease-in-out hover:bg-brand-accent"
+									class="inline-block rounded-lg border border-brand-accent bg-brand-accent px-3 py-1 text-sm font-medium text-white shadow-md transition duration-200 ease-in-out hover:bg-brand"
 								>
 									{$isLoading ? '' : $t('schedule_for_stop.view_schedule')}
 								</a>

--- a/src/components/stops/__tests__/StopPageHeader.test.js
+++ b/src/components/stops/__tests__/StopPageHeader.test.js
@@ -276,7 +276,7 @@ describe('StopPageHeader', () => {
 			'items-center',
 			'gap-2',
 			'rounded-md',
-			'bg-brand',
+			'bg-brand-accent',
 			'px-4',
 			'py-2',
 			'text-sm',

--- a/src/components/trip-planner/LegDetails.svelte
+++ b/src/components/trip-planner/LegDetails.svelte
@@ -207,7 +207,7 @@
 		<!-- Walking steps toggle -->
 		{#if isWalking && leg.steps?.length > 0}
 			<button
-				class="mt-3 flex items-center gap-1.5 rounded-lg px-2 py-1 text-sm font-medium text-brand-accent transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
+				class="mt-3 flex items-center gap-1.5 rounded-lg px-2 py-1 text-sm font-medium text-brand-accent transition-colors hover:bg-gray-100 dark:text-brand dark:hover:bg-gray-800"
 				onclick={() => toggleSteps(index)}
 			>
 				<FontAwesomeIcon


### PR DESCRIPTION
## What I did in this PR
The PR fixes a batch of axe-flagged WCAG 2 AA color-contrast violations across the search pane, stop pages, and shared header. Most failures came from the brand green being too light against white text, the use of `bg-opacity-80` washing out already-borderline pairs, and bright `text-{color}-500` shades on white backgrounds in light mode and on near-black backgrounds in dark mode.


## Changes I did

**Search pane**
- `SearchPane.svelte` - "Click here" link now gets a `dark:` variant so it stays readable on the dark surface.

**Service alerts**
- `ServiceAlerts.svelte` - Show / Hide toggle gets a `dark:` variant for the same reason; small hover state added so the change is consistent.

**Trip planner**
- `LegDetails.svelte` - "Show / Hide steps" button gets a `dark:` text variant; the existing dark hover background already handled the rest.

**Stop pages**
- `StopPane.svelte` - drop `bg-opacity-80` from the stop info card so white text passes 4.5:1 on `bg-brand-accent` (~6.6:1); View Details / View Schedule CTAs swapped to `bg-brand-accent` (resting) → `bg-brand` (hover) so white text passes in both modes.
- `StopPageHeader.svelte` - "Back to Map" button follows the same swap so white text reaches AA. Focus ring updated to match.
- `ArrivalDeparture.svelte` - status color helpers now return paired `text-{color}-600 dark:text-{color}-400` for green / blue / red / violet, passing AA on both white and `gray-800`.

**Shared header**
- `Header.svelte` - header background changed from `bg-brand/80` to`bg-brand-accent/80` so the bold region-name text passes the 3:1 large-text threshold (~4.15:1).
- `app.css` (`.tab-container__item` / `--active`) - inactive tab text and the active tab text + underline get `dark:` variants so the Arrivals / Route Schedules tabs are legible on `dark:bg-black`.
- `TripDetailsPane.svelte` - trip-stop time text gets `dark:text-gray-400`.

**Tests**
All tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode support with improved color contrast and visual consistency across tabs, navigation, service alerts, stops, and trip planning.
  * Refined brand accent color styling throughout the interface for improved visual hierarchy and aesthetic consistency.
  * Improved hover states and focus indicators on interactive buttons and links for clearer user feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/wayfinder/pull/494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->