### PR TITLE
fix: add null safeguard and source-asymmetry test for buildVehiclePopupData

### DIFF
--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -26,11 +26,10 @@ import { t } from 'svelte-i18n';
 import { ROUTE_PANE_Z_INDEX } from '$lib/mapPanes.js';
 
 // activeTrip is always truthy here: the sole caller (vehicleUtils.js) guards on
-// it, and buildVehiclePopupData reads activeTrip.tripHeadsign without optional
-// chaining. Keep this contract consistent rather than implying null is expected.
+// it. The optional chaining here and in buildVehiclePopupData is belt-and-braces.
 function getVehicleLabel(activeTrip) {
 	const translate = get(t);
-	return activeTrip.tripHeadsign
+	return activeTrip?.tripHeadsign
 		? translate('vehicle.to_headsign', { values: { headsign: activeTrip.tripHeadsign } })
 		: translate('vehicle.label');
 }

--- a/src/lib/__tests__/vehicleUtils.test.js
+++ b/src/lib/__tests__/vehicleUtils.test.js
@@ -72,6 +72,50 @@ describe('buildVehiclePopupData', () => {
 			predicted: false
 		});
 	});
+
+	it('extracts fields from the correct sources when vehicle and activeTrip share properties', () => {
+		const vehicle = {
+			vehicleId: 'v-789',
+			lastUpdateTime: 1600000200,
+			predicted: true,
+			tripHeadsign: 'Wrong Destination' // Testing asymmetry
+		};
+		const activeTrip = {
+			tripHeadsign: 'Right Destination',
+			vehicleId: 'wrong-id' // Testing asymmetry
+		};
+		const stopsMap = new Map();
+
+		const result = buildVehiclePopupData(vehicle, activeTrip, stopsMap);
+
+		expect(result).toEqual({
+			nextDestination: 'Right Destination',
+			vehicleId: 'v-789',
+			lastUpdateTime: 1600000200,
+			nextStopName: undefined,
+			predicted: true
+		});
+	});
+
+	it('returns undefined nextDestination safely when activeTrip is undefined', () => {
+		const vehicle = {
+			vehicleId: 'v-999',
+			lastUpdateTime: 1600000300,
+			predicted: false
+		};
+		const activeTrip = undefined;
+		const stopsMap = new Map();
+
+		const result = buildVehiclePopupData(vehicle, activeTrip, stopsMap);
+
+		expect(result).toEqual({
+			nextDestination: undefined,
+			vehicleId: 'v-999',
+			lastUpdateTime: 1600000300,
+			nextStopName: undefined,
+			predicted: false
+		});
+	});
 });
 
 // This suite used to drive the now-deleted single-route `updateVehicleMarkers`

--- a/src/lib/__tests__/vehicleUtils.test.js
+++ b/src/lib/__tests__/vehicleUtils.test.js
@@ -82,7 +82,9 @@ describe('buildVehiclePopupData', () => {
 		};
 		const activeTrip = {
 			tripHeadsign: 'Right Destination',
-			vehicleId: 'wrong-id' // Testing asymmetry
+			vehicleId: 'wrong-id', // Testing asymmetry
+			lastUpdateTime: 999999999,
+			predicted: false
 		};
 		const stopsMap = new Map();
 

--- a/src/lib/__tests__/vehicleUtils.test.js
+++ b/src/lib/__tests__/vehicleUtils.test.js
@@ -48,4 +48,48 @@ describe('buildVehiclePopupData', () => {
 			predicted: false
 		});
 	});
+
+	it('extracts fields from the correct sources when vehicle and activeTrip share properties', () => {
+		const vehicle = {
+			vehicleId: 'v-789',
+			lastUpdateTime: 1600000200,
+			predicted: true,
+			tripHeadsign: 'Wrong Destination' // Testing asymmetry
+		};
+		const activeTrip = {
+			tripHeadsign: 'Right Destination',
+			vehicleId: 'wrong-id' // Testing asymmetry
+		};
+		const stopsMap = new Map();
+
+		const result = buildVehiclePopupData(vehicle, activeTrip, stopsMap);
+
+		expect(result).toEqual({
+			nextDestination: 'Right Destination',
+			vehicleId: 'v-789',
+			lastUpdateTime: 1600000200,
+			nextStopName: undefined,
+			predicted: true
+		});
+	});
+
+	it('returns undefined nextDestination safely when activeTrip is undefined', () => {
+		const vehicle = {
+			vehicleId: 'v-999',
+			lastUpdateTime: 1600000300,
+			predicted: false
+		};
+		const activeTrip = undefined;
+		const stopsMap = new Map();
+
+		const result = buildVehiclePopupData(vehicle, activeTrip, stopsMap);
+
+		expect(result).toEqual({
+			nextDestination: undefined,
+			vehicleId: 'v-999',
+			lastUpdateTime: 1600000300,
+			nextStopName: undefined,
+			predicted: false
+		});
+	});
 });

--- a/src/lib/vehicleUtils.js
+++ b/src/lib/vehicleUtils.js
@@ -95,7 +95,7 @@ export function clearVehicleMarkersMap() {
 
 export function buildVehiclePopupData(vehicle, activeTrip, stopsMap) {
 	return {
-		nextDestination: activeTrip.tripHeadsign,
+		nextDestination: activeTrip?.tripHeadsign,
 		vehicleId: vehicle.vehicleId,
 		lastUpdateTime: vehicle.lastUpdateTime,
 		nextStopName: stopsMap.get(vehicle.nextStop)?.name,

--- a/src/lib/vehicleUtils.js
+++ b/src/lib/vehicleUtils.js
@@ -267,7 +267,7 @@ export function removeVehicleMarkersForRoutes(routeIds, mapProvider) {
 
 export function buildVehiclePopupData(vehicle, activeTrip, stopsMap) {
 	return {
-		nextDestination: activeTrip.tripHeadsign,
+		nextDestination: activeTrip?.tripHeadsign,
 		vehicleId: vehicle.vehicleId,
 		lastUpdateTime: vehicle.lastUpdateTime,
 		nextStopName: stopsMap.get(vehicle.nextStop)?.name,


### PR DESCRIPTION
This PR addresses the two follow-up suggestions from the maintainer regarding `buildVehiclePopupData` edge cases.

## Changes
1. **Null Safeguard:** Added optional chaining (`activeTrip?.tripHeadsign`) inside `buildVehiclePopupData` so that if `activeTripMap.get(...)` ever returns `undefined`, the code gracefully returns `undefined` instead of throwing a fatal TypeError.
2. **Asymmetry Test:** Added a new test in `vehicleUtils.test.js` where `vehicle` and `activeTrip` have identically-named properties with different values. This explicitly proves that the helper is pulling data from the correct source object.
3. **Null-State Test:** Added a test that passes `undefined` for `activeTrip` to guarantee the optional chaining correctly prevents crashes.

Closes #508


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented vehicle labels and popup details from failing when trip information is unavailable.
  * Vehicle information now remains visible even when no active trip or destination is present.

* **Tests**
  * Added coverage for missing trip data and overlapping vehicle/trip fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->