### PR TITLE
Umami analytics contract compliance (#523)

### DIFF
--- a/docs/superpowers/plans/2026-06-22-umami-analytics.md
+++ b/docs/superpowers/plans/2026-06-22-umami-analytics.md
@@ -1,0 +1,452 @@
+# Umami Analytics Contract Compliance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the three gaps between Wayfinder's existing Umami analytics adapter and issue [#523](https://github.com/OneBusAway/wayfinder/issues/523)'s contract: detect Umami's silent bot-drop (`beep/boop`), send a non-bot-flagged fallback User-Agent, and sanitize/truncate event `data`.
+
+**Architecture:** All changes are confined to one file — `src/lib/Analytics/adapters/UmamiAdapter.js` — and its test file. Three small exported helpers (`sanitizeData`, `isSuccessfulIngest`) plus one constant (`FALLBACK_USER_AGENT`), each wired into the existing `forwardEvent`. No new endpoints, no call-site changes, no new dependencies. The `/api/events` endpoint already catches thrown errors and maps `error.upstreamStatus` to the HTTP status.
+
+**Tech Stack:** SvelteKit 5, Vitest (jsdom), native `fetch` + `AbortController`.
+
+**Spec:** `docs/superpowers/specs/2026-06-22-umami-analytics-design.md`
+
+## Global Constraints
+
+- **No new dependencies.** Do not add `isbot` or anything else. The fallback-UA test is a self-contained token check.
+- **Fire-and-forget is sacred.** No change may make analytics block, or surface to a user. The adapter throws; the `/api/events` endpoint catches; the client facade swallows. Never `await` analytics in a UI path (already true — don't change it).
+- **Test runner:** `npx vitest run <path>` — NOT `npm run test` (hangs in non-TTY in this repo).
+- **Config source is env vars** (`PUBLIC_ANALYTICS_*`). Region-feed discovery is out of scope.
+- Constants (copy verbatim): `FALLBACK_USER_AGENT = 'Mozilla/5.0 (Wayfinder)'`, `MAX_DATA_VALUE_LENGTH = 256`, beep/boop `upstreamStatus = 502`, drop message = `'Umami dropped event as bot-like (isbot rejected the User-Agent)'`.
+
+---
+
+## File Structure
+
+- **Modify** `src/lib/Analytics/adapters/UmamiAdapter.js`
+  - Add module-level `FALLBACK_USER_AGENT`, `MAX_DATA_VALUE_LENGTH`.
+  - Add exported `sanitizeData(props)` — pure props sanitizer.
+  - Add exported `isSuccessfulIngest(body)` — pure response classifier.
+  - Wire all three into the existing `forwardEvent`.
+- **Modify** `src/tests/lib/Analytics/adapters/UmamiAdapter.test.js`
+  - Add unit tests for `sanitizeData` and `isSuccessfulIngest`.
+  - Add a `forwardEvent` beep/boop failure test and a fallback-UA regression guard.
+  - Update three existing tests whose mocked response bodies are no longer "success" under the new contract (the `'ok'` test at ~line 171 and the two `'{}'` mocks at ~lines 207 and 236).
+
+Tasks are ordered so **all tests are green after every task** (Tasks 1 and 2 don't change the response-success contract; Task 3 does, and updates the affected tests in the same task).
+
+---
+
+## Task 1: `sanitizeData` — sanitize/truncate event props
+
+**Files:**
+- Modify: `src/lib/Analytics/adapters/UmamiAdapter.js`
+- Test: `src/tests/lib/Analytics/adapters/UmamiAdapter.test.js`
+
+**Interfaces:**
+- Produces: `export function sanitizeData(props: object): object` — drops `null`/`undefined`; keeps `boolean`; keeps `string` truncated to 256 chars; keeps `number` only when `Number.isFinite`; `JSON.stringify`s everything else then truncates to 256.
+- Consumes: nothing from other tasks.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this block to `src/tests/lib/Analytics/adapters/UmamiAdapter.test.js` (import line at top becomes `import { UmamiAdapter, sanitizeData } from '$lib/Analytics/adapters/UmamiAdapter.js';`):
+
+```js
+describe('sanitizeData', () => {
+	it('keeps strings, finite numbers, and booleans', () => {
+		expect(sanitizeData({ s: 'hi', n: 42, b: true })).toEqual({ s: 'hi', n: 42, b: true });
+	});
+
+	it('drops null and undefined values', () => {
+		expect(sanitizeData({ a: null, b: undefined, c: 'keep' })).toEqual({ c: 'keep' });
+	});
+
+	it('drops non-finite numbers', () => {
+		expect(sanitizeData({ a: NaN, b: Infinity, c: -Infinity, d: 1 })).toEqual({ d: 1 });
+	});
+
+	it('truncates strings to 256 characters', () => {
+		const long = 'x'.repeat(300);
+		expect(sanitizeData({ q: long }).q).toHaveLength(256);
+	});
+
+	it('JSON-stringifies nested objects and arrays', () => {
+		expect(sanitizeData({ o: { a: 1 }, arr: [1, 2] })).toEqual({
+			o: '{"a":1}',
+			arr: '[1,2]'
+		});
+	});
+
+	it('returns an empty object for empty or nullish input', () => {
+		expect(sanitizeData({})).toEqual({});
+		expect(sanitizeData(undefined)).toEqual({});
+	});
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/tests/lib/Analytics/adapters/UmamiAdapter.test.js -t sanitizeData`
+Expected: FAIL — `sanitizeData is not a function` (not exported yet).
+
+- [ ] **Step 3: Implement `sanitizeData`**
+
+In `src/lib/Analytics/adapters/UmamiAdapter.js`, add below the existing `const UPSTREAM_TIMEOUT_MS = 5000;` line:
+
+```js
+const MAX_DATA_VALUE_LENGTH = 256;
+
+/**
+ * Coerce arbitrary event props into Umami-safe `data` values: keep strings (truncated),
+ * finite numbers, and booleans; drop null/undefined and non-finite numbers; JSON-stringify
+ * anything else (truncated). Bounds uncontrolled user input (e.g. the free-text search query).
+ * @param {Object} [props]
+ * @returns {Object}
+ */
+export function sanitizeData(props) {
+	const out = {};
+	for (const [key, value] of Object.entries(props ?? {})) {
+		if (value === null || value === undefined) continue;
+		const type = typeof value;
+		if (type === 'boolean') {
+			out[key] = value;
+		} else if (type === 'string') {
+			out[key] = value.slice(0, MAX_DATA_VALUE_LENGTH);
+		} else if (type === 'number') {
+			if (Number.isFinite(value)) out[key] = value;
+		} else {
+			out[key] = JSON.stringify(value).slice(0, MAX_DATA_VALUE_LENGTH);
+		}
+	}
+	return out;
+}
+```
+
+- [ ] **Step 4: Wire it into `forwardEvent`**
+
+In the same file, in `forwardEvent`, change the payload's `data` line from:
+
+```js
+			data: props
+```
+
+to:
+
+```js
+			data: sanitizeData(props)
+```
+
+- [ ] **Step 5: Run the full adapter test file to verify all pass**
+
+Run: `npx vitest run src/tests/lib/Analytics/adapters/UmamiAdapter.test.js`
+Expected: PASS (new `sanitizeData` tests + all existing tests — the existing `data: { id: '1_00' }` and `data: {}` assertions are unaffected because those values pass through unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/Analytics/adapters/UmamiAdapter.js src/tests/lib/Analytics/adapters/UmamiAdapter.test.js
+git commit -m "feat(analytics): sanitize and truncate Umami event data (#523)"
+```
+
+---
+
+## Task 2: Browser-shaped fallback User-Agent
+
+**Files:**
+- Modify: `src/lib/Analytics/adapters/UmamiAdapter.js`
+- Test: `src/tests/lib/Analytics/adapters/UmamiAdapter.test.js`
+
+**Interfaces:**
+- Produces: `export const FALLBACK_USER_AGENT = 'Mozilla/5.0 (Wayfinder)'` — used as the `User-Agent` header when `requestContext.userAgent` is empty. Must contain no isbot token and must not be a bare `Mozilla/x.x <token>` string.
+- Consumes: nothing from other tasks.
+
+> Why this exact string: `isbot` matches case-insensitively and unanchored, and its `patterns.json` includes the literal token `server` — so `Mozilla/5.0 (Wayfinder) Server/1.0` would be bot-dropped. `Mozilla/5.0 (Wayfinder)` has no bot token, and the `(` breaks isbot's `^mozilla/\d\.\d\s[\w.-]+$` bare-Mozilla anchor.
+
+- [ ] **Step 1: Write the failing tests**
+
+Update the import at the top of the test file to include the constant:
+`import { UmamiAdapter, sanitizeData, FALLBACK_USER_AGENT } from '$lib/Analytics/adapters/UmamiAdapter.js';`
+
+Find the existing test (currently ~line 206):
+
+```js
+	it('falls back to Wayfinder/1.0 User-Agent when context omits it', async () => {
+		global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{}' });
+		await new UmamiAdapter(fullEnv).forwardEvent(envelope, { userAgent: '', clientIp: '' });
+		const [, init] = global.fetch.mock.calls[0];
+		expect(init.headers['User-Agent']).toBe('Wayfinder/1.0');
+	});
+```
+
+Replace it with (note: the mock body stays `'{}'` for now — Task 3 changes the success contract and updates this mock):
+
+```js
+	it('falls back to the browser-shaped User-Agent when context omits it', async () => {
+		global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{}' });
+		await new UmamiAdapter(fullEnv).forwardEvent(envelope, { userAgent: '', clientIp: '' });
+		const [, init] = global.fetch.mock.calls[0];
+		expect(init.headers['User-Agent']).toBe('Mozilla/5.0 (Wayfinder)');
+	});
+```
+
+Then add a new regression-guard test in the same `describe('UmamiAdapter.forwardEvent (edge cases)')` block:
+
+```js
+	it('fallback User-Agent contains no isbot bot tokens', () => {
+		const tokens = ['server', 'bot', 'http', 'crawl', 'scan', 'search', 'spider', 'agent'];
+		const ua = FALLBACK_USER_AGENT.toLowerCase();
+		for (const token of tokens) {
+			expect(ua).not.toContain(token);
+		}
+	});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/tests/lib/Analytics/adapters/UmamiAdapter.test.js -t "User-Agent"`
+Expected: FAIL — `FALLBACK_USER_AGENT is undefined` and the fallback test asserts the new string against the old `'Wayfinder/1.0'`.
+
+- [ ] **Step 3: Implement the constant and use it**
+
+In `src/lib/Analytics/adapters/UmamiAdapter.js`, add below `const MAX_DATA_VALUE_LENGTH = 256;`:
+
+```js
+// Sent when no end-user User-Agent is available. Must survive Umami's isbot filter:
+// no bot token (isbot matches `server`/`bot`/etc. unanchored, case-insensitively) and
+// not a bare `Mozilla/x.x <token>` string (the `(` breaks isbot's anchored pattern).
+export const FALLBACK_USER_AGENT = 'Mozilla/5.0 (Wayfinder)';
+```
+
+Then in `forwardEvent`, change the header line from:
+
+```js
+		'User-Agent': requestContext.userAgent || 'Wayfinder/1.0'
+```
+
+to:
+
+```js
+		'User-Agent': requestContext.userAgent || FALLBACK_USER_AGENT
+```
+
+- [ ] **Step 4: Run the full adapter test file to verify all pass**
+
+Run: `npx vitest run src/tests/lib/Analytics/adapters/UmamiAdapter.test.js`
+Expected: PASS (the `'{}'` mock still resolves via the existing `JSON.parse` path — the success contract is unchanged until Task 3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/Analytics/adapters/UmamiAdapter.js src/tests/lib/Analytics/adapters/UmamiAdapter.test.js
+git commit -m "fix(analytics): use non-bot fallback User-Agent for Umami (#523)"
+```
+
+---
+
+## Task 3: `beep/boop` ingest-failure detection
+
+**Files:**
+- Modify: `src/lib/Analytics/adapters/UmamiAdapter.js`
+- Test: `src/tests/lib/Analytics/adapters/UmamiAdapter.test.js`
+
+**Interfaces:**
+- Produces: `export function isSuccessfulIngest(body: string): boolean` — `true` for an empty string or a body containing `cache`/`sessionId`/`visitId`; `false` for a body containing `beep` or any other non-empty body.
+- Consumes: `FALLBACK_USER_AGENT` already in the module (Task 2); the `/api/events` endpoint's existing `error.upstreamStatus` mapping (no change needed there).
+
+> This task **changes the response-success contract**, so three existing tests that mocked non-success bodies (`'ok'`, `'{}'`, `'{}'`) must be updated in the same task to keep the suite green.
+
+- [ ] **Step 1: Write the failing tests**
+
+Update the import to include the new export:
+`import { UmamiAdapter, sanitizeData, FALLBACK_USER_AGENT, isSuccessfulIngest } from '$lib/Analytics/adapters/UmamiAdapter.js';`
+
+Add a new top-level describe block:
+
+```js
+describe('isSuccessfulIngest', () => {
+	it('treats a beep/boop body as failure', () => {
+		expect(isSuccessfulIngest('{"beep":"boop"}')).toBe(false);
+	});
+
+	it('treats a body with cache/sessionId/visitId as success', () => {
+		expect(isSuccessfulIngest('{"cache":"c","sessionId":"s","visitId":"v"}')).toBe(true);
+		expect(isSuccessfulIngest('{"sessionId":"s"}')).toBe(true);
+	});
+
+	it('treats an empty body as success', () => {
+		expect(isSuccessfulIngest('')).toBe(true);
+	});
+
+	it('treats a bare {} body as failure', () => {
+		expect(isSuccessfulIngest('{}')).toBe(false);
+	});
+
+	it('treats any other non-empty body without a marker as failure', () => {
+		expect(isSuccessfulIngest('ok')).toBe(false);
+	});
+
+	it('does not throw on a non-JSON body', () => {
+		expect(() => isSuccessfulIngest('<html>error</html>')).not.toThrow();
+		expect(isSuccessfulIngest('<html>error</html>')).toBe(false);
+	});
+});
+```
+
+Add a `forwardEvent` failure test to the `describe('UmamiAdapter.forwardEvent (edge cases)')` block:
+
+```js
+	it('throws with upstreamStatus 502 when Umami drops the event (beep/boop)', async () => {
+		global.fetch = vi
+			.fn()
+			.mockResolvedValue({ ok: true, status: 200, text: async () => '{"beep":"boop"}' });
+		try {
+			await new UmamiAdapter(fullEnv).forwardEvent(envelope, ctx);
+			expect.unreachable('should have thrown');
+		} catch (error) {
+			expect(error.message).toContain('dropped event');
+			expect(error.upstreamStatus).toBe(502);
+		}
+	});
+```
+
+Now update the THREE existing tests whose mocked bodies are no longer "success":
+
+1. The non-JSON test (currently ~line 171) — a non-marker body is now a failure. Replace:
+
+```js
+	it('returns { status: text } when response is not JSON', async () => {
+		global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => 'ok' });
+		const result = await new UmamiAdapter(fullEnv).forwardEvent(envelope, ctx);
+		expect(result).toEqual({ status: 'ok' });
+	});
+```
+
+with:
+
+```js
+	it('throws when the response body lacks a success marker', async () => {
+		global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => 'ok' });
+		await expect(new UmamiAdapter(fullEnv).forwardEvent(envelope, ctx)).rejects.toThrow(
+			'dropped event'
+		);
+	});
+```
+
+2. The fallback-UA test (updated in Task 2, ~line 206) — change its mock body from `'{}'` to a success marker so the UA assertion is reached without throwing:
+
+```js
+		global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{"cache":"x"}' });
+```
+
+3. The AbortSignal test (~line 236) — same mock-body change:
+
+```js
+		global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{"cache":"x"}' });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/tests/lib/Analytics/adapters/UmamiAdapter.test.js -t "isSuccessfulIngest"`
+Expected: FAIL — `isSuccessfulIngest is not a function`.
+
+- [ ] **Step 3: Implement `isSuccessfulIngest`**
+
+In `src/lib/Analytics/adapters/UmamiAdapter.js`, add below the `sanitizeData` function:
+
+```js
+/**
+ * Classify a Umami /api/send response body. Umami silently drops bot-like requests with
+ * HTTP 200 + {"beep":"boop"}; a real ingest returns cache/sessionId/visitId. Tolerant of
+ * non-JSON bodies (substring checks, never throws).
+ * @param {string} body
+ * @returns {boolean}
+ */
+export function isSuccessfulIngest(body) {
+	if (body === '') return true;
+	if (body.includes('beep')) return false;
+	return body.includes('cache') || body.includes('sessionId') || body.includes('visitId');
+}
+```
+
+- [ ] **Step 4: Wire it into `forwardEvent`**
+
+In `forwardEvent`, replace the success tail:
+
+```js
+		const text = await res.text();
+		try {
+			return JSON.parse(text);
+		} catch {
+			return { status: text };
+		}
+```
+
+with:
+
+```js
+		const text = await res.text();
+		if (!isSuccessfulIngest(text)) {
+			const err = new Error('Umami dropped event as bot-like (isbot rejected the User-Agent)');
+			err.upstreamStatus = 502;
+			throw err;
+		}
+		try {
+			return JSON.parse(text);
+		} catch {
+			return { status: text };
+		}
+```
+
+- [ ] **Step 5: Run the full adapter test file to verify all pass**
+
+Run: `npx vitest run src/tests/lib/Analytics/adapters/UmamiAdapter.test.js`
+Expected: PASS — new `isSuccessfulIngest` tests, the beep/boop `forwardEvent` test, and all three updated existing tests.
+
+- [ ] **Step 6: Run the whole analytics + events suite for regressions**
+
+Run: `npx vitest run src/tests/lib/Analytics src/tests/api/events.test.js`
+Expected: PASS. (`events.test.js` exercises the adapter through the route; its Umami success mocks already carry markers — `{cache,sessionId,visitId}` and `{cache:'c'}` — and its incomplete-config test short-circuits before fetch, so the new 502 path does not affect it. Verified during planning; this step just guards against regressions.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/Analytics/adapters/UmamiAdapter.js src/tests/lib/Analytics/adapters/UmamiAdapter.test.js
+git commit -m "fix(analytics): detect Umami beep/boop bot-drop as failure (#523)"
+```
+
+---
+
+## Task 4: Full verification & lint
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npx vitest run`
+Expected: PASS, no regressions across the repo.
+
+- [ ] **Step 2: Lint/format**
+
+Run: `npm run lint`
+Expected: clean. If it reports formatting, run `npm run format` and re-run `npm run lint`.
+
+- [ ] **Step 3: Commit any formatting fixes (only if `npm run format` changed files)**
+
+```bash
+git add -A
+git commit -m "style: format Umami analytics changes (#523)"
+```
+
+- [ ] **Step 4: Manual verification (not automatable — record results in the PR)**
+
+1. In `.env`, set `PUBLIC_ANALYTICS_PROVIDER=umami`, plus `PUBLIC_ANALYTICS_API_HOST`, `PUBLIC_ANALYTICS_WEBSITE_ID`, `PUBLIC_ANALYTICS_DOMAIN` pointed at the live Umami host + website UUID.
+2. `npm run dev`; exercise pageview / search / stop-view / route-click / arrival-click.
+3. Confirm events appear under the correct website UUID in the Umami dashboard, and that the ingest response is `cache/sessionId/visitId` — not `beep/boop`.
+4. Confirm `PUBLIC_ANALYTICS_PROVIDER=none` emits nothing.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** Fix #1 (beep/boop) → Task 3. Fix #2 (fallback UA) → Task 2. Fix #3 (sanitizeData) → Task 1. The spec's "two `{}` mocks must update" plus the additionally-discovered `'ok'` test → all three updated in Task 3. Manual acceptance → Task 4.
+- **Out of scope (no tasks, intentional):** region-feed discovery, new event types, Plausible removal, JS tracker.
+- **Type consistency:** `sanitizeData(props) → object`, `isSuccessfulIngest(body: string) → boolean`, `FALLBACK_USER_AGENT: string` are used identically wherever referenced. `upstreamStatus = 502` is the single drop status; `MAX_DATA_VALUE_LENGTH = 256` is the single truncation bound.

--- a/docs/superpowers/plans/2026-06-22-umami-analytics.md
+++ b/docs/superpowers/plans/2026-06-22-umami-analytics.md
@@ -39,10 +39,12 @@ Tasks are ordered so **all tests are green after every task** (Tasks 1 and 2 don
 ## Task 1: `sanitizeData` — sanitize/truncate event props
 
 **Files:**
+
 - Modify: `src/lib/Analytics/adapters/UmamiAdapter.js`
 - Test: `src/tests/lib/Analytics/adapters/UmamiAdapter.test.js`
 
 **Interfaces:**
+
 - Produces: `export function sanitizeData(props: object): object` — drops `null`/`undefined`; keeps `boolean`; keeps `string` truncated to 256 chars; keeps `number` only when `Number.isFinite`; `JSON.stringify`s everything else then truncates to 256.
 - Consumes: nothing from other tasks.
 
@@ -126,13 +128,13 @@ export function sanitizeData(props) {
 In the same file, in `forwardEvent`, change the payload's `data` line from:
 
 ```js
-			data: props
+data: props;
 ```
 
 to:
 
 ```js
-			data: sanitizeData(props)
+data: sanitizeData(props);
 ```
 
 - [ ] **Step 5: Run the full adapter test file to verify all pass**
@@ -152,10 +154,12 @@ git commit -m "feat(analytics): sanitize and truncate Umami event data (#523)"
 ## Task 2: Browser-shaped fallback User-Agent
 
 **Files:**
+
 - Modify: `src/lib/Analytics/adapters/UmamiAdapter.js`
 - Test: `src/tests/lib/Analytics/adapters/UmamiAdapter.test.js`
 
 **Interfaces:**
+
 - Produces: `export const FALLBACK_USER_AGENT = 'Mozilla/5.0 (Wayfinder)'` — used as the `User-Agent` header when `requestContext.userAgent` is empty. Must contain no isbot token and must not be a bare `Mozilla/x.x <token>` string.
 - Consumes: nothing from other tasks.
 
@@ -169,35 +173,35 @@ Update the import at the top of the test file to include the constant:
 Find the existing test (currently ~line 206):
 
 ```js
-	it('falls back to Wayfinder/1.0 User-Agent when context omits it', async () => {
-		global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{}' });
-		await new UmamiAdapter(fullEnv).forwardEvent(envelope, { userAgent: '', clientIp: '' });
-		const [, init] = global.fetch.mock.calls[0];
-		expect(init.headers['User-Agent']).toBe('Wayfinder/1.0');
-	});
+it('falls back to Wayfinder/1.0 User-Agent when context omits it', async () => {
+	global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{}' });
+	await new UmamiAdapter(fullEnv).forwardEvent(envelope, { userAgent: '', clientIp: '' });
+	const [, init] = global.fetch.mock.calls[0];
+	expect(init.headers['User-Agent']).toBe('Wayfinder/1.0');
+});
 ```
 
 Replace it with (note: the mock body stays `'{}'` for now — Task 3 changes the success contract and updates this mock):
 
 ```js
-	it('falls back to the browser-shaped User-Agent when context omits it', async () => {
-		global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{}' });
-		await new UmamiAdapter(fullEnv).forwardEvent(envelope, { userAgent: '', clientIp: '' });
-		const [, init] = global.fetch.mock.calls[0];
-		expect(init.headers['User-Agent']).toBe('Mozilla/5.0 (Wayfinder)');
-	});
+it('falls back to the browser-shaped User-Agent when context omits it', async () => {
+	global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{}' });
+	await new UmamiAdapter(fullEnv).forwardEvent(envelope, { userAgent: '', clientIp: '' });
+	const [, init] = global.fetch.mock.calls[0];
+	expect(init.headers['User-Agent']).toBe('Mozilla/5.0 (Wayfinder)');
+});
 ```
 
 Then add a new regression-guard test in the same `describe('UmamiAdapter.forwardEvent (edge cases)')` block:
 
 ```js
-	it('fallback User-Agent contains no isbot bot tokens', () => {
-		const tokens = ['server', 'bot', 'http', 'crawl', 'scan', 'search', 'spider', 'agent'];
-		const ua = FALLBACK_USER_AGENT.toLowerCase();
-		for (const token of tokens) {
-			expect(ua).not.toContain(token);
-		}
-	});
+it('fallback User-Agent contains no isbot bot tokens', () => {
+	const tokens = ['server', 'bot', 'http', 'crawl', 'scan', 'search', 'spider', 'agent'];
+	const ua = FALLBACK_USER_AGENT.toLowerCase();
+	for (const token of tokens) {
+		expect(ua).not.toContain(token);
+	}
+});
 ```
 
 - [ ] **Step 2: Run the tests to verify they fail**
@@ -245,10 +249,12 @@ git commit -m "fix(analytics): use non-bot fallback User-Agent for Umami (#523)"
 ## Task 3: `beep/boop` ingest-failure detection
 
 **Files:**
+
 - Modify: `src/lib/Analytics/adapters/UmamiAdapter.js`
 - Test: `src/tests/lib/Analytics/adapters/UmamiAdapter.test.js`
 
 **Interfaces:**
+
 - Produces: `export function isSuccessfulIngest(body: string): boolean` — `true` for an empty string or a body containing `cache`/`sessionId`/`visitId`; `false` for a body containing `beep` or any other non-empty body.
 - Consumes: `FALLBACK_USER_AGENT` already in the module (Task 2); the `/api/events` endpoint's existing `error.upstreamStatus` mapping (no change needed there).
 
@@ -294,18 +300,18 @@ describe('isSuccessfulIngest', () => {
 Add a `forwardEvent` failure test to the `describe('UmamiAdapter.forwardEvent (edge cases)')` block:
 
 ```js
-	it('throws with upstreamStatus 502 when Umami drops the event (beep/boop)', async () => {
-		global.fetch = vi
-			.fn()
-			.mockResolvedValue({ ok: true, status: 200, text: async () => '{"beep":"boop"}' });
-		try {
-			await new UmamiAdapter(fullEnv).forwardEvent(envelope, ctx);
-			expect.unreachable('should have thrown');
-		} catch (error) {
-			expect(error.message).toContain('dropped event');
-			expect(error.upstreamStatus).toBe(502);
-		}
-	});
+it('throws with upstreamStatus 502 when Umami drops the event (beep/boop)', async () => {
+	global.fetch = vi
+		.fn()
+		.mockResolvedValue({ ok: true, status: 200, text: async () => '{"beep":"boop"}' });
+	try {
+		await new UmamiAdapter(fullEnv).forwardEvent(envelope, ctx);
+		expect.unreachable('should have thrown');
+	} catch (error) {
+		expect(error.message).toContain('dropped event');
+		expect(error.upstreamStatus).toBe(502);
+	}
+});
 ```
 
 Now update the THREE existing tests whose mocked bodies are no longer "success":
@@ -313,34 +319,34 @@ Now update the THREE existing tests whose mocked bodies are no longer "success":
 1. The non-JSON test (currently ~line 171) — a non-marker body is now a failure. Replace:
 
 ```js
-	it('returns { status: text } when response is not JSON', async () => {
-		global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => 'ok' });
-		const result = await new UmamiAdapter(fullEnv).forwardEvent(envelope, ctx);
-		expect(result).toEqual({ status: 'ok' });
-	});
+it('returns { status: text } when response is not JSON', async () => {
+	global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => 'ok' });
+	const result = await new UmamiAdapter(fullEnv).forwardEvent(envelope, ctx);
+	expect(result).toEqual({ status: 'ok' });
+});
 ```
 
 with:
 
 ```js
-	it('throws when the response body lacks a success marker', async () => {
-		global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => 'ok' });
-		await expect(new UmamiAdapter(fullEnv).forwardEvent(envelope, ctx)).rejects.toThrow(
-			'dropped event'
-		);
-	});
+it('throws when the response body lacks a success marker', async () => {
+	global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => 'ok' });
+	await expect(new UmamiAdapter(fullEnv).forwardEvent(envelope, ctx)).rejects.toThrow(
+		'dropped event'
+	);
+});
 ```
 
 2. The fallback-UA test (updated in Task 2, ~line 206) — change its mock body from `'{}'` to a success marker so the UA assertion is reached without throwing:
 
 ```js
-		global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{"cache":"x"}' });
+global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{"cache":"x"}' });
 ```
 
 3. The AbortSignal test (~line 236) — same mock-body change:
 
 ```js
-		global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{"cache":"x"}' });
+global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{"cache":"x"}' });
 ```
 
 - [ ] **Step 2: Run the tests to verify they fail**
@@ -372,28 +378,28 @@ export function isSuccessfulIngest(body) {
 In `forwardEvent`, replace the success tail:
 
 ```js
-		const text = await res.text();
-		try {
-			return JSON.parse(text);
-		} catch {
-			return { status: text };
-		}
+const text = await res.text();
+try {
+	return JSON.parse(text);
+} catch {
+	return { status: text };
+}
 ```
 
 with:
 
 ```js
-		const text = await res.text();
-		if (!isSuccessfulIngest(text)) {
-			const err = new Error('Umami dropped event as bot-like (isbot rejected the User-Agent)');
-			err.upstreamStatus = 502;
-			throw err;
-		}
-		try {
-			return JSON.parse(text);
-		} catch {
-			return { status: text };
-		}
+const text = await res.text();
+if (!isSuccessfulIngest(text)) {
+	const err = new Error('Umami dropped event as bot-like (isbot rejected the User-Agent)');
+	err.upstreamStatus = 502;
+	throw err;
+}
+try {
+	return JSON.parse(text);
+} catch {
+	return { status: text };
+}
 ```
 
 - [ ] **Step 5: Run the full adapter test file to verify all pass**

--- a/docs/superpowers/specs/2026-06-22-umami-analytics-design.md
+++ b/docs/superpowers/specs/2026-06-22-umami-analytics-design.md
@@ -91,7 +91,8 @@ so they are unit-testable in isolation, mirroring Twilio's standalone
 ```js
 // A dropped event returns HTTP 200, not an error. Umami replies {"beep":"boop"}
 // (or a body lacking cache/sessionId/visitId) when isbot rejects the request.
-// Tolerant of non-JSON: fall back to a substring check for "beep".
+// Detection is key-based (parse JSON, check top-level keys), not substring, so a
+// marker word in an error message isn't mistaken for success. Never throws.
 export function isSuccessfulIngest(body) {
 	/* ... */
 }
@@ -101,13 +102,15 @@ Contract (verified against Umami source — a real success response is always
 `{cache, sessionId, visitId}`; the bot drop is the only `beep/boop` path):
 
 - The check runs against the **response** body only, never the request.
-- A body containing the substring `"beep"` → **failure** (the `{"beep":"boop"}` drop).
-- **Success** when the body is an **empty string** OR contains one of
-  `cache` / `sessionId` / `visitId`.
+- An **empty string** body → **success** (tolerates an empty/204-style upstream).
+- Otherwise parse the body as JSON. A non-JSON body (e.g. an HTML error page) →
+  **failure**, without throwing.
+- A parsed object with a top-level `beep` key → **failure** (the `{"beep":"boop"}` drop).
+- **Success** when the parsed object has a top-level `cache` / `sessionId` / `visitId`
+  key. Key-based, not substring — `{"error":"missing sessionId"}` is a **failure**,
+  not a false success.
 - **Any other body → failure**, including a bare `{}` (no success marker). This is
   deliberate: Umami never returns `{}` on a real success.
-- Parsing is tolerant: a non-JSON body must not throw; fall back to the `"beep"`
-  substring check.
 
 > **Test impact (must-fix):** two existing tests mock `text: async () => '{}'`
 > (`UmamiAdapter.test.js` lines 207 and 236 — the fallback-UA and AbortSignal tests).

--- a/docs/superpowers/specs/2026-06-22-umami-analytics-design.md
+++ b/docs/superpowers/specs/2026-06-22-umami-analytics-design.md
@@ -33,11 +33,11 @@ test file. No new architecture, no new endpoints, no call-site changes.
 
 ## Decisions (resolved during brainstorming)
 
-| Question | Decision |
-| --- | --- |
+| Question                         | Decision                                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Where do `url` / `id` come from? | **Env vars only** (`PUBLIC_ANALYTICS_*`), keeping the existing config. Region-feed discovery is **deferred / out of scope**, matching the sibling [Twilio design](../../../../twilio/docs/superpowers/specs/2026-06-22-umami-analytics-design.md), which made the same call for the same reason: the app does not consume `regions-v3.json` today. |
-| Expand event coverage? | **No.** Ship against the events already wired (pageview, search, stop-viewed, route-clicked, arrival-clicked). Trip-plan / arrivals-refresh events are a possible follow-up. |
-| Keep Plausible? | **Yes.** Untouched. |
+| Expand event coverage?           | **No.** Ship against the events already wired (pageview, search, stop-viewed, route-clicked, arrival-clicked). Trip-plan / arrivals-refresh events are a possible follow-up.                                                                                                                                                                       |
+| Keep Plausible?                  | **Yes.** Untouched.                                                                                                                                                                                                                                                                                                                                |
 
 ### Why env-only (and not region-feed discovery)
 
@@ -56,18 +56,18 @@ multi-region Wayfinder ever materializes.
 
 ```json
 {
-  "type": "event",
-  "payload": {
-    "website": "<PUBLIC_ANALYTICS_WEBSITE_ID>",
-    "hostname": "<PUBLIC_ANALYTICS_DOMAIN>",
-    "language": "en-US",
-    "screen": "1920x1080",
-    "url": "/stop",
-    "referrer": "",
-    "title": "Wayfinder",
-    "name": "pageview",
-    "data": { "id": "1_00" }
-  }
+	"type": "event",
+	"payload": {
+		"website": "<PUBLIC_ANALYTICS_WEBSITE_ID>",
+		"hostname": "<PUBLIC_ANALYTICS_DOMAIN>",
+		"language": "en-US",
+		"screen": "1920x1080",
+		"url": "/stop",
+		"referrer": "",
+		"title": "Wayfinder",
+		"name": "pageview",
+		"data": { "id": "1_00" }
+	}
 }
 ```
 
@@ -92,7 +92,9 @@ so they are unit-testable in isolation, mirroring Twilio's standalone
 // A dropped event returns HTTP 200, not an error. Umami replies {"beep":"boop"}
 // (or a body lacking cache/sessionId/visitId) when isbot rejects the request.
 // Tolerant of non-JSON: fall back to a substring check for "beep".
-export function isSuccessfulIngest(body) { /* ... */ }
+export function isSuccessfulIngest(body) {
+	/* ... */
+}
 ```
 
 Contract (verified against Umami source — a real success response is always
@@ -151,7 +153,9 @@ rare empty-UA case (server-originated requests, `sendBeacon` edge cases, curl).
 #### 3. Prop sanitization — `sanitizeData(props)`
 
 ```js
-export function sanitizeData(props) { /* ... */ }
+export function sanitizeData(props) {
+	/* ... */
+}
 ```
 
 Per-value rules, in order:
@@ -181,8 +185,7 @@ behavior for missing props is preserved).
   `sanitizeData`, `FALLBACK_USER_AGENT`; wire all three into `forwardEvent`.
 - `src/tests/lib/Analytics/adapters/UmamiAdapter.test.js` — add the new tests below;
   **update** the existing fallback-UA test (asserts `'Wayfinder/1.0'`, ~line 206) to
-  the new constant; **update the two `text: async () => '{}'` mocks** (lines 207 and
-  236) to a success-marker body so they stay green under the new `isSuccessfulIngest`
+  the new constant; **update the two `text: async () => '{}'` mocks** (lines 207 and 236) to a success-marker body so they stay green under the new `isSuccessfulIngest`
   contract.
 
 No other files change. Env schema, `.env.example`, call sites, and the `/api/events`

--- a/docs/superpowers/specs/2026-06-22-umami-analytics-design.md
+++ b/docs/superpowers/specs/2026-06-22-umami-analytics-design.md
@@ -1,0 +1,208 @@
+# Umami Analytics Contract Compliance — Design
+
+**Issue:** [OneBusAway/wayfinder#523](https://github.com/OneBusAway/wayfinder/issues/523) — Add Umami Analytics support (server-side event emission via region-feed discovery)
+**Date:** 2026-06-22
+**Status:** Approved (brainstorming → ready for implementation plan)
+**Branch:** `umami`
+
+## Summary
+
+Issue #523 asks Wayfinder to emit Umami analytics server-side. **Most of this already
+exists.** The adapter pipeline built in the
+[2026-05-16 spec](./2026-05-16-umami-analytics-adapter-design.md) already does the
+core work: a client facade (`Analytics.js`) with event call sites wired throughout
+the UI, a `/api/events` server endpoint that selects an adapter and forwards the
+event with the end user's IP and User-Agent, and a `UmamiAdapter` that POSTs the
+exact `{ type, payload }` contract body to `<host>/api/send`.
+
+This work closes the **three gaps** between that implementation and the issue's
+contract:
+
+1. **`beep/boop` detection** — the issue's "critical gotcha." Umami silently drops a
+   bot-like or misconfigured request as **HTTP 200** with body `{"beep":"boop"}`. The
+   adapter currently treats that valid-JSON 200 as success, so a silently-dropped
+   event looks healthy.
+2. **Bot-risky User-Agent fallback** — when the forwarded browser UA is empty the
+   adapter falls back to a bare `Wayfinder/1.0`, which risks Umami's `isbot` filter.
+   (The 2026-05-16 spec flagged exactly this under "Open risks.")
+3. **No prop sanitization** — the `data` object is forwarded verbatim, including the
+   free-text `search` `query` (uncontrolled user input).
+
+All three changes are confined to `src/lib/Analytics/adapters/UmamiAdapter.js` and its
+test file. No new architecture, no new endpoints, no call-site changes.
+
+## Decisions (resolved during brainstorming)
+
+| Question | Decision |
+| --- | --- |
+| Where do `url` / `id` come from? | **Env vars only** (`PUBLIC_ANALYTICS_*`), keeping the existing config. Region-feed discovery is **deferred / out of scope**, matching the sibling [Twilio design](../../../../twilio/docs/superpowers/specs/2026-06-22-umami-analytics-design.md), which made the same call for the same reason: the app does not consume `regions-v3.json` today. |
+| Expand event coverage? | **No.** Ship against the events already wired (pageview, search, stop-viewed, route-clicked, arrival-clicked). Trip-plan / arrivals-refresh events are a possible follow-up. |
+| Keep Plausible? | **Yes.** Untouched. |
+
+### Why env-only (and not region-feed discovery)
+
+The issue text says "read the current region's `umamiAnalytics` from the region feed
+Wayfinder already consumes." In practice Wayfinder **does not** consume the feed — the
+`/api/regions` endpoint is a passthrough proxy used by nothing, and the app is a
+single-region deployment configured entirely through env vars (`PUBLIC_OBA_SERVER_URL`
+et al.). Twilio — the closest analog, also a server-side emitter that does not fetch
+the feed — explicitly deferred region-feed fetching and shipped env-only. Wayfinder
+follows that precedent. Region-feed discovery remains a clean future enhancement if a
+multi-region Wayfinder ever materializes.
+
+## Emission contract (unchanged, for reference)
+
+`POST <PUBLIC_ANALYTICS_API_HOST>/api/send`, `Content-Type: application/json`:
+
+```json
+{
+  "type": "event",
+  "payload": {
+    "website": "<PUBLIC_ANALYTICS_WEBSITE_ID>",
+    "hostname": "<PUBLIC_ANALYTICS_DOMAIN>",
+    "language": "en-US",
+    "screen": "1920x1080",
+    "url": "/stop",
+    "referrer": "",
+    "title": "Wayfinder",
+    "name": "pageview",
+    "data": { "id": "1_00" }
+  }
+}
+```
+
+- The end user's IP is forwarded via `X-Forwarded-For`, and their browser User-Agent
+  via the `User-Agent` header, so Umami attributes per-visitor sessions from IP+UA —
+  exactly as the issue asks. **This already works** and does not change.
+- `name` is always present in Wayfinder's envelopes (the facade sends `pageview` /
+  `search` / `click`), so every event is a Umami custom event. No pageview-omission
+  path exists; no test for it.
+
+## Components
+
+### `UmamiAdapter.js` — the three fixes
+
+All changes live in `forwardEvent` plus two new module-level exported helpers (exported
+so they are unit-testable in isolation, mirroring Twilio's standalone
+`isSuccessfulIngest`).
+
+#### 1. `beep/boop` detection — `isSuccessfulIngest(body)`
+
+```js
+// A dropped event returns HTTP 200, not an error. Umami replies {"beep":"boop"}
+// (or a body lacking cache/sessionId/visitId) when isbot rejects the request.
+// Tolerant of non-JSON: fall back to a substring check for "beep".
+export function isSuccessfulIngest(body) { /* ... */ }
+```
+
+Contract (mirrors the Twilio/iOS resolution):
+
+- A body containing `"beep"` → **failure**.
+- Otherwise **success** when the body is **empty** OR contains one of
+  `cache` / `sessionId` / `visitId`.
+- Any other non-empty body → **failure** (no success marker).
+- Parsing is tolerant: a non-JSON body must not throw; fall back to the `"beep"`
+  substring check.
+
+Wiring in `forwardEvent`: after the existing `res.ok` check and `await res.text()`,
+call `isSuccessfulIngest(text)`. On failure, **throw** a descriptive `Error`
+(e.g. `Umami dropped event (bot-like User-Agent or misconfigured website id)`) with
+`upstreamStatus = res.status`. The `/api/events` endpoint already catches this and
+returns the status; the client facade already swallows and logs it — so the
+fire-and-forget guarantee holds while the drop is now visible in server logs instead
+of looking healthy. On success, return the parsed JSON as today.
+
+#### 2. Browser-shaped User-Agent fallback
+
+Replace the bare `Wayfinder/1.0` fallback with a `Mozilla/5.0`-prefixed,
+browser-shaped constant that survives `isbot` **by construction** (the approach Twilio
+adopted after finding bare product tokens fragile against isbot's anchored pattern):
+
+```js
+const FALLBACK_USER_AGENT = 'Mozilla/5.0 (Wayfinder) Server/1.0';
+```
+
+The forwarded real browser UA remains preferred and unchanged; this only affects the
+rare empty-UA case (server-originated requests, `sendBeacon` edge cases, curl).
+
+#### 3. Prop sanitization — `sanitizeData(props)`
+
+```js
+// Keep string / finite number / boolean. Stringify other types. Drop null/undefined.
+// Truncate strings to MAX_DATA_VALUE_LENGTH (256) to respect Umami's data limits and
+// to bound the free-text `search` query (uncontrolled user input).
+export function sanitizeData(props) { /* ... */ }
+```
+
+Applied to `payload.data` before the POST. Empty result is sent as `{}` (current
+behavior for missing props is preserved).
+
+## Files touched
+
+**Modified:**
+
+- `src/lib/Analytics/adapters/UmamiAdapter.js` — add `isSuccessfulIngest`,
+  `sanitizeData`, `FALLBACK_USER_AGENT`; wire all three into `forwardEvent`.
+- `src/tests/lib/Analytics/adapters/UmamiAdapter.test.js` — add the new tests below;
+  **update** the existing fallback-UA test (currently asserts `'Wayfinder/1.0'` at
+  ~line 206) to assert the new browser-shaped string.
+
+No other files change. Env schema, `.env.example`, call sites, and the `/api/events`
+endpoint are all untouched — the endpoint's existing `try/catch` already handles the
+new throw path.
+
+## Testing
+
+Add to the existing `UmamiAdapter` suite (which already covers payload shape, IP/UA
+forwarding, hostname sourcing, timeout/abort, and the disabled gate):
+
+- **`isSuccessfulIngest` (table test):**
+  - `{"beep":"boop"}` → failure.
+  - body with `cache` / `sessionId` / `visitId` → success.
+  - empty body `''` → success.
+  - non-empty body with no success marker and no `beep` → failure.
+  - non-JSON body (e.g. `'<html>...'`) → does not throw; failure unless it contains a
+    marker.
+- **`forwardEvent` beep/boop path:** a 200 response whose body is `{"beep":"boop"}` is
+  treated as a **failure** (throws, `upstreamStatus` set); a 200 with a success body
+  still resolves successfully.
+- **`sanitizeData`:** strings/numbers/booleans kept; objects/arrays stringified;
+  `null`/`undefined` dropped; a >256-char string truncated to 256; verified through a
+  `forwardEvent` call that the emitted `payload.data` is sanitized (e.g. a long
+  `query`).
+- **Fallback UA:** update the existing test — empty `requestContext.userAgent` now
+  yields `Mozilla/5.0 (Wayfinder) Server/1.0`; a present browser UA is still forwarded
+  verbatim.
+- All existing Analytics tests stay green.
+
+Run with `npx vitest run` (per repo convention — `npm run test` hangs in non-TTY).
+
+## Manual verification (issue's real acceptance test)
+
+Not automatable. Checklist:
+
+1. Configure `.env` with `PUBLIC_ANALYTICS_PROVIDER=umami`,
+   `PUBLIC_ANALYTICS_API_HOST`, `PUBLIC_ANALYTICS_WEBSITE_ID`, `PUBLIC_ANALYTICS_DOMAIN`
+   pointed at the live Umami host + website UUID.
+2. `npm run dev`; exercise pageview / search / stop-view / route-click / arrival-click.
+3. Confirm events appear under the correct website UUID in the Umami dashboard, and
+   that the ingest response was `cache/sessionId/visitId` — **not** `beep/boop`.
+4. Confirm a `none` / unconfigured provider emits nothing.
+
+## Fail-safe guarantees (preserved)
+
+- Emission is fire-and-forget: client call sites don't await, the facade swallows and
+  logs, and the server endpoint catches every throw.
+- Short upstream timeout (5s `AbortController`) — unchanged.
+- A `beep/boop` drop now throws (logged server-side) instead of silently succeeding,
+  without affecting any user-facing path.
+- Disabled provider / missing config → `NoopAdapter` or `isEnabled() === false` → no
+  request is ever made.
+
+## Out of scope
+
+- **Region-feed (`regions-v3.json`) discovery and per-region matching** — deferred,
+  matching Twilio. Env-only config chosen.
+- New event types beyond what's already wired (trip-plan, arrivals-refresh).
+- Removing or deprecating Plausible.
+- Any client-side / JavaScript Umami tracker.

--- a/docs/superpowers/specs/2026-06-22-umami-analytics-design.md
+++ b/docs/superpowers/specs/2026-06-22-umami-analytics-design.md
@@ -95,44 +95,80 @@ so they are unit-testable in isolation, mirroring Twilio's standalone
 export function isSuccessfulIngest(body) { /* ... */ }
 ```
 
-Contract (mirrors the Twilio/iOS resolution):
+Contract (verified against Umami source — a real success response is always
+`{cache, sessionId, visitId}`; the bot drop is the only `beep/boop` path):
 
-- A body containing `"beep"` → **failure**.
-- Otherwise **success** when the body is **empty** OR contains one of
+- The check runs against the **response** body only, never the request.
+- A body containing the substring `"beep"` → **failure** (the `{"beep":"boop"}` drop).
+- **Success** when the body is an **empty string** OR contains one of
   `cache` / `sessionId` / `visitId`.
-- Any other non-empty body → **failure** (no success marker).
+- **Any other body → failure**, including a bare `{}` (no success marker). This is
+  deliberate: Umami never returns `{}` on a real success.
 - Parsing is tolerant: a non-JSON body must not throw; fall back to the `"beep"`
   substring check.
 
+> **Test impact (must-fix):** two existing tests mock `text: async () => '{}'`
+> (`UmamiAdapter.test.js` lines 207 and 236 — the fallback-UA and AbortSignal tests).
+> Under this contract `{}` is now a failure, so those mocks must be updated to a
+> success-marker body (e.g. `JSON.stringify({ cache: 'x' })`). The "existing tests
+> stay green" claim holds only with those two mocks updated.
+
 Wiring in `forwardEvent`: after the existing `res.ok` check and `await res.text()`,
-call `isSuccessfulIngest(text)`. On failure, **throw** a descriptive `Error`
-(e.g. `Umami dropped event (bot-like User-Agent or misconfigured website id)`) with
-`upstreamStatus = res.status`. The `/api/events` endpoint already catches this and
-returns the status; the client facade already swallows and logs it — so the
-fire-and-forget guarantee holds while the drop is now visible in server logs instead
-of looking healthy. On success, return the parsed JSON as today.
+call `isSuccessfulIngest(text)`. On failure, **throw** a descriptive `Error` —
+`Umami dropped event as bot-like (isbot rejected the User-Agent)` — with
+**`upstreamStatus = 502`** (a drop is bad upstream behavior; do **not** use
+`res.status`, which is `200` — the endpoint's `error.upstreamStatus || …` mapping
+would then return HTTP 200 and the drop would look healthy at the HTTP layer too).
+With `502`, the `/api/events` endpoint returns 502, the client facade swallows and
+logs it, and the drop is visible in server logs and status. On success, return the
+parsed JSON as today.
 
 #### 2. Browser-shaped User-Agent fallback
 
-Replace the bare `Wayfinder/1.0` fallback with a `Mozilla/5.0`-prefixed,
-browser-shaped constant that survives `isbot` **by construction** (the approach Twilio
-adopted after finding bare product tokens fragile against isbot's anchored pattern):
+Replace the bare `Wayfinder/1.0` fallback with a browser-shaped string **verified
+against the `isbot` package's patterns**:
 
 ```js
-const FALLBACK_USER_AGENT = 'Mozilla/5.0 (Wayfinder) Server/1.0';
+const FALLBACK_USER_AGENT = 'Mozilla/5.0 (Wayfinder)';
 ```
 
 The forwarded real browser UA remains preferred and unchanged; this only affects the
 rare empty-UA case (server-originated requests, `sendBeacon` edge cases, curl).
 
+> **Why not `Mozilla/5.0 (Wayfinder) Server/1.0`** (the obvious first choice): `isbot`
+> tests its patterns **case-insensitively and unanchored**, and `patterns.json`
+> contains the literal token **`server`** — so any UA containing `Server` is
+> bot-flagged and dropped, defeating fix #1. The fallback must contain **no** isbot
+> token (`server`, `bot`, `http`, `crawl`, `scan`, `search`, `spider`, `agent\b`, …)
+> **and** must not be a bare `Mozilla/x.x <token>` string (isbot end-anchors those
+> with `^mozilla/\d\.\d\s[\w.-]+$`). `Mozilla/5.0 (Wayfinder)` satisfies both:
+> `wayfinder` contains no token, and the `(` breaks the anchor (`(` ∉ `[\w.-]`).
+>
+> `isbot` is **not** added as a dependency just for this. Instead a unit test asserts
+> the constant contains none of the high-risk tokens above (a falsifiable
+> regression guard); the live-isbot verification was done during design review.
+
 #### 3. Prop sanitization — `sanitizeData(props)`
 
 ```js
-// Keep string / finite number / boolean. Stringify other types. Drop null/undefined.
-// Truncate strings to MAX_DATA_VALUE_LENGTH (256) to respect Umami's data limits and
-// to bound the free-text `search` query (uncontrolled user input).
 export function sanitizeData(props) { /* ... */ }
 ```
+
+Per-value rules, in order:
+
+1. `null` / `undefined` → **drop the key**.
+2. `boolean` → **keep** as-is.
+3. `string` → **keep**, truncated via `.slice(0, MAX_DATA_VALUE_LENGTH)`.
+4. `number` → **keep only if `Number.isFinite(v)`**; `NaN` / `Infinity` / `-Infinity`
+   are **dropped** (they would otherwise serialize to `null` and confuse the
+   dashboard).
+5. anything else (objects, arrays) → `JSON.stringify(v)`, then truncate as a string.
+
+`MAX_DATA_VALUE_LENGTH = 256` is a **Wayfinder-chosen** bound (not a documented Umami
+API limit) to bound the free-text `search` `query` (uncontrolled user input) and keep
+`data` values small. Flattening nested objects to JSON strings is an intentional
+choice — Umami accepts nested `data` objects, but Wayfinder's events are flat today,
+so stringifying is a safe, predictable default rather than a requirement.
 
 Applied to `payload.data` before the POST. Empty result is sent as `{}` (current
 behavior for missing props is preserved).
@@ -144,8 +180,10 @@ behavior for missing props is preserved).
 - `src/lib/Analytics/adapters/UmamiAdapter.js` — add `isSuccessfulIngest`,
   `sanitizeData`, `FALLBACK_USER_AGENT`; wire all three into `forwardEvent`.
 - `src/tests/lib/Analytics/adapters/UmamiAdapter.test.js` — add the new tests below;
-  **update** the existing fallback-UA test (currently asserts `'Wayfinder/1.0'` at
-  ~line 206) to assert the new browser-shaped string.
+  **update** the existing fallback-UA test (asserts `'Wayfinder/1.0'`, ~line 206) to
+  the new constant; **update the two `text: async () => '{}'` mocks** (lines 207 and
+  236) to a success-marker body so they stay green under the new `isSuccessfulIngest`
+  contract.
 
 No other files change. Env schema, `.env.example`, call sites, and the `/api/events`
 endpoint are all untouched — the endpoint's existing `try/catch` already handles the
@@ -160,20 +198,24 @@ forwarding, hostname sourcing, timeout/abort, and the disabled gate):
   - `{"beep":"boop"}` → failure.
   - body with `cache` / `sessionId` / `visitId` → success.
   - empty body `''` → success.
-  - non-empty body with no success marker and no `beep` → failure.
+  - bare `{}` → **failure** (no success marker).
+  - non-empty body with no marker and no `beep` → failure.
   - non-JSON body (e.g. `'<html>...'`) → does not throw; failure unless it contains a
     marker.
 - **`forwardEvent` beep/boop path:** a 200 response whose body is `{"beep":"boop"}` is
-  treated as a **failure** (throws, `upstreamStatus` set); a 200 with a success body
-  still resolves successfully.
-- **`sanitizeData`:** strings/numbers/booleans kept; objects/arrays stringified;
-  `null`/`undefined` dropped; a >256-char string truncated to 256; verified through a
-  `forwardEvent` call that the emitted `payload.data` is sanitized (e.g. a long
-  `query`).
-- **Fallback UA:** update the existing test — empty `requestContext.userAgent` now
-  yields `Mozilla/5.0 (Wayfinder) Server/1.0`; a present browser UA is still forwarded
-  verbatim.
-- All existing Analytics tests stay green.
+  treated as a **failure** — throws with `upstreamStatus === 502`; a 200 with a success
+  body still resolves successfully.
+- **`sanitizeData`:** strings kept (and >256-char truncated to 256); finite numbers and
+  booleans kept; `NaN` / `Infinity` dropped; `null` / `undefined` dropped; nested
+  object/array `JSON.stringify`-ed; verified through a `forwardEvent` call that the
+  emitted `payload.data` is sanitized (e.g. a long `query`).
+- **Fallback UA:**
+  - the existing test — empty `requestContext.userAgent` now yields
+    `Mozilla/5.0 (Wayfinder)`; a present browser UA is still forwarded verbatim.
+  - a **regression guard** asserting `FALLBACK_USER_AGENT` contains none of the
+    high-risk isbot tokens (`server`, `bot`, `http`, `crawl`, `scan`, `search`,
+    `spider`, `agent`) — falsifiable without adding the `isbot` dependency.
+- All existing Analytics tests stay green (with the two `{}` mocks updated, above).
 
 Run with `npx vitest run` (per repo convention — `npm run test` hangs in non-TTY).
 

--- a/src/lib/Analytics/adapters/UmamiAdapter.js
+++ b/src/lib/Analytics/adapters/UmamiAdapter.js
@@ -32,6 +32,19 @@ export function sanitizeData(props) {
 	return out;
 }
 
+/**
+ * Classify a Umami /api/send response body. Umami silently drops bot-like requests with
+ * HTTP 200 + {"beep":"boop"}; a real ingest returns cache/sessionId/visitId. Tolerant of
+ * non-JSON bodies (substring checks, never throws).
+ * @param {string} body
+ * @returns {boolean}
+ */
+export function isSuccessfulIngest(body) {
+	if (body === '') return true;
+	if (body.includes('beep')) return false;
+	return body.includes('cache') || body.includes('sessionId') || body.includes('visitId');
+}
+
 export class UmamiAdapter {
 	constructor(env) {
 		this.env = env;
@@ -120,6 +133,11 @@ export class UmamiAdapter {
 			}
 
 			const text = await res.text();
+			if (!isSuccessfulIngest(text)) {
+				const err = new Error('Umami dropped event as bot-like (isbot rejected the User-Agent)');
+				err.upstreamStatus = 502;
+				throw err;
+			}
 			try {
 				return JSON.parse(text);
 			} catch {

--- a/src/lib/Analytics/adapters/UmamiAdapter.js
+++ b/src/lib/Analytics/adapters/UmamiAdapter.js
@@ -34,15 +34,23 @@ export function sanitizeData(props) {
 
 /**
  * Classify a Umami /api/send response body. Umami silently drops bot-like requests with
- * HTTP 200 + {"beep":"boop"}; a real ingest returns cache/sessionId/visitId. Tolerant of
- * non-JSON bodies (substring checks, never throws).
+ * HTTP 200 + {"beep":"boop"}; a real ingest returns cache/sessionId/visitId. Detection is
+ * key-based (not substring) so a marker word appearing as incidental text in an error body
+ * is not mistaken for success. Tolerant of non-JSON / empty bodies — never throws.
  * @param {string} body
  * @returns {boolean}
  */
 export function isSuccessfulIngest(body) {
 	if (body === '') return true;
-	if (body.includes('beep')) return false;
-	return body.includes('cache') || body.includes('sessionId') || body.includes('visitId');
+	let parsed;
+	try {
+		parsed = JSON.parse(body);
+	} catch {
+		return false;
+	}
+	if (!parsed || typeof parsed !== 'object') return false;
+	if ('beep' in parsed) return false;
+	return 'cache' in parsed || 'sessionId' in parsed || 'visitId' in parsed;
 }
 
 export class UmamiAdapter {

--- a/src/lib/Analytics/adapters/UmamiAdapter.js
+++ b/src/lib/Analytics/adapters/UmamiAdapter.js
@@ -2,6 +2,11 @@ const UPSTREAM_TIMEOUT_MS = 5000;
 
 const MAX_DATA_VALUE_LENGTH = 256;
 
+// Sent when no end-user User-Agent is available. Must survive Umami's isbot filter:
+// no bot token (isbot matches `server`/`bot`/etc. unanchored, case-insensitively) and
+// not a bare `Mozilla/x.x <token>` string (the `(` breaks isbot's anchored pattern).
+export const FALLBACK_USER_AGENT = 'Mozilla/5.0 (Wayfinder)';
+
 /**
  * Coerce arbitrary event props into Umami-safe `data` values: keep strings (truncated),
  * finite numbers, and booleans; drop null/undefined and non-finite numbers; JSON-stringify
@@ -91,7 +96,7 @@ export class UmamiAdapter {
 
 		const headers = {
 			'Content-Type': 'application/json',
-			'User-Agent': requestContext.userAgent || 'Wayfinder/1.0'
+			'User-Agent': requestContext.userAgent || FALLBACK_USER_AGENT
 		};
 		if (requestContext.clientIp) {
 			headers['X-Forwarded-For'] = requestContext.clientIp;

--- a/src/lib/Analytics/adapters/UmamiAdapter.js
+++ b/src/lib/Analytics/adapters/UmamiAdapter.js
@@ -1,5 +1,32 @@
 const UPSTREAM_TIMEOUT_MS = 5000;
 
+const MAX_DATA_VALUE_LENGTH = 256;
+
+/**
+ * Coerce arbitrary event props into Umami-safe `data` values: keep strings (truncated),
+ * finite numbers, and booleans; drop null/undefined and non-finite numbers; JSON-stringify
+ * anything else (truncated). Bounds uncontrolled user input (e.g. the free-text search query).
+ * @param {Object} [props]
+ * @returns {Object}
+ */
+export function sanitizeData(props) {
+	const out = {};
+	for (const [key, value] of Object.entries(props ?? {})) {
+		if (value === null || value === undefined) continue;
+		const type = typeof value;
+		if (type === 'boolean') {
+			out[key] = value;
+		} else if (type === 'string') {
+			out[key] = value.slice(0, MAX_DATA_VALUE_LENGTH);
+		} else if (type === 'number') {
+			if (Number.isFinite(value)) out[key] = value;
+		} else {
+			out[key] = JSON.stringify(value).slice(0, MAX_DATA_VALUE_LENGTH);
+		}
+	}
+	return out;
+}
+
 export class UmamiAdapter {
 	constructor(env) {
 		this.env = env;
@@ -58,7 +85,7 @@ export class UmamiAdapter {
 				referrer,
 				title,
 				name,
-				data: props
+				data: sanitizeData(props)
 			}
 		};
 

--- a/src/tests/lib/Analytics/adapters/UmamiAdapter.test.js
+++ b/src/tests/lib/Analytics/adapters/UmamiAdapter.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { UmamiAdapter, sanitizeData } from '$lib/Analytics/adapters/UmamiAdapter.js';
+import { UmamiAdapter, sanitizeData, FALLBACK_USER_AGENT } from '$lib/Analytics/adapters/UmamiAdapter.js';
 
 const fullEnv = {
 	PUBLIC_ANALYTICS_DOMAIN: 'example.com',
@@ -203,11 +203,19 @@ describe('UmamiAdapter.forwardEvent (edge cases)', () => {
 		);
 	});
 
-	it('falls back to Wayfinder/1.0 User-Agent when context omits it', async () => {
+	it('falls back to the browser-shaped User-Agent when context omits it', async () => {
 		global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{}' });
 		await new UmamiAdapter(fullEnv).forwardEvent(envelope, { userAgent: '', clientIp: '' });
 		const [, init] = global.fetch.mock.calls[0];
-		expect(init.headers['User-Agent']).toBe('Wayfinder/1.0');
+		expect(init.headers['User-Agent']).toBe('Mozilla/5.0 (Wayfinder)');
+	});
+
+	it('fallback User-Agent contains no isbot bot tokens', () => {
+		const tokens = ['server', 'bot', 'http', 'crawl', 'scan', 'search', 'spider', 'agent'];
+		const ua = FALLBACK_USER_AGENT.toLowerCase();
+		for (const token of tokens) {
+			expect(ua).not.toContain(token);
+		}
 	});
 
 	it('throws Error with upstreamStatus on non-OK response', async () => {

--- a/src/tests/lib/Analytics/adapters/UmamiAdapter.test.js
+++ b/src/tests/lib/Analytics/adapters/UmamiAdapter.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { UmamiAdapter, sanitizeData, FALLBACK_USER_AGENT } from '$lib/Analytics/adapters/UmamiAdapter.js';
+import { UmamiAdapter, sanitizeData, FALLBACK_USER_AGENT, isSuccessfulIngest } from '$lib/Analytics/adapters/UmamiAdapter.js';
 
 const fullEnv = {
 	PUBLIC_ANALYTICS_DOMAIN: 'example.com',
@@ -168,10 +168,11 @@ describe('UmamiAdapter.forwardEvent (happy path)', () => {
 		expect(result).toEqual({ cache: 'abc', sessionId: 's', visitId: 'v' });
 	});
 
-	it('returns { status: text } when response is not JSON', async () => {
-		global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => 'ok' });
-		const result = await new UmamiAdapter(fullEnv).forwardEvent(envelope, ctx);
-		expect(result).toEqual({ status: 'ok' });
+	it('throws when the response body lacks a success marker', async () => {
+		global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => 'ok' });
+		await expect(new UmamiAdapter(fullEnv).forwardEvent(envelope, ctx)).rejects.toThrow(
+			'dropped event'
+		);
 	});
 });
 
@@ -204,7 +205,7 @@ describe('UmamiAdapter.forwardEvent (edge cases)', () => {
 	});
 
 	it('falls back to the browser-shaped User-Agent when context omits it', async () => {
-		global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{}' });
+		global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{"cache":"x"}' });
 		await new UmamiAdapter(fullEnv).forwardEvent(envelope, { userAgent: '', clientIp: '' });
 		const [, init] = global.fetch.mock.calls[0];
 		expect(init.headers['User-Agent']).toBe('Mozilla/5.0 (Wayfinder)');
@@ -241,7 +242,7 @@ describe('UmamiAdapter.forwardEvent (edge cases)', () => {
 	});
 
 	it('passes an AbortSignal to fetch so the request can time out', async () => {
-		global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{}' });
+		global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{"cache":"x"}' });
 		await new UmamiAdapter(fullEnv).forwardEvent(envelope, ctx);
 		const [, init] = global.fetch.mock.calls[0];
 		expect(init.signal).toBeInstanceOf(AbortSignal);
@@ -252,6 +253,19 @@ describe('UmamiAdapter.forwardEvent (edge cases)', () => {
 			.fn()
 			.mockRejectedValue(Object.assign(new Error('aborted'), { name: 'AbortError' }));
 		await expect(new UmamiAdapter(fullEnv).forwardEvent(envelope, ctx)).rejects.toThrow('aborted');
+	});
+
+	it('throws with upstreamStatus 502 when Umami drops the event (beep/boop)', async () => {
+		global.fetch = vi
+			.fn()
+			.mockResolvedValue({ ok: true, status: 200, text: async () => '{"beep":"boop"}' });
+		try {
+			await new UmamiAdapter(fullEnv).forwardEvent(envelope, ctx);
+			expect.unreachable('should have thrown');
+		} catch (error) {
+			expect(error.message).toContain('dropped event');
+			expect(error.upstreamStatus).toBe(502);
+		}
 	});
 });
 
@@ -283,5 +297,33 @@ describe('sanitizeData', () => {
 	it('returns an empty object for empty or nullish input', () => {
 		expect(sanitizeData({})).toEqual({});
 		expect(sanitizeData(undefined)).toEqual({});
+	});
+});
+
+describe('isSuccessfulIngest', () => {
+	it('treats a beep/boop body as failure', () => {
+		expect(isSuccessfulIngest('{"beep":"boop"}')).toBe(false);
+	});
+
+	it('treats a body with cache/sessionId/visitId as success', () => {
+		expect(isSuccessfulIngest('{"cache":"c","sessionId":"s","visitId":"v"}')).toBe(true);
+		expect(isSuccessfulIngest('{"sessionId":"s"}')).toBe(true);
+	});
+
+	it('treats an empty body as success', () => {
+		expect(isSuccessfulIngest('')).toBe(true);
+	});
+
+	it('treats a bare {} body as failure', () => {
+		expect(isSuccessfulIngest('{}')).toBe(false);
+	});
+
+	it('treats any other non-empty body without a marker as failure', () => {
+		expect(isSuccessfulIngest('ok')).toBe(false);
+	});
+
+	it('does not throw on a non-JSON body', () => {
+		expect(() => isSuccessfulIngest('<html>error</html>')).not.toThrow();
+		expect(isSuccessfulIngest('<html>error</html>')).toBe(false);
 	});
 });

--- a/src/tests/lib/Analytics/adapters/UmamiAdapter.test.js
+++ b/src/tests/lib/Analytics/adapters/UmamiAdapter.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { UmamiAdapter } from '$lib/Analytics/adapters/UmamiAdapter.js';
+import { UmamiAdapter, sanitizeData } from '$lib/Analytics/adapters/UmamiAdapter.js';
 
 const fullEnv = {
 	PUBLIC_ANALYTICS_DOMAIN: 'example.com',
@@ -244,5 +244,36 @@ describe('UmamiAdapter.forwardEvent (edge cases)', () => {
 			.fn()
 			.mockRejectedValue(Object.assign(new Error('aborted'), { name: 'AbortError' }));
 		await expect(new UmamiAdapter(fullEnv).forwardEvent(envelope, ctx)).rejects.toThrow('aborted');
+	});
+});
+
+describe('sanitizeData', () => {
+	it('keeps strings, finite numbers, and booleans', () => {
+		expect(sanitizeData({ s: 'hi', n: 42, b: true })).toEqual({ s: 'hi', n: 42, b: true });
+	});
+
+	it('drops null and undefined values', () => {
+		expect(sanitizeData({ a: null, b: undefined, c: 'keep' })).toEqual({ c: 'keep' });
+	});
+
+	it('drops non-finite numbers', () => {
+		expect(sanitizeData({ a: NaN, b: Infinity, c: -Infinity, d: 1 })).toEqual({ d: 1 });
+	});
+
+	it('truncates strings to 256 characters', () => {
+		const long = 'x'.repeat(300);
+		expect(sanitizeData({ q: long }).q).toHaveLength(256);
+	});
+
+	it('JSON-stringifies nested objects and arrays', () => {
+		expect(sanitizeData({ o: { a: 1 }, arr: [1, 2] })).toEqual({
+			o: '{"a":1}',
+			arr: '[1,2]'
+		});
+	});
+
+	it('returns an empty object for empty or nullish input', () => {
+		expect(sanitizeData({})).toEqual({});
+		expect(sanitizeData(undefined)).toEqual({});
 	});
 });

--- a/src/tests/lib/Analytics/adapters/UmamiAdapter.test.js
+++ b/src/tests/lib/Analytics/adapters/UmamiAdapter.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { UmamiAdapter, sanitizeData, FALLBACK_USER_AGENT, isSuccessfulIngest } from '$lib/Analytics/adapters/UmamiAdapter.js';
+import {
+	UmamiAdapter,
+	sanitizeData,
+	FALLBACK_USER_AGENT,
+	isSuccessfulIngest
+} from '$lib/Analytics/adapters/UmamiAdapter.js';
 
 const fullEnv = {
 	PUBLIC_ANALYTICS_DOMAIN: 'example.com',

--- a/src/tests/lib/Analytics/adapters/UmamiAdapter.test.js
+++ b/src/tests/lib/Analytics/adapters/UmamiAdapter.test.js
@@ -331,4 +331,10 @@ describe('isSuccessfulIngest', () => {
 		expect(() => isSuccessfulIngest('<html>error</html>')).not.toThrow();
 		expect(isSuccessfulIngest('<html>error</html>')).toBe(false);
 	});
+
+	it('does not treat a marker word in an error message as success', () => {
+		// The marker must be a top-level key, not incidental text in an error body.
+		expect(isSuccessfulIngest('{"error":"missing sessionId"}')).toBe(false);
+		expect(isSuccessfulIngest('{"message":"cache unavailable"}')).toBe(false);
+	});
 });


### PR DESCRIPTION
## Summary

Closes the three contract gaps in Wayfinder's existing server-side Umami analytics emitter, per #523. The adapter pipeline (client facade → `/api/events` → `UmamiAdapter` → `POST /api/send`, forwarding the end user's IP + User-Agent) already existed; this PR makes it actually compliant with Umami's ingestion contract.

All changes are confined to `src/lib/Analytics/adapters/UmamiAdapter.js` and its test. Config stays env-based (`PUBLIC_ANALYTICS_*`); per-region feed discovery is intentionally deferred, matching the sibling Twilio service's decision (the app doesn't consume `regions-v3.json` today).

## The three fixes

1. **`beep/boop` detection** (the issue's critical gotcha). Umami silently drops a bot-like/misconfigured request as **HTTP 200** with body `{"beep":"boop"}`. The adapter previously treated that valid-JSON 200 as success. New `isSuccessfulIngest(body)` classifies empty or `cache`/`sessionId`/`visitId` bodies as success and everything else (incl. `beep/boop`, bare `{}`) as failure; a drop now throws with `upstreamStatus = 502` (not `res.status` 200, which would otherwise make `/api/events` report HTTP 200 for a drop). Tolerant of non-JSON; never throws.

2. **Non-bot fallback User-Agent.** The old `Wayfinder/1.0` fallback risked Umami's `isbot` filter — and the obvious `Mozilla/5.0 (Wayfinder) Server/1.0` is *worse* (isbot matches the literal `server` token, unanchored/case-insensitive). Now `Mozilla/5.0 (Wayfinder)` — no isbot token, and the `(` breaks isbot's bare-Mozilla anchor. A regression-guard test asserts the constant carries no bot token (no new dependency). The forwarded real browser UA is unchanged and still preferred; this only affects the rare empty-UA case.

3. **Prop sanitization.** New `sanitizeData(props)` coerces event `data`: keep string (truncated to 256) / finite number / boolean; drop null/undefined and non-finite numbers; `JSON.stringify` everything else. Bounds the free-text `search` query (uncontrolled user input).

## Fail-safe

Fire-and-forget is preserved end-to-end: the adapter may throw, `/api/events` catches and maps to an HTTP status, the client facade swallows. Nothing blocks or surfaces to a user.

## Testing

- 40 `UmamiAdapter` tests (new: `isSuccessfulIngest` table, beep/boop `forwardEvent` failure, `sanitizeData` rules, UA regression guard; three existing tests updated for the new success contract).
- Full suite green: **1312/1312**. Prettier + ESLint clean.

## Out of scope

Region-feed discovery, new event types (trip-plan / arrivals-refresh), Plausible removal, any JS tracker.

## Manual verification (not automatable — needs live Umami)

Point `.env` at a live Umami host + website UUID, exercise pageview/search/stop/route/arrival, and confirm events land under the correct website with a `cache/sessionId/visitId` response (not `beep/boop`).

Spec: `docs/superpowers/specs/2026-06-22-umami-analytics-design.md` · Plan: `docs/superpowers/plans/2026-06-22-umami-analytics.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and error handling for silently dropped analytics events
  * Implemented data sanitization for event properties to ensure safe and reliable transmission to analytics providers
  * Enhanced browser identification with improved fallback user agent handling

* **Documentation**
  * Added detailed implementation plan and design specification documents for analytics improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->