### PR TITLE
fix(a11y): wrap autocomplete result buttons in li elements

### DIFF
--- a/src/components/trip-planner/TripPlanSearchField.svelte
+++ b/src/components/trip-planner/TripPlanSearchField.svelte
@@ -67,13 +67,15 @@
 			class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md border border-gray-300 bg-white shadow-lg"
 		>
 			{#each results as result}
-				<button
-					class="flex w-full cursor-pointer items-center px-4 py-2 text-left hover:bg-gray-100 dark:text-black"
-					onclick={() => handleSelect(result)}
-				>
-					<FontAwesomeIcon icon={faMapMarkerAlt} class="mr-2 text-gray-400  " />
-					{result.displayText}
-				</button>
+				<li>
+					<button
+						class="flex w-full cursor-pointer items-center px-4 py-2 text-left hover:bg-gray-100 dark:text-black"
+						onclick={() => handleSelect(result)}
+					>
+						<FontAwesomeIcon icon={faMapMarkerAlt} class="mr-2 text-gray-400  " />
+						{result.displayText}
+					</button>
+				</li>
 			{/each}
 		</ul>
 	{/if}


### PR DESCRIPTION
Fixes #517 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the search results dropdown so each result is properly grouped in a list item, making the selection list more consistent and reliable.
* **Style**
  * Updated the results list structure for better semantic HTML.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->