### PR TITLE
fix: clear trip planner from/to pins from the map

### DIFF
--- a/src/components/search/SearchPane.svelte
+++ b/src/components/search/SearchPane.svelte
@@ -193,6 +193,11 @@
 
 	function handleTabSwitch() {
 		if (isContextMenuTrigger) return;
+
+		if (activeTab === 'plan') {
+			window.dispatchEvent(new CustomEvent('tripPlanModalClosed'));
+			clearTripItineraries();
+		}
 		const event = new CustomEvent('tabSwitched');
 		window.dispatchEvent(event);
 	}

--- a/src/components/search/__tests__/SearchPane.test.js
+++ b/src/components/search/__tests__/SearchPane.test.js
@@ -84,6 +84,7 @@ describe('SearchPane', () => {
 		// Mock props
 		mockProps = {
 			clearPolylines: vi.fn(),
+			clearTripItineraries: vi.fn(),
 			handleRouteSelected: vi.fn(),
 			handleViewAllRoutes: vi.fn(),
 			handleTripPlan: vi.fn(),
@@ -172,6 +173,26 @@ describe('SearchPane', () => {
 			await user.click(tripTab);
 			expect(global.dispatchEvent).toHaveBeenCalledWith(
 				expect.objectContaining({ type: 'planTripTabClicked' })
+			);
+		});
+
+		test('clears trip plan map state when leaving the plan tab', async () => {
+			const user = userEvent.setup();
+
+			render(SearchPane, { props: mockProps });
+
+			await user.click(screen.getByRole('tab', { name: 'Plan Trip' }));
+			vi.mocked(global.dispatchEvent).mockClear();
+			mockProps.clearTripItineraries.mockClear();
+
+			await user.click(screen.getByRole('tab', { name: 'Stops & Stations' }));
+
+			expect(global.dispatchEvent).toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'tripPlanModalClosed' })
+			);
+			expect(mockProps.clearTripItineraries).toHaveBeenCalled();
+			expect(global.dispatchEvent).toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'tabSwitched' })
 			);
 		});
 

--- a/src/components/trip-planner/TripPlan.svelte
+++ b/src/components/trip-planner/TripPlan.svelte
@@ -221,12 +221,7 @@
 			const data = await fetchTripPlan(selectedFrom, selectedTo);
 
 			if (data) {
-				const tripPlanData = {
-					data,
-					fromMarker,
-					toMarker
-				};
-				handleTripPlan(tripPlanData);
+				handleTripPlan({ data });
 
 				// Save to recent trips
 				try {

--- a/src/components/trip-planner/TripPlan.svelte
+++ b/src/components/trip-planner/TripPlan.svelte
@@ -134,12 +134,18 @@
 			fromPlace = '';
 			fromResults = [];
 			selectedFrom = null;
-			mapProvider.removePinMarker(fromMarker);
+			if (fromMarker) {
+				mapProvider.removePinMarker(fromMarker);
+				fromMarker = null;
+			}
 		} else {
 			toPlace = '';
 			toResults = [];
 			selectedTo = null;
-			mapProvider.removePinMarker(toMarker);
+			if (toMarker) {
+				mapProvider.removePinMarker(toMarker);
+				toMarker = null;
+			}
 		}
 		clearTripItineraries();
 	}
@@ -291,6 +297,12 @@
 	});
 
 	onDestroy(() => {
+		// Safety when the plan tab unmounts before tabSwitched runs.
+		if (mapProvider && (fromMarker || toMarker)) {
+			const result = clearTripPlanPins({ fromMarker, toMarker, mapProvider });
+			fromMarker = result.fromMarker;
+			toMarker = result.toMarker;
+		}
 		if (browser) {
 			if (tabSwitchedHandler) {
 				window.removeEventListener('tabSwitched', tabSwitchedHandler);

--- a/src/components/trip-planner/TripPlan.svelte
+++ b/src/components/trip-planner/TripPlan.svelte
@@ -17,7 +17,7 @@
 	import { formatDepartureDisplay } from '$lib/dateTimeFormat';
 	import { env } from '$env/dynamic/public';
 	import { createRequestFromTripOptions, buildOTPParams, validateCoordinates } from '$lib/otp';
-	import { swapTripLocations } from '$lib/tripPlanUtils';
+	import { swapTripLocations, clearTripPlanPins } from '$lib/tripPlanUtils';
 	import { recentTrips } from '$stores/recentTripsStore';
 	import RecentTripsList from './RecentTripsList.svelte';
 
@@ -241,6 +241,14 @@
 
 	let tabSwitchedHandler;
 	let setTripPlanLocationHandler;
+	let tripPlanModalClosedHandler;
+
+	// Remove the From/To pins when the itineraries modal closes, but keep the form inputs so the user can tweak options and re-plan in one click. The pins are recreated by planTrip() on the next search.
+	function handleTripPlanModalClosed() {
+		const result = clearTripPlanPins({ fromMarker, toMarker, mapProvider });
+		fromMarker = result.fromMarker;
+		toMarker = result.toMarker;
+	}
 
 	function handleSetTripPlanLocation(e) {
 		const { type, lat, lng } = e.detail;
@@ -275,8 +283,10 @@
 				clearInput(false);
 			};
 			setTripPlanLocationHandler = handleSetTripPlanLocation;
+			tripPlanModalClosedHandler = handleTripPlanModalClosed;
 			window.addEventListener('tabSwitched', tabSwitchedHandler);
 			window.addEventListener('setTripPlanLocation', setTripPlanLocationHandler);
+			window.addEventListener('tripPlanModalClosed', tripPlanModalClosedHandler);
 		}
 	});
 
@@ -287,6 +297,9 @@
 			}
 			if (setTripPlanLocationHandler) {
 				window.removeEventListener('setTripPlanLocation', setTripPlanLocationHandler);
+			}
+			if (tripPlanModalClosedHandler) {
+				window.removeEventListener('tripPlanModalClosed', tripPlanModalClosedHandler);
 			}
 		}
 	});

--- a/src/components/trip-planner/__tests__/TripPlan.test.js
+++ b/src/components/trip-planner/__tests__/TripPlan.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import TripPlan from '../TripPlan.svelte';
+
+vi.mock('$app/environment', () => ({
+	browser: true,
+	dev: false,
+	building: false,
+	version: '1.0.0'
+}));
+
+vi.mock('@fortawesome/svelte-fontawesome', () => ({
+	FontAwesomeIcon: vi.fn(() => ({ $$: { component: 'div' } }))
+}));
+
+/**
+ * Populate the From and To pins by dispatching the same setTripPlanLocation event
+ * the map context menu uses. This avoids mocking the geocode fetch and exercises
+ * the real marker-creation path. Returns the two markers addPinMarker produced.
+ */
+async function selectFromAndTo(mapProvider) {
+	window.dispatchEvent(
+		new CustomEvent('setTripPlanLocation', { detail: { type: 'from', lat: 47.6, lng: -122.3 } })
+	);
+	window.dispatchEvent(
+		new CustomEvent('setTripPlanLocation', { detail: { type: 'to', lat: 47.7, lng: -122.4 } })
+	);
+	await tick();
+
+	const markers = mapProvider.addPinMarker.mock.results.map((r) => r.value);
+	return { fromMarker: markers[0], toMarker: markers[1] };
+}
+
+describe('TripPlan pin cleanup', () => {
+	let mapProvider;
+	let props;
+
+	beforeEach(() => {
+		let markerId = 0;
+		mapProvider = {
+			addPinMarker: vi.fn(() => ({ id: `marker-${++markerId}` })),
+			removePinMarker: vi.fn(),
+			clearAllPolylines: vi.fn()
+		};
+		props = {
+			handleTripPlan: vi.fn(),
+			clearTripItineraries: vi.fn(),
+			mapProvider
+		};
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('removes both pins when the itineraries modal closes, but keeps the form inputs', async () => {
+		const { container, unmount } = render(TripPlan, { props });
+
+		const { fromMarker, toMarker } = await selectFromAndTo(mapProvider);
+		expect(mapProvider.addPinMarker).toHaveBeenCalledTimes(2);
+
+		window.dispatchEvent(new CustomEvent('tripPlanModalClosed'));
+		await tick();
+
+		expect(mapProvider.removePinMarker).toHaveBeenCalledTimes(2);
+		expect(mapProvider.removePinMarker).toHaveBeenCalledWith(fromMarker);
+		expect(mapProvider.removePinMarker).toHaveBeenCalledWith(toMarker);
+
+		expect(container.querySelector('#from-location-input').value).toBe('47.60000, -122.30000');
+		expect(container.querySelector('#to-location-input').value).toBe('47.70000, -122.40000');
+
+		expect(mapProvider.addPinMarker).toHaveBeenCalledTimes(2);
+
+		unmount();
+	});
+
+	it('removes any active pins when the component unmounts (tab switch safety net)', async () => {
+		const { unmount } = render(TripPlan, { props });
+
+		const { fromMarker, toMarker } = await selectFromAndTo(mapProvider);
+		expect(mapProvider.addPinMarker).toHaveBeenCalledTimes(2);
+
+		unmount();
+		await tick();
+
+		expect(mapProvider.removePinMarker).toHaveBeenCalledTimes(2);
+		expect(mapProvider.removePinMarker).toHaveBeenCalledWith(fromMarker);
+		expect(mapProvider.removePinMarker).toHaveBeenCalledWith(toMarker);
+	});
+});

--- a/src/components/trip-planner/__tests__/TripPlanSwap.test.js
+++ b/src/components/trip-planner/__tests__/TripPlanSwap.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { swapTripLocations } from '$lib/tripPlanUtils';
+import { swapTripLocations, clearTripPlanPins } from '$lib/tripPlanUtils';
 
 describe('tripPlanUtils', () => {
 	describe('swapTripLocations', () => {
@@ -206,6 +206,53 @@ describe('tripPlanUtils', () => {
 			expect(result).toHaveProperty('selectedTo');
 			expect(result).toHaveProperty('fromMarker');
 			expect(result).toHaveProperty('toMarker');
+		});
+	});
+
+	describe('clearTripPlanPins', () => {
+		let mockMapProvider;
+
+		beforeEach(() => {
+			mockMapProvider = {
+				removePinMarker: vi.fn()
+			};
+		});
+
+		it('removes both pins and returns nulled marker references', () => {
+			const fromMarker = { id: 'marker-from' };
+			const toMarker = { id: 'marker-to' };
+
+			const result = clearTripPlanPins({ fromMarker, toMarker, mapProvider: mockMapProvider });
+
+			expect(mockMapProvider.removePinMarker).toHaveBeenCalledWith(fromMarker);
+			expect(mockMapProvider.removePinMarker).toHaveBeenCalledWith(toMarker);
+			expect(mockMapProvider.removePinMarker).toHaveBeenCalledTimes(2);
+			expect(result).toEqual({ fromMarker: null, toMarker: null });
+		});
+
+		it('only removes the markers that exist', () => {
+			const fromMarker = { id: 'marker-from' };
+
+			const result = clearTripPlanPins({
+				fromMarker,
+				toMarker: null,
+				mapProvider: mockMapProvider
+			});
+
+			expect(mockMapProvider.removePinMarker).toHaveBeenCalledTimes(1);
+			expect(mockMapProvider.removePinMarker).toHaveBeenCalledWith(fromMarker);
+			expect(result).toEqual({ fromMarker: null, toMarker: null });
+		});
+
+		it('is a no-op when no markers exist', () => {
+			const result = clearTripPlanPins({
+				fromMarker: null,
+				toMarker: null,
+				mapProvider: mockMapProvider
+			});
+
+			expect(mockMapProvider.removePinMarker).not.toHaveBeenCalled();
+			expect(result).toEqual({ fromMarker: null, toMarker: null });
 		});
 	});
 });

--- a/src/lib/tripPlanUtils.js
+++ b/src/lib/tripPlanUtils.js
@@ -60,8 +60,10 @@ export function swapTripLocations({
  * @returns {{ fromMarker: null, toMarker: null }} Nulled marker references
  */
 export function clearTripPlanPins({ fromMarker, toMarker, mapProvider }) {
-	if (fromMarker) mapProvider.removePinMarker(fromMarker);
-	if (toMarker) mapProvider.removePinMarker(toMarker);
+	if (mapProvider) {
+		if (fromMarker) mapProvider.removePinMarker(fromMarker);
+		if (toMarker) mapProvider.removePinMarker(toMarker);
+	}
 
 	return { fromMarker: null, toMarker: null };
 }

--- a/src/lib/tripPlanUtils.js
+++ b/src/lib/tripPlanUtils.js
@@ -49,6 +49,24 @@ export function swapTripLocations({
 }
 
 /**
+ * Removes the From/To pin markers from the map without touching the form
+ * inputs or selected coordinates. Used when the itineraries modal closes so the
+ * map clears (matching Google/Apple Maps) while the search stays populated for a
+ * quick re-plan. The pins are recreated the next time the user plans a trip.
+ * @param {Object} params
+ * @param {Object|null} params.fromMarker - Origin map marker
+ * @param {Object|null} params.toMarker - Destination map marker
+ * @param {Object} params.mapProvider - Map provider instance
+ * @returns {{ fromMarker: null, toMarker: null }} Nulled marker references
+ */
+export function clearTripPlanPins({ fromMarker, toMarker, mapProvider }) {
+	if (fromMarker) mapProvider.removePinMarker(fromMarker);
+	if (toMarker) mapProvider.removePinMarker(toMarker);
+
+	return { fromMarker: null, toMarker: null };
+}
+
+/**
  * Determines if there is a stay-seated transition between two legs. That occurs when a
  * passenger stays on the same vehicle and it continues under a different id.
  * @see https://github.com/opentripplanner/OpenTripPlanner/pull/4264

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -51,8 +51,6 @@
 	let tripItineraries = $state([]);
 	let tripPlanError = $state(null);
 	let loadingItineraries = false;
-	let fromMarker = $state(null);
-	let toMarker = $state(null);
 	let currentHighlightedStopId = null;
 
 	let currentUserLocation = $state($userLocation);
@@ -202,8 +200,6 @@
 		if (browser) {
 			window.dispatchEvent(new CustomEvent('tripPlanModalClosed'));
 		}
-		fromMarker = null;
-		toMarker = null;
 		clearTripItineraries();
 	}
 
@@ -226,16 +222,11 @@
 	}
 
 	/**
-	 *
 	 * @param {Object} tripPlanData - The data returned from the trip planning API.
 	 * @param {Object} tripPlanData.data - The trip planning data.
-	 * @param {Object} tripPlanData.fromMarker - The marker for the from location.
-	 * @param {Object} tripPlanData.toMarker - The marker for the to location.
 	 */
 	function handleTripPlan(tripPlanData) {
 		const tripData = tripPlanData.data;
-		fromMarker = tripPlanData.fromMarker;
-		toMarker = tripPlanData.toMarker;
 		tripItineraries = tripData.plan?.itineraries || [];
 		tripPlanError = tripData.error || null;
 		currentModal = Modal.TRIP_PLANNER;
@@ -245,8 +236,6 @@
 		if (browser) {
 			window.dispatchEvent(new CustomEvent('tripPlanModalClosed'));
 		}
-		fromMarker = null;
-		toMarker = null;
 		tripItineraries = [];
 		tripPlanError = null;
 		currentModal = null;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -198,6 +198,15 @@
 		mapProvider.clearAllPolylines();
 	}
 
+	function closeTripPlanModal() {
+		if (browser) {
+			window.dispatchEvent(new CustomEvent('tripPlanModalClosed'));
+		}
+		fromMarker = null;
+		toMarker = null;
+		clearTripItineraries();
+	}
+
 	async function loadAlerts() {
 		try {
 			const response = await fetch('/api/oba/alerts');
@@ -318,10 +327,8 @@
 						{mapProvider}
 						itineraries={tripItineraries}
 						error={tripPlanError}
-						{fromMarker}
-						{toMarker}
 						loading={loadingItineraries}
-						{closePane}
+						closePane={closeTripPlanModal}
 					/>
 				{/if}
 			</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -242,7 +242,17 @@
 	}
 
 	function handleTabSwitched() {
+		if (browser) {
+			window.dispatchEvent(new CustomEvent('tripPlanModalClosed'));
+		}
+		fromMarker = null;
+		toMarker = null;
+		tripItineraries = [];
+		tripPlanError = null;
 		currentModal = null;
+		if (mapProvider) {
+			mapProvider.clearAllPolylines();
+		}
 	}
 
 	function handlePlanTripTabClicked() {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -233,15 +233,8 @@
 	}
 
 	function handleTabSwitched() {
-		if (browser) {
-			window.dispatchEvent(new CustomEvent('tripPlanModalClosed'));
-		}
-		tripItineraries = [];
-		tripPlanError = null;
+		// SearchPane owns trip-plan teardown when leaving the Plan tab (it dispatches tripPlanModalClosed and calls clearTripItineraries). Here we just close any open modal for the generic tab switch.
 		currentModal = null;
-		if (mapProvider) {
-			mapProvider.clearAllPolylines();
-		}
 	}
 
 	function handlePlanTripTabClicked() {


### PR DESCRIPTION
Fixes #490 

## What this fixes

Two related bugs with the trip planner pins (From and To markers) sticking around on the map when they shouldn't.

**Bug 1: pins stay after closing the itineraries modal**

When you planned a trip and then closed the itineraries modal, the route line cleared but the From and To pins stayed floating on the map. You were left with two pins and no route between them, which looked broken.

**Bug 2: pins stay after switching tabs** (this comes new apart from what I discussed in the issue #490)

When you switched from the Plan Trip tab back to Stops and Stations, the pins also stayed on the map. This happened because the plan tab can get unmounted before its cleanup runs, so the pins never got removed.

## How it works now

Closing the itineraries modal:
- Removes the From and To pins and the route from the map, so the map is clean
- Keeps the From and To inputs filled in, so you can tweak options and plan again in one click (same as Google and Apple Maps)
- The pins come back the next time you hit Plan your trip

Switching away from the Plan Trip tab:
- Clears the pins, the route, and the itinerary state right away, before the tab unmounts
- Added a safety net so the pins are removed even if the component is already gone

## Tests

- Unit tests for `clearTripPlanPins` covering both pins, one pin, and no pins.
- A SearchPane test that checks the map state is cleared when leaving the plan tab.
- All trip planner and search tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trip planner now properly clears map pins and resets planning state when closing the modal or switching away from the Plan Trip tab.
  * Improved lifecycle handling ensures map markers and trip itineraries are consistently cleaned up during state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->