### PR TITLE
feat: add reset to defaults in trip options modal

### DIFF
--- a/src/components/trip-planner/TripOptionsModal.svelte
+++ b/src/components/trip-planner/TripOptionsModal.svelte
@@ -75,9 +75,9 @@
 		}
 	}
 
-	// Reset everything back to defaults immediately: clears the store and localStorage
+	// Reset the local editing copies back to defaults. Like every other control
+	// in this modal, this is draft-only: nothing is persisted until handleDone() runs, so Cancel still discards the reset and keeps the saved preferences
 	function handleReset() {
-		tripOptions.resetAll();
 		departureType = DEFAULT_TRIP_OPTIONS.departureType;
 		departureTime = DEFAULT_TRIP_OPTIONS.departureTime || '';
 		departureDate = DEFAULT_TRIP_OPTIONS.departureDate || '';
@@ -407,7 +407,7 @@
 				<button
 					type="button"
 					onclick={handleReset}
-					class="text-sm font-medium text-gray-500 underline-offset-2 hover:text-gray-700 hover:underline focus:outline-none dark:text-gray-400 dark:hover:text-gray-200"
+					class="rounded text-sm font-medium text-gray-500 underline-offset-2 hover:text-gray-700 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-gray-400 dark:hover:text-gray-200"
 				>
 					{$t('trip-planner.reset_to_defaults')}
 				</button>

--- a/src/components/trip-planner/TripOptionsModal.svelte
+++ b/src/components/trip-planner/TripOptionsModal.svelte
@@ -6,6 +6,7 @@
 		effectiveDistanceUnit,
 		getWalkDistanceOptions,
 		snapToClosestOption,
+		DEFAULT_TRIP_OPTIONS,
 		UNIT_METRIC,
 		UNIT_IMPERIAL
 	} from '$stores/tripOptionsStore';
@@ -72,6 +73,18 @@
 			departureTime = getCurrentTimeForInput(regionTz);
 			departureDate = getTodayDateForInput(regionTz);
 		}
+	}
+
+	// Reset everything back to defaults immediately: clears the store and localStorage
+	function handleReset() {
+		tripOptions.resetAll();
+		departureType = DEFAULT_TRIP_OPTIONS.departureType;
+		departureTime = DEFAULT_TRIP_OPTIONS.departureTime || '';
+		departureDate = DEFAULT_TRIP_OPTIONS.departureDate || '';
+		wheelchair = DEFAULT_TRIP_OPTIONS.wheelchair;
+		optimize = DEFAULT_TRIP_OPTIONS.optimize;
+		maxWalkDistance = DEFAULT_TRIP_OPTIONS.maxWalkDistance;
+		distanceUnit = DEFAULT_TRIP_OPTIONS.distanceUnit;
 	}
 </script>
 
@@ -387,6 +400,17 @@
 						{/if}
 					</button>
 				</div>
+			</div>
+
+			<!-- Reset to defaults -->
+			<div class="mt-4 flex justify-center">
+				<button
+					type="button"
+					onclick={handleReset}
+					class="text-sm font-medium text-gray-500 underline-offset-2 hover:text-gray-700 hover:underline focus:outline-none dark:text-gray-400 dark:hover:text-gray-200"
+				>
+					{$t('trip-planner.reset_to_defaults')}
+				</button>
 			</div>
 		</div>
 	</div>

--- a/src/components/trip-planner/TripOptionsModal.svelte
+++ b/src/components/trip-planner/TripOptionsModal.svelte
@@ -76,7 +76,8 @@
 	}
 
 	// Reset the local editing copies back to defaults. Like every other control
-	// in this modal, this is draft-only: nothing is persisted until handleDone() runs, so Cancel still discards the reset and keeps the saved preferences
+	// in this modal, this is draft-only: nothing is persisted until handleDone()
+	// runs, so Cancel still discards the reset and keeps the saved preferences.
 	function handleReset() {
 		departureType = DEFAULT_TRIP_OPTIONS.departureType;
 		departureTime = DEFAULT_TRIP_OPTIONS.departureTime || '';

--- a/src/components/trip-planner/__tests__/TripOptionsModal.test.js
+++ b/src/components/trip-planner/__tests__/TripOptionsModal.test.js
@@ -2,6 +2,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import TripOptionsModal from '../TripOptionsModal.svelte';
+import { tripOptions, DEFAULT_TRIP_OPTIONS } from '$stores/tripOptionsStore';
+
+// browser = true so the real store's setPersisted touches the (mocked)
+// localStorage, letting us assert the commit/draft-only persistence behavior.
+vi.mock('$app/environment', () => ({ browser: true }));
 
 // Only the translation layer is mocked; the real tripOptionsStore is used so the test exercises the actual reset wiring (handleReset + DEFAULT_TRIP_OPTIONS)
 vi.mock('svelte-i18n', () => {
@@ -40,11 +45,22 @@ function getOptionButton(label) {
 	return screen.getByText(label).closest('button');
 }
 
+function getStoreValue() {
+	let value;
+	tripOptions.subscribe((v) => (value = v))();
+	return value;
+}
+
 describe('TripOptionsModal reset', () => {
 	let user;
 
 	beforeEach(() => {
 		user = userEvent.setup();
+		// Start each test from a clean, default store and clear localStorage spies.
+		tripOptions.set({ ...DEFAULT_TRIP_OPTIONS });
+		localStorage.setItem.mockClear();
+		localStorage.removeItem.mockClear();
+		localStorage.getItem.mockClear();
 	});
 
 	it('resets all locally edited options back to defaults', async () => {
@@ -59,29 +75,84 @@ describe('TripOptionsModal reset', () => {
 		await user.click(getOptionButton('Depart At'));
 		await user.click(getOptionButton('Fewest Transfers'));
 
+		// Walk distance + unit interact through handleUnitChange's snapping, so
+		// exercise them together.
+		const walkSelect = screen.getByRole('combobox');
+		await user.selectOptions(walkSelect, '3219');
+		await user.click(getOptionButton('Metric'));
+
 		// Confirm the non-default state took effect.
 		expect(wheelchairSwitch).toHaveAttribute('aria-checked', 'true');
 		expect(getOptionButton('Depart At')).toHaveTextContent('✓');
 		expect(getOptionButton('Fewest Transfers')).toHaveTextContent('✓');
+		expect(getOptionButton('Metric')).toHaveTextContent('✓');
 
 		await user.click(screen.getByText('Reset to defaults'));
 
-		// Everything is back to defaults (Leave now, no wheelchair, fastest).
+		// Everything is back to defaults (Leave now, no wheelchair, fastest, auto unit).
 		expect(wheelchairSwitch).toHaveAttribute('aria-checked', 'false');
 		expect(getOptionButton('Leave Now')).toHaveTextContent('✓');
 		expect(getOptionButton('Fastest Trip')).toHaveTextContent('✓');
 		expect(getOptionButton('Depart At')).not.toHaveTextContent('✓');
 		expect(getOptionButton('Fewest Transfers')).not.toHaveTextContent('✓');
+		expect(getOptionButton('Auto')).toHaveTextContent('✓');
+		expect(getOptionButton('Metric')).not.toHaveTextContent('✓');
+		expect(screen.getByRole('combobox')).toHaveValue(String(DEFAULT_TRIP_OPTIONS.maxWalkDistance));
 	});
 
-	it('does not persist the reset until Done (Cancel keeps it draft-only)', async () => {
+	it('keeps the reset draft-only: Cancel leaves the saved store untouched', async () => {
+		// Seed non-default saved preferences (set() does not touch localStorage).
+		tripOptions.set({
+			...DEFAULT_TRIP_OPTIONS,
+			wheelchair: true,
+			optimize: 'fewestTransfers'
+		});
+
 		const onClose = vi.fn();
 		render(TripOptionsModal, { props: { onClose, onDone: vi.fn() } });
 
 		await user.click(screen.getByText('Reset to defaults'));
 		await user.click(screen.getByText('Cancel'));
 
-		// Cancel simply closes; the reset was never committed to the store.
+		// Cancel only closes — the store still holds the saved non-default values
+		// and nothing was written to or removed from localStorage.
 		expect(onClose).toHaveBeenCalled();
+		const value = getStoreValue();
+		expect(value.wheelchair).toBe(true);
+		expect(value.optimize).toBe('fewestTransfers');
+		expect(localStorage.setItem).not.toHaveBeenCalled();
+		expect(localStorage.removeItem).not.toHaveBeenCalled();
+	});
+
+	it('Reset then Done commits defaults and clears the persisted keys', async () => {
+		// Seed non-default saved preferences first.
+		tripOptions.set({
+			...DEFAULT_TRIP_OPTIONS,
+			wheelchair: true,
+			optimize: 'fewestTransfers'
+		});
+
+		const onDone = vi.fn();
+		render(TripOptionsModal, { props: { onClose: vi.fn(), onDone } });
+
+		await user.click(screen.getByText('Reset to defaults'));
+		await user.click(screen.getByText('Done'));
+
+		expect(onDone).toHaveBeenCalled();
+
+		// Store is back to defaults.
+		const value = getStoreValue();
+		expect(value.wheelchair).toBe(false);
+		expect(value.optimize).toBe('fastest');
+		expect(value.maxWalkDistance).toBe(DEFAULT_TRIP_OPTIONS.maxWalkDistance);
+		expect(value.distanceUnit).toBeNull();
+
+		// Defaults are cleared from localStorage rather than written, so the user
+		// tracks future default changes instead of freezing today's values.
+		expect(localStorage.removeItem).toHaveBeenCalledWith('tripOptions_wheelchair');
+		expect(localStorage.removeItem).toHaveBeenCalledWith('tripOptions_optimize');
+		expect(localStorage.removeItem).toHaveBeenCalledWith('tripOptions_maxWalkDistance');
+		expect(localStorage.removeItem).toHaveBeenCalledWith('tripOptions_distanceUnit');
+		expect(localStorage.setItem).not.toHaveBeenCalled();
 	});
 });

--- a/src/components/trip-planner/__tests__/TripOptionsModal.test.js
+++ b/src/components/trip-planner/__tests__/TripOptionsModal.test.js
@@ -8,7 +8,8 @@ import { tripOptions, DEFAULT_TRIP_OPTIONS } from '$stores/tripOptionsStore';
 // localStorage, letting us assert the commit/draft-only persistence behavior.
 vi.mock('$app/environment', () => ({ browser: true }));
 
-// Only the translation layer is mocked; the real tripOptionsStore is used so the test exercises the actual reset wiring (handleReset + DEFAULT_TRIP_OPTIONS)
+// Translation layer and browser env are mocked; the real tripOptionsStore is used
+// so the test exercises the actual reset wiring (handleReset + DEFAULT_TRIP_OPTIONS).
 vi.mock('svelte-i18n', () => {
 	const translations = {
 		'trip-planner.cancel': 'Cancel',
@@ -125,11 +126,17 @@ describe('TripOptionsModal reset', () => {
 	});
 
 	it('Reset then Done commits defaults and clears the persisted keys', async () => {
-		// Seed non-default saved preferences first.
+		// Seed non-default saved preferences, including fields that must be reset
+		// before their localStorage keys are cleared.
 		tripOptions.set({
 			...DEFAULT_TRIP_OPTIONS,
+			departureType: 'departAt',
+			departureTime: '14:30',
+			departureDate: '2026-08-01',
 			wheelchair: true,
-			optimize: 'fewestTransfers'
+			optimize: 'fewestTransfers',
+			maxWalkDistance: 4828,
+			distanceUnit: 'metric'
 		});
 
 		const onDone = vi.fn();
@@ -140,8 +147,11 @@ describe('TripOptionsModal reset', () => {
 
 		expect(onDone).toHaveBeenCalled();
 
-		// Store is back to defaults.
+		// Store is back to defaults, including session-only departure fields.
 		const value = getStoreValue();
+		expect(value.departureType).toBe('now');
+		expect(value.departureTime).toBeNull();
+		expect(value.departureDate).toBeNull();
 		expect(value.wheelchair).toBe(false);
 		expect(value.optimize).toBe('fastest');
 		expect(value.maxWalkDistance).toBe(DEFAULT_TRIP_OPTIONS.maxWalkDistance);

--- a/src/components/trip-planner/__tests__/TripOptionsModal.test.js
+++ b/src/components/trip-planner/__tests__/TripOptionsModal.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import TripOptionsModal from '../TripOptionsModal.svelte';
+
+// Only the translation layer is mocked; the real tripOptionsStore is used so the test exercises the actual reset wiring (handleReset + DEFAULT_TRIP_OPTIONS)
+vi.mock('svelte-i18n', () => {
+	const translations = {
+		'trip-planner.cancel': 'Cancel',
+		'trip-planner.done': 'Done',
+		'trip-planner.reset_to_defaults': 'Reset to defaults',
+		'trip-planner.trip_options': 'Trip Options',
+		'trip-planner.departure_time': 'Departure Time',
+		'trip-planner.leave_now': 'Leave Now',
+		'trip-planner.depart_at': 'Depart At',
+		'trip-planner.arrive_by': 'Arrive By',
+		'trip-planner.wheelchair_accessible': 'Wheelchair accessible',
+		'trip-planner.wheelchair_desc': 'Wheelchair description',
+		'trip-planner.route_optimization': 'Route Optimization',
+		'trip-planner.fastest_trip': 'Fastest Trip',
+		'trip-planner.fewest_transfers': 'Fewest Transfers',
+		'trip-planner.walking_distance': 'Walking Distance',
+		'trip-planner.max_walking_distance': 'Maximum walking distance',
+		'trip-planner.distance_unit': 'Distance Unit',
+		'trip-planner.unit_auto': 'Auto',
+		'trip-planner.unit_metric': 'Metric',
+		'trip-planner.unit_imperial': 'Imperial'
+	};
+	return {
+		t: {
+			subscribe: vi.fn((fn) => {
+				fn((key) => translations[key] || key);
+				return { unsubscribe: () => {} };
+			})
+		}
+	};
+});
+
+function getOptionButton(label) {
+	return screen.getByText(label).closest('button');
+}
+
+describe('TripOptionsModal reset', () => {
+	let user;
+
+	beforeEach(() => {
+		user = userEvent.setup();
+	});
+
+	it('resets all locally edited options back to defaults', async () => {
+		render(TripOptionsModal, { props: { onClose: vi.fn(), onDone: vi.fn() } });
+
+		const wheelchairSwitch = screen.getByRole('switch', { name: 'Wheelchair accessible' });
+
+		// Move several options away from their defaults.
+		if (wheelchairSwitch.getAttribute('aria-checked') === 'false') {
+			await user.click(wheelchairSwitch);
+		}
+		await user.click(getOptionButton('Depart At'));
+		await user.click(getOptionButton('Fewest Transfers'));
+
+		// Confirm the non-default state took effect.
+		expect(wheelchairSwitch).toHaveAttribute('aria-checked', 'true');
+		expect(getOptionButton('Depart At')).toHaveTextContent('✓');
+		expect(getOptionButton('Fewest Transfers')).toHaveTextContent('✓');
+
+		await user.click(screen.getByText('Reset to defaults'));
+
+		// Everything is back to defaults (Leave now, no wheelchair, fastest).
+		expect(wheelchairSwitch).toHaveAttribute('aria-checked', 'false');
+		expect(getOptionButton('Leave Now')).toHaveTextContent('✓');
+		expect(getOptionButton('Fastest Trip')).toHaveTextContent('✓');
+		expect(getOptionButton('Depart At')).not.toHaveTextContent('✓');
+		expect(getOptionButton('Fewest Transfers')).not.toHaveTextContent('✓');
+	});
+
+	it('does not persist the reset until Done (Cancel keeps it draft-only)', async () => {
+		const onClose = vi.fn();
+		render(TripOptionsModal, { props: { onClose, onDone: vi.fn() } });
+
+		await user.click(screen.getByText('Reset to defaults'));
+		await user.click(screen.getByText('Cancel'));
+
+		// Cancel simply closes; the reset was never committed to the store.
+		expect(onClose).toHaveBeenCalled();
+	});
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -34,6 +34,7 @@
 		"trip_options": "Trip Options",
 		"cancel": "Cancel",
 		"done": "Done",
+		"reset_to_defaults": "Reset to defaults",
 		"departure_time": "Departure Time",
 		"leave_now": "Leave Now",
 		"depart_at": "Depart At",

--- a/src/stores/__tests__/tripOptionsStore.test.js
+++ b/src/stores/__tests__/tripOptionsStore.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Override the global vitest-setup mock: store tests need browser = true
+// so localStorage calls actually execute
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
+
+describe('tripOptionsStore', () => {
+	let tripOptions;
+	let DEFAULT_TRIP_OPTIONS;
+
+	beforeEach(async () => {
+		localStorage.getItem.mockReset();
+		localStorage.setItem.mockReset();
+		localStorage.removeItem.mockReset();
+		localStorage.clear.mockReset();
+		localStorage.getItem.mockReturnValue(null);
+
+		vi.resetModules();
+		const mod = await import('../../stores/tripOptionsStore.js');
+		tripOptions = mod.tripOptions;
+		DEFAULT_TRIP_OPTIONS = mod.DEFAULT_TRIP_OPTIONS;
+	});
+
+	function getStoreValue(store) {
+		let value;
+		store.subscribe((v) => (value = v))();
+		return value;
+	}
+
+	it('exposes the default option values', () => {
+		expect(DEFAULT_TRIP_OPTIONS).toMatchObject({
+			departureType: 'now',
+			departureTime: null,
+			departureDate: null,
+			wheelchair: false,
+			optimize: 'fastest',
+			distanceUnit: null
+		});
+	});
+
+	it('resetAll restores defaults and clears persisted values', () => {
+		tripOptions.setPersisted('wheelchair', true);
+		tripOptions.setPersisted('optimize', 'fewestTransfers');
+		tripOptions.setSession('departureType', 'arriveBy');
+
+		let value = getStoreValue(tripOptions);
+		expect(value.wheelchair).toBe(true);
+		expect(value.optimize).toBe('fewestTransfers');
+		expect(value.departureType).toBe('arriveBy');
+
+		tripOptions.resetAll();
+
+		value = getStoreValue(tripOptions);
+		expect(value.wheelchair).toBe(false);
+		expect(value.optimize).toBe('fastest');
+		expect(value.departureType).toBe('now');
+
+		// Persisted keys are removed from localStorage
+		expect(localStorage.removeItem).toHaveBeenCalledWith('tripOptions_wheelchair');
+		expect(localStorage.removeItem).toHaveBeenCalledWith('tripOptions_optimize');
+		expect(localStorage.removeItem).toHaveBeenCalledWith('tripOptions_maxWalkDistance');
+		expect(localStorage.removeItem).toHaveBeenCalledWith('tripOptions_distanceUnit');
+	});
+});

--- a/src/stores/__tests__/tripOptionsStore.test.js
+++ b/src/stores/__tests__/tripOptionsStore.test.js
@@ -41,27 +41,31 @@ describe('tripOptionsStore', () => {
 		});
 	});
 
-	it('resetAll restores defaults and clears persisted values', () => {
+	it('setPersisted writes non-default values to localStorage', () => {
 		tripOptions.setPersisted('wheelchair', true);
 		tripOptions.setPersisted('optimize', 'fewestTransfers');
-		tripOptions.setSession('departureType', 'arriveBy');
 
-		let value = getStoreValue(tripOptions);
-		expect(value.wheelchair).toBe(true);
-		expect(value.optimize).toBe('fewestTransfers');
-		expect(value.departureType).toBe('arriveBy');
+		expect(getStoreValue(tripOptions).wheelchair).toBe(true);
+		expect(localStorage.setItem).toHaveBeenCalledWith('tripOptions_wheelchair', 'true');
+		expect(localStorage.setItem).toHaveBeenCalledWith('tripOptions_optimize', 'fewestTransfers');
+	});
 
-		tripOptions.resetAll();
+	it('setPersisted clears the key when the value equals the default', () => {
+		// Setting a value back to its default should remove the key so the user
+		// tracks future default changes instead of being pinned to today's value.
+		tripOptions.setPersisted('wheelchair', false);
+		tripOptions.setPersisted('optimize', 'fastest');
+		tripOptions.setPersisted('maxWalkDistance', DEFAULT_TRIP_OPTIONS.maxWalkDistance);
 
-		value = getStoreValue(tripOptions);
-		expect(value.wheelchair).toBe(false);
-		expect(value.optimize).toBe('fastest');
-		expect(value.departureType).toBe('now');
-
-		// Persisted keys are removed from localStorage
 		expect(localStorage.removeItem).toHaveBeenCalledWith('tripOptions_wheelchair');
 		expect(localStorage.removeItem).toHaveBeenCalledWith('tripOptions_optimize');
 		expect(localStorage.removeItem).toHaveBeenCalledWith('tripOptions_maxWalkDistance');
+		expect(localStorage.setItem).not.toHaveBeenCalled();
+	});
+
+	it('setPersisted clears the key when the value is null (distanceUnit)', () => {
+		tripOptions.setPersisted('distanceUnit', null);
+
 		expect(localStorage.removeItem).toHaveBeenCalledWith('tripOptions_distanceUnit');
 	});
 });

--- a/src/stores/__tests__/tripOptionsStore.test.js
+++ b/src/stores/__tests__/tripOptionsStore.test.js
@@ -36,6 +36,7 @@ describe('tripOptionsStore', () => {
 			departureDate: null,
 			wheelchair: false,
 			optimize: 'fastest',
+			maxWalkDistance: 1609,
 			distanceUnit: null
 		});
 	});

--- a/src/stores/tripOptionsStore.js
+++ b/src/stores/tripOptionsStore.js
@@ -31,6 +31,9 @@ const defaults = {
 	distanceUnit: null // null = auto-detect, 'metric', or 'imperial'
 };
 
+// Default option values, exported so the options modal can reset its local editing copies to the same source of truth used by the store.
+export const DEFAULT_TRIP_OPTIONS = defaults;
+
 // Re-export for use by components
 export { getWalkDistanceOptions, snapToClosestOption, UNIT_METRIC, UNIT_IMPERIAL };
 

--- a/src/stores/tripOptionsStore.js
+++ b/src/stores/tripOptionsStore.js
@@ -31,7 +31,10 @@ const defaults = {
 	distanceUnit: null // null = auto-detect, 'metric', or 'imperial'
 };
 
-// Default option values, exported so the options modal can reset its local editing copies to the same source of truth used by the store. Frozen copy so consumers can't mutate the canonical `defaults` object that resetAll() uses.
+// Exported so the options modal can reset its local editing copies to the same
+// source of truth the store uses. The spread already makes this a separate
+// object from `defaults`; Object.freeze additionally stops consumers from
+// mutating this exported snapshot.
 export const DEFAULT_TRIP_OPTIONS = Object.freeze({ ...defaults });
 
 // Re-export for use by components
@@ -91,18 +94,11 @@ function createTripOptionsStore() {
 			}));
 		},
 
-		// Reset all values to defaults
-		resetAll: () => {
-			if (browser) {
-				localStorage.removeItem('tripOptions_wheelchair');
-				localStorage.removeItem('tripOptions_optimize');
-				localStorage.removeItem('tripOptions_maxWalkDistance');
-				localStorage.removeItem('tripOptions_distanceUnit');
-			}
-			set(defaults);
-		},
-
-		// Update a persisted option (saves to localStorage)
+		// Update a persisted option (saves to localStorage).
+		// Writing the default value clears the key instead of storing it, so the
+		// user tracks future changes to the default rather than being pinned to
+		// today's value. This is what makes "Reset to defaults" forward-compatible:
+		// resetting the draft to defaults and committing removes every key.
 		setPersisted: (key, value) => {
 			update((opts) => {
 				const newOpts = { ...opts, [key]: value };
@@ -110,7 +106,7 @@ function createTripOptionsStore() {
 					browser &&
 					['wheelchair', 'optimize', 'maxWalkDistance', 'distanceUnit'].includes(key)
 				) {
-					if (value === null) {
+					if (value === null || value === defaults[key]) {
 						localStorage.removeItem(`tripOptions_${key}`);
 					} else {
 						localStorage.setItem(`tripOptions_${key}`, String(value));

--- a/src/stores/tripOptionsStore.js
+++ b/src/stores/tripOptionsStore.js
@@ -31,8 +31,8 @@ const defaults = {
 	distanceUnit: null // null = auto-detect, 'metric', or 'imperial'
 };
 
-// Default option values, exported so the options modal can reset its local editing copies to the same source of truth used by the store.
-export const DEFAULT_TRIP_OPTIONS = defaults;
+// Default option values, exported so the options modal can reset its local editing copies to the same source of truth used by the store. Frozen copy so consumers can't mutate the canonical `defaults` object that resetAll() uses.
+export const DEFAULT_TRIP_OPTIONS = Object.freeze({ ...defaults });
 
 // Re-export for use by components
 export { getWalkDistanceOptions, snapToClosestOption, UNIT_METRIC, UNIT_IMPERIAL };


### PR DESCRIPTION
Fixes #491 

## What this does

Add a "Reset to defaults" button to the Trip Options modal that restores all options to their default values.

## Why it was needed

After changing several options, the only way to start fresh was to undo each setting manually. That is annoying when you want a clean search with default routing again.

## How it works

- Reset is draft-only, like every other control in the modal. handleReset() only updates local $state copies — nothing is persisted until the user clicks Done.
- Cancel discards the reset and keeps the previously saved preferences untouched.
- Done commits the reset: persisted options are written back to defaults via setPersisted, which clears localStorage keys when the value equals the default (forward-compatible — users track future default changes rather than being pinned to today's values).
- resetAll() was removed from the store; it was dead code never wired to any UI.

## How to test

1. Plan Trip → Options → change wheelchair, optimization, walk distance, etc. → Done (pills show).
2. Reopen Options → click **Reset to defaults**.
3. Confirm UI shows defaults and pills are gone.
4. Reload the page and confirm options stayed at defaults.

## SS:
<img width="1111" height="640" alt="Screenshot 2026-06-05 at 11 12 08 PM" src="https://github.com/user-attachments/assets/03d6f6df-a1d7-4955-b1fc-f14caa4518e8" />