### PR TITLE
fix(types): add Stop/MapProvider typedefs and type Tier-1 component props

### DIFF
--- a/src/components/map/MapView.svelte
+++ b/src/components/map/MapView.svelte
@@ -19,8 +19,8 @@
 	 * @property {any} [selectedRoute]
 	 * @property {boolean} [showRoute]
 	 * @property {boolean} [showRouteMap]
-	 * @property {any} [mapProvider]
-	 * @property {any} [stop] - Currently selected stop to preserve visual context
+	 * @property {import('$lib/types').MapProvider | null} [mapProvider]
+	 * @property {import('$lib/types').Stop | null} [stop] - Currently selected stop to preserve visual context
 	 * @property {{ lat: number, lng: number } | null} [initialCoords] - Optional initial coordinates from URL params
 	 */
 

--- a/src/components/oba/TripDetailsPane.svelte
+++ b/src/components/oba/TripDetailsPane.svelte
@@ -7,9 +7,9 @@
 
 	/**
 	 * @typedef {Object} Props
-	 * @property {any} stop
-	 * @property {any} tripId
-	 * @property {any} [serviceDate]
+	 * @property {import('$lib/types').Stop} stop
+	 * @property {string} tripId
+	 * @property {number | null} [serviceDate]
 	 */
 
 	/** @type {Props} */

--- a/src/components/search/SearchResultItem.svelte
+++ b/src/components/search/SearchResultItem.svelte
@@ -5,9 +5,9 @@
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 	/**
 	 * @typedef {Object} Props
-	 * @property {any} [icon]
-	 * @property {any} [title]
-	 * @property {any} [subtitle]
+	 * @property {import('@fortawesome/fontawesome-svg-core').IconDefinition | null} [icon]
+	 * @property {string | null} [title]
+	 * @property {string | null} [subtitle]
 	 */
 
 	/** @type {Props} */

--- a/src/components/trip-planner/TripPlanModal.svelte
+++ b/src/components/trip-planner/TripPlanModal.svelte
@@ -9,9 +9,9 @@
 
 	/**
 	 * @typedef {Object} Props
-	 * @property {any} mapProvider
+	 * @property {import('$lib/types').MapProvider} mapProvider
 	 * @property {any} [itineraries]
-	 * @property {any} [error]
+	 * @property {string | null} [error]
 	 * @property {boolean} [loading]
 	 * @property {Function} closePane
 	 */

--- a/src/components/trip-planner/TripPlanSearchField.svelte
+++ b/src/components/trip-planner/TripPlanSearchField.svelte
@@ -8,8 +8,8 @@
 	 * @property {string} [place]
 	 * @property {any} [results]
 	 * @property {boolean} [isLoading]
-	 * @property {any} onInput
-	 * @property {any} onClear
+	 * @property {(value: string) => void} onInput
+	 * @property {() => void} onClear
 	 * @property {any} onSelect
 	 */
 

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -1,0 +1,28 @@
+/**
+ * Shared JSDoc type definitions used across components.
+ *
+ * This module intentionally contains no runtime code. It centralizes type
+ * definitions so components can reference them via `import('$lib/types').Name`.
+ */
+
+/**
+ * A map provider instance, as created in MapContainer.svelte. Either the
+ * Leaflet/OpenStreetMap implementation or the Google Maps implementation; both
+ * expose the same interface (initMap, addMarker, panTo, flyTo, ...).
+ *
+ * @typedef {import('./Provider/OpenStreetMapProvider.svelte.js').default
+ * 	| import('./Provider/GoogleMapProvider.svelte.js').default} MapProvider
+ */
+
+/**
+ * A transit stop from the OneBusAway "stops-for-location" endpoint, augmented
+ * at runtime with resolved `routes`. The SDK list item only carries `routeIds`;
+ * MapView.svelte joins those ids against the response's route references and
+ * attaches the resulting `routes` array before passing the stop to markers and
+ * panes. Route references may also carry a non-SDK `code` field.
+ *
+ * @typedef {import('onebusaway-sdk/resources/stops-for-location').StopsForLocationListResponse.Data.List
+ * 	& { routes?: (import('onebusaway-sdk/resources/shared').References.Route & { code?: string })[] }} Stop
+ */
+
+export {};


### PR DESCRIPTION
Refs #404 — partial contribution; leaves the issue open for the remaining work.
Adds src/lib/types.js with shared Stop and MapProvider typedefs, and replaces any on the unambiguous props of five components not covered by the existing PRs:

TripDetailsPane
SearchResultItem
MapView
TripPlanModal
TripPlanSearchField

The four example files (StopMarker, StopPane, TabLink, Accordion) are intentionally untouched — already covered by #417 and #477.
AccordionItem.data is left generic on purpose: it's a reusable container holding different payloads at each call site, so narrowing it would be incorrect.
Object-shape props (itineraries, geocode results / onSelect, selectedTrip / selectedRoute) are deferred to a follow-up PR that defines their typedefs.

