### PR TITLE
fix(a11y): announce loading state in LoadingSpinner for screen readers

### DIFF
--- a/src/components/LoadingSpinner.svelte
+++ b/src/components/LoadingSpinner.svelte
@@ -3,6 +3,9 @@
 </script>
 
 <div
+	aria-label={$t('loading')}
+	role="status"
+	aria-live="polite"
 	class="absolute inset-0 z-50 flex items-center justify-center bg-neutral-800 bg-opacity-80 md:rounded-lg"
 >
 	<div class="flex items-center text-white">

--- a/src/components/__tests__/LoadingSpinner.test.js
+++ b/src/components/__tests__/LoadingSpinner.test.js
@@ -1,18 +1,72 @@
-import { render, screen } from '@testing-library/svelte';
-import { expect, test, describe } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import LoadingSpinner from '../LoadingSpinner.svelte';
+import { locale } from 'svelte-i18n';
+
+vi.mock('svelte-i18n', () => {
+	let currentLocale = 'en';
+	const tSubscribers = [];
+	const translations = {
+		en: {
+			loading: 'Loading'
+		},
+		es: {
+			loading: 'Cargando'
+		}
+	};
+
+	const getTranslator = () => (key) => translations[currentLocale]?.[key] || key;
+
+	return {
+		t: {
+			subscribe: vi.fn((fn) => {
+				tSubscribers.push(fn);
+				fn(getTranslator());
+
+				return {
+					unsubscribe: () => {
+						const index = tSubscribers.indexOf(fn);
+						if (index !== -1) tSubscribers.splice(index, 1);
+					}
+				};
+			})
+		},
+		locale: {
+			subscribe: vi.fn((fn) => {
+				fn(currentLocale);
+				return { unsubscribe: () => {} };
+			}),
+			set: vi.fn((newLocale) => {
+				currentLocale = newLocale;
+				const translator = getTranslator();
+				tSubscribers.forEach((fn) => fn(translator));
+			})
+		}
+	};
+});
 
 describe('LoadingSpinner', () => {
-	test('displays loading spinner with localized text', () => {
+	beforeEach(() => {
+		locale.set('en');
+	});
+
+	test('renders an accessible loading status in English by default', () => {
 		render(LoadingSpinner);
 
-		// Check for the loading text (mocked to return the key)
-		expect(screen.getByText('loading...')).toBeInTheDocument();
+		const status = screen.getByRole('status', { name: 'Loading' });
+		expect(status).toHaveAttribute('aria-live', 'polite');
+		expect(screen.getByText('Loading...')).toBeInTheDocument();
+	});
 
-		// Check for the spinner SVG by class
-		const { container } = render(LoadingSpinner);
-		const spinner = container.querySelector('.animate-spin');
-		expect(spinner).toBeInTheDocument();
+	test('updates the visible text and aria-label when the locale changes to Spanish', async () => {
+		render(LoadingSpinner);
+
+		locale.set('es');
+
+		await waitFor(() => {
+			expect(screen.getByRole('status', { name: 'Cargando' })).toBeInTheDocument();
+		});
+		expect(screen.getByText('Cargando...')).toBeInTheDocument();
 	});
 
 	test('has correct CSS classes for styling', () => {
@@ -28,19 +82,6 @@ describe('LoadingSpinner', () => {
 			'justify-center'
 		);
 		expect(outerDiv).toHaveClass('bg-neutral-800', 'bg-opacity-80', 'md:rounded-lg');
-	});
-
-	test('has proper structure for accessibility', () => {
-		const { container } = render(LoadingSpinner);
-
-		// The outer container should be accessible as a loading indicator
-		const loadingContainer = container.firstChild;
-		expect(loadingContainer).toBeInTheDocument();
-
-		// Check for the loading text
-		const loadingText = screen.getByText('loading...');
-		expect(loadingText).toBeInTheDocument();
-		expect(loadingText.closest('div')).toHaveClass('text-white');
 	});
 
 	test('spinner SVG has correct attributes', () => {


### PR DESCRIPTION
Fixes #505 #405 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Loading spinner now features ARIA accessibility attributes and live region announcements, enabling screen readers to accurately communicate loading state to users. Includes full localization support with translated announcements across multiple languages.

* **Tests**
  * Test suite updated to comprehensively verify accessibility features function correctly across language localization and assistive technology scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->