### PR TITLE
refactor: extract buildVehiclePopupData helper for map providers

### DIFF
--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -9,6 +9,7 @@ import VehiclePopupContent from '$components/map/VehiclePopupContent.svelte';
 import { createVehicleIconSvg, iconHeight, iconWidth } from '$lib/MapHelpers/generateVehicleIcon';
 import TripPlanPinMarker from '$components/trip-planner/tripPlanPinMarker.svelte';
 import { mount, unmount } from 'svelte';
+import { buildVehiclePopupData } from '$lib/vehicleUtils';
 
 export default class GoogleMapProvider {
 	constructor(apiKey, handleStopMarkerSelect) {
@@ -351,13 +352,7 @@ export default class GoogleMapProvider {
 
 		this.vehicleMarkers.push(marker);
 
-		let vehicleData = $state({
-			nextDestination: activeTrip.tripHeadsign,
-			vehicleId: vehicle.vehicleId,
-			lastUpdateTime: vehicle.lastUpdateTime,
-			nextStopName: this.stopsMap.get(vehicle.nextStop)?.name,
-			predicted: vehicle.predicted
-		});
+		const vehicleData = $state(buildVehiclePopupData(vehicle, activeTrip, this.stopsMap));
 
 		marker.vehicleData = vehicleData;
 
@@ -395,13 +390,10 @@ export default class GoogleMapProvider {
 			anchor: new google.maps.Point(iconWidth / 2, iconHeight / 2)
 		});
 
-		Object.assign(marker.vehicleData, {
-			nextDestination: activeTrip.tripHeadsign,
-			vehicleId: vehicleStatus.vehicleId,
-			lastUpdateTime: vehicleStatus.lastUpdateTime,
-			nextStopName: this.stopsMap.get(vehicleStatus.nextStop)?.name,
-			predicted: vehicleStatus.predicted
-		});
+		Object.assign(
+			marker.vehicleData,
+			buildVehiclePopupData(vehicleStatus, activeTrip, this.stopsMap)
+		);
 	}
 
 	removeVehicleMarker(marker) {

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -12,6 +12,7 @@ import VehiclePopupContent from '$components/map/VehiclePopupContent.svelte';
 import TripPlanPinMarker from '$components/trip-planner/tripPlanPinMarker.svelte';
 import { mount, unmount } from 'svelte';
 import { env } from '$env/dynamic/public';
+import { buildVehiclePopupData } from '$lib/vehicleUtils';
 
 export default class OpenStreetMapProvider {
 	constructor(handleStopMarkerSelect) {
@@ -292,13 +293,7 @@ export default class OpenStreetMapProvider {
 
 		this.vehicleMarkers.push(marker);
 
-		let vehicleData = $state({
-			nextDestination: activeTrip.tripHeadsign,
-			vehicleId: vehicle.vehicleId,
-			lastUpdateTime: vehicle.lastUpdateTime,
-			nextStopName: this.stopsMap.get(vehicle.nextStop)?.name,
-			predicted: vehicle.predicted
-		});
+		const vehicleData = $state(buildVehiclePopupData(vehicle, activeTrip, this.stopsMap));
 
 		marker.vehicleData = vehicleData;
 
@@ -345,13 +340,10 @@ export default class OpenStreetMapProvider {
 		marker.setLatLng([vehicleStatus.position.lat, vehicleStatus.position.lon]);
 		marker.setIcon(updatedIcon);
 
-		Object.assign(marker.vehicleData, {
-			nextDestination: activeTrip.tripHeadsign,
-			vehicleId: vehicleStatus.vehicleId,
-			lastUpdateTime: vehicleStatus.lastUpdateTime,
-			nextStopName: this.stopsMap.get(vehicleStatus.nextStop)?.name,
-			predicted: vehicleStatus.predicted
-		});
+		Object.assign(
+			marker.vehicleData,
+			buildVehiclePopupData(vehicleStatus, activeTrip, this.stopsMap)
+		);
 	}
 	removeVehicleMarker(marker) {
 		if (marker) {

--- a/src/lib/vehicleUtils.js
+++ b/src/lib/vehicleUtils.js
@@ -92,3 +92,13 @@ export function clearVehicleMarkersMap() {
 	vehicleMarkersMap.clear();
 	activeTripMap.clear();
 }
+
+export function buildVehiclePopupData(vehicle, activeTrip, stopsMap) {
+	return {
+		nextDestination: activeTrip.tripHeadsign,
+		vehicleId: vehicle.vehicleId,
+		lastUpdateTime: vehicle.lastUpdateTime,
+		nextStopName: stopsMap.get(vehicle.nextStop)?.name,
+		predicted: vehicle.predicted
+	};
+}


### PR DESCRIPTION
### Description
Closes #471

This PR refactors both `GoogleMapProvider` and `OpenStreetMapProvider` to extract and use a shared helper `buildVehiclePopupData` inside the vehicle utility layer. This deduplicates the vehicle popup details schema across both providers, ensuring that any future property additions automatically synchronize across both map engines.

Additionally, local state proxy variables inside the providers were updated from `let` to `const` to signal Svelte 5 state intent.

### Technical Changes
- Extracted and exported `buildVehiclePopupData` inside `src/lib/vehicleUtils.js`.
- Imported and integrated the helper inside `src/lib/Provider/GoogleMapProvider.svelte.js` (`addVehicleMarker` and `updateVehicleMarker`).
- Imported and integrated the helper inside `src/lib/Provider/OpenStreetMapProvider.svelte.js` (`addVehicleMarker` and `updateVehicleMarker`).
- Optimized `$state` proxy variable declarations from `let` to `const`.

### Verification
- **Formatting**: Formatted all three files with Prettier.
- **Linter**: ESLint checked the three files and passed with 0 errors and 0 warnings.
- **Tests**: Ran the Svelte component and utility tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Vehicle popup data handling refactored to improve code organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/wayfinder/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->