### PR TITLE
fix: mark decorative spinner SVGs as aria-hidden

### DIFF
--- a/src/components/FullPageLoadingSpinner.svelte
+++ b/src/components/FullPageLoadingSpinner.svelte
@@ -14,6 +14,7 @@
 			xmlns="http://www.w3.org/2000/svg"
 			fill="none"
 			viewBox="0 0 24 24"
+			aria-hidden="true"
 		>
 			<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
 			></circle>

--- a/src/components/LoadingSpinner.svelte
+++ b/src/components/LoadingSpinner.svelte
@@ -14,6 +14,7 @@
 			xmlns="http://www.w3.org/2000/svg"
 			fill="none"
 			viewBox="0 0 24 24"
+			aria-hidden="true"
 		>
 			<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
 			></circle>


### PR DESCRIPTION
Fixes #509 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility by ensuring decorative loading spinners are properly hidden from screen readers, enhancing the experience for users with assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->