### PR TITLE
fix(a11y): make route schedule table reachable by keyboard with all translations

### DIFF
--- a/src/components/schedule-for-stop/RouteScheduleTable.svelte
+++ b/src/components/schedule-for-stop/RouteScheduleTable.svelte
@@ -4,6 +4,10 @@
 
 	let { schedule } = $props();
 
+	/** Unique per instance so multiple expanded route tables don't share one */
+	/** caption id (aria-labelledby would otherwise resolve to the first table). */
+	const captionId = `schedule-table-caption-${crypto.randomUUID()}`;
+
 	let scheduleData = $derived(renderScheduleTable(schedule));
 
 	function renderScheduleTable(schedule) {
@@ -29,13 +33,13 @@
 <div
 	role="region"
 	tabindex="0"
-	aria-labelledby="schedule-table-caption"
+	aria-labelledby={captionId}
 	class="overflow-x-auto dark:bg-black"
 >
 	<table
 		class="mt-4 w-full table-auto rounded-lg border border-gray-200 shadow-lg dark:border-gray-700 dark:bg-black"
 	>
-		<caption id="schedule-table-caption" class="sr-only">
+		<caption id={captionId} class="sr-only">
 			{$isLoading
 				? ''
 				: $t('schedule_for_stop.schedule_table_caption', {

--- a/src/components/schedule-for-stop/RouteScheduleTable.svelte
+++ b/src/components/schedule-for-stop/RouteScheduleTable.svelte
@@ -23,25 +23,46 @@
 	}
 </script>
 
-<div class="overflow-x-auto dark:bg-black">
+<!-- A focusable scroll container gives keyboard users an entry point to the
+	scrollable schedule table; role="region" + aria-label provide context. -->
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<div
+	role="region"
+	tabindex="0"
+	aria-label={$isLoading
+		? undefined
+		: $t('schedule_for_stop.schedule_table_caption', {
+				values: { route: schedule.tripHeadsign }
+			})}
+	class="overflow-x-auto dark:bg-black"
+>
 	<table
 		class="mt-4 w-full table-auto rounded-lg border border-gray-200 shadow-lg dark:border-gray-700 dark:bg-black"
 	>
+		<caption class="sr-only">
+			{$isLoading
+				? ''
+				: $t('schedule_for_stop.schedule_table_caption', {
+						values: { route: schedule.tripHeadsign }
+					})}
+		</caption>
 		<thead class="bg-gray-100 text-gray-800 dark:bg-gray-900">
 			<tr>
-				<th class="cursor-pointer px-6 py-3 text-left dark:text-white"
+				<th scope="col" class="px-6 py-3 text-left dark:text-white"
 					>{$isLoading ? '' : $t('schedule_for_stop.hour')}</th
 				>
-				<th class="cursor-pointer px-6 py-3 text-left dark:text-white"
+				<th scope="col" class="px-6 py-3 text-left dark:text-white"
 					>{$isLoading ? '' : $t('schedule_for_stop.minutes')}</th
 				>
 			</tr>
 		</thead>
 		<tbody>
 			<tr class="bg-gray-50 hover:bg-gray-100 dark:hover:bg-gray-600">
-				<td
+				<th
 					colspan="2"
-					class="px-6 py-3 font-semibold text-gray-700 dark:bg-gray-800 dark:text-white">AM</td
+					scope="colgroup"
+					class="px-6 py-3 text-left font-semibold text-gray-700 dark:bg-gray-800 dark:text-white"
+					>AM</th
 				>
 			</tr>
 			{#if scheduleData.amTimes.length === 0}
@@ -74,9 +95,11 @@
 			{/if}
 
 			<tr class="bg-gray-50 hover:bg-gray-100 dark:hover:bg-gray-900">
-				<td
+				<th
 					colspan="2"
-					class="px-6 py-3 font-semibold text-gray-700 dark:bg-gray-800 dark:text-white">PM</td
+					scope="colgroup"
+					class="px-6 py-3 text-left font-semibold text-gray-700 dark:bg-gray-800 dark:text-white"
+					>PM</th
 				>
 			</tr>
 			{#if scheduleData.pmTimes.length === 0}

--- a/src/components/schedule-for-stop/RouteScheduleTable.svelte
+++ b/src/components/schedule-for-stop/RouteScheduleTable.svelte
@@ -24,22 +24,18 @@
 </script>
 
 <!-- A focusable scroll container gives keyboard users an entry point to the
-	scrollable schedule table; role="region" + aria-label provide context. -->
+	scrollable schedule table; role="region" + aria-labelledby name it via the caption. -->
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <div
 	role="region"
 	tabindex="0"
-	aria-label={$isLoading
-		? undefined
-		: $t('schedule_for_stop.schedule_table_caption', {
-				values: { route: schedule.tripHeadsign }
-			})}
+	aria-labelledby="schedule-table-caption"
 	class="overflow-x-auto dark:bg-black"
 >
 	<table
 		class="mt-4 w-full table-auto rounded-lg border border-gray-200 shadow-lg dark:border-gray-700 dark:bg-black"
 	>
-		<caption class="sr-only">
+		<caption id="schedule-table-caption" class="sr-only">
 			{$isLoading
 				? ''
 				: $t('schedule_for_stop.schedule_table_caption', {
@@ -60,7 +56,7 @@
 			<tr class="bg-gray-50 hover:bg-gray-100 dark:hover:bg-gray-600">
 				<th
 					colspan="2"
-					scope="colgroup"
+					scope="rowgroup"
 					class="px-6 py-3 text-left font-semibold text-gray-700 dark:bg-gray-800 dark:text-white"
 					>AM</th
 				>
@@ -93,11 +89,12 @@
 					</tr>
 				{/each}
 			{/if}
-
+		</tbody>
+		<tbody>
 			<tr class="bg-gray-50 hover:bg-gray-100 dark:hover:bg-gray-900">
 				<th
 					colspan="2"
-					scope="colgroup"
+					scope="rowgroup"
 					class="px-6 py-3 text-left font-semibold text-gray-700 dark:bg-gray-800 dark:text-white"
 					>PM</th
 				>

--- a/src/components/schedule-for-stop/RouteScheduleTable.svelte
+++ b/src/components/schedule-for-stop/RouteScheduleTable.svelte
@@ -30,12 +30,7 @@
 <!-- A focusable scroll container gives keyboard users an entry point to the
 	scrollable schedule table; role="region" + aria-labelledby name it via the caption. -->
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-<div
-	role="region"
-	tabindex="0"
-	aria-labelledby={captionId}
-	class="overflow-x-auto dark:bg-black"
->
+<div role="region" tabindex="0" aria-labelledby={captionId} class="overflow-x-auto dark:bg-black">
 	<table
 		class="mt-4 w-full table-auto rounded-lg border border-gray-200 shadow-lg dark:border-gray-700 dark:bg-black"
 	>

--- a/src/components/schedule-for-stop/__tests__/RouteScheduleTable.test.js
+++ b/src/components/schedule-for-stop/__tests__/RouteScheduleTable.test.js
@@ -1,6 +1,9 @@
 import { render, screen } from '@testing-library/svelte';
-import { expect, test, describe, vi } from 'vitest';
+import { expect, test, describe, vi, beforeEach, afterEach } from 'vitest';
 import RouteScheduleTable from '../RouteScheduleTable.svelte';
+import { __setIsLoading } from 'svelte-i18n';
+
+let isLoading = false;
 
 vi.mock('svelte-i18n', () => ({
 	t: {
@@ -20,9 +23,12 @@ vi.mock('svelte-i18n', () => ({
 	},
 	isLoading: {
 		subscribe: vi.fn((fn) => {
-			fn(false);
+			fn(isLoading);
 			return { unsubscribe: () => {} };
 		})
+	},
+	__setIsLoading: (value) => {
+		isLoading = value;
 	}
 }));
 
@@ -35,6 +41,10 @@ const schedule = {
 };
 
 describe('RouteScheduleTable accessibility', () => {
+	beforeEach(() => {
+		isLoading = false;
+	});
+
 	test('exposes the table within a keyboard-focusable labelled region', () => {
 		render(RouteScheduleTable, { props: { schedule } });
 
@@ -42,27 +52,29 @@ describe('RouteScheduleTable accessibility', () => {
 			name: 'Departure times for 44 - University District'
 		});
 		expect(region).toHaveAttribute('tabindex', '0');
+		expect(region).toHaveAttribute('aria-labelledby', 'schedule-table-caption');
+		expect(region).not.toHaveAttribute('aria-label');
 		expect(region.querySelector('table')).toBeInTheDocument();
 	});
 
 	test('table has a caption providing context for the route', () => {
 		const { container } = render(RouteScheduleTable, { props: { schedule } });
 
-		const caption = container.querySelector('caption');
+		const caption = container.querySelector('#schedule-table-caption');
 		expect(caption).toBeInTheDocument();
 		expect(caption).toHaveTextContent('Departure times for 44 - University District');
 	});
 
-	test('AM and PM section rows are header cells with colgroup scope', () => {
+	test('AM and PM section rows are header cells with rowgroup scope', () => {
 		render(RouteScheduleTable, { props: { schedule } });
 
-		const amHeader = screen.getByRole('columnheader', { name: 'AM' });
-		const pmHeader = screen.getByRole('columnheader', { name: 'PM' });
+		const amHeader = screen.getByRole('rowheader', { name: 'AM' });
+		const pmHeader = screen.getByRole('rowheader', { name: 'PM' });
 
 		expect(amHeader.tagName).toBe('TH');
-		expect(amHeader).toHaveAttribute('scope', 'colgroup');
+		expect(amHeader).toHaveAttribute('scope', 'rowgroup');
 		expect(pmHeader.tagName).toBe('TH');
-		expect(pmHeader).toHaveAttribute('scope', 'colgroup');
+		expect(pmHeader).toHaveAttribute('scope', 'rowgroup');
 	});
 
 	test('column headers use scope="col"', () => {
@@ -82,5 +94,51 @@ describe('RouteScheduleTable accessibility', () => {
 
 		expect(screen.getByText('No AM schedules available')).toBeInTheDocument();
 		expect(screen.getByText('No PM schedules available')).toBeInTheDocument();
+	});
+});
+
+describe('RouteScheduleTable loading state', () => {
+	beforeEach(() => {
+		__setIsLoading(true);
+	});
+
+	afterEach(() => {
+		__setIsLoading(false);
+	});
+
+	test('keeps a stable region name reference while i18n loads', () => {
+		const { container } = render(RouteScheduleTable, { props: { schedule } });
+
+		const region = container.querySelector('[role="region"]');
+		expect(region).not.toHaveAttribute('aria-label');
+		expect(region).toHaveAttribute('aria-labelledby', 'schedule-table-caption');
+
+		const caption = container.querySelector('#schedule-table-caption');
+		expect(caption).toHaveTextContent('');
+	});
+});
+
+describe('RouteScheduleTable content', () => {
+	beforeEach(() => {
+		isLoading = false;
+	});
+
+	test('renders converted hours, minute cells, and full-time titles from schedule data', () => {
+		render(RouteScheduleTable, { props: { schedule } });
+
+		const amHourCell = screen.getByTitle('Full Time: 8:05');
+		expect(amHourCell).toHaveTextContent('8');
+		expect(amHourCell).toHaveTextContent('AM');
+
+		const amMinutesCell = amHourCell.closest('tr')?.querySelector('td:last-child');
+		expect(amMinutesCell).toHaveTextContent('05');
+		expect(amMinutesCell).toHaveTextContent('25');
+
+		const pmHourCell = screen.getByTitle('Full Time: 15:10');
+		expect(pmHourCell).toHaveTextContent('3');
+		expect(pmHourCell).toHaveTextContent('PM');
+
+		const pmMinutesCell = pmHourCell.closest('tr')?.querySelector('td:last-child');
+		expect(pmMinutesCell).toHaveTextContent('10');
 	});
 });

--- a/src/components/schedule-for-stop/__tests__/RouteScheduleTable.test.js
+++ b/src/components/schedule-for-stop/__tests__/RouteScheduleTable.test.js
@@ -46,13 +46,15 @@ describe('RouteScheduleTable accessibility', () => {
 	});
 
 	test('exposes the table within a keyboard-focusable labelled region', () => {
-		render(RouteScheduleTable, { props: { schedule } });
+		const { container } = render(RouteScheduleTable, { props: { schedule } });
 
 		const region = screen.getByRole('region', {
 			name: 'Departure times for 44 - University District'
 		});
+		const caption = container.querySelector('caption');
 		expect(region).toHaveAttribute('tabindex', '0');
-		expect(region).toHaveAttribute('aria-labelledby', 'schedule-table-caption');
+		expect(region).toHaveAttribute('aria-labelledby', caption.id);
+		expect(caption.id).toMatch(/^schedule-table-caption-/);
 		expect(region).not.toHaveAttribute('aria-label');
 		expect(region.querySelector('table')).toBeInTheDocument();
 	});
@@ -60,9 +62,25 @@ describe('RouteScheduleTable accessibility', () => {
 	test('table has a caption providing context for the route', () => {
 		const { container } = render(RouteScheduleTable, { props: { schedule } });
 
-		const caption = container.querySelector('#schedule-table-caption');
+		const caption = container.querySelector('caption');
 		expect(caption).toBeInTheDocument();
 		expect(caption).toHaveTextContent('Departure times for 44 - University District');
+	});
+
+	test('assigns a unique caption id per instance', () => {
+		const { container: first } = render(RouteScheduleTable, { props: { schedule } });
+		const { container: second } = render(RouteScheduleTable, {
+			props: { schedule: { ...schedule, tripHeadsign: '8 - Rainier Beach' } }
+		});
+
+		const firstCaption = first.querySelector('caption');
+		const secondCaption = second.querySelector('caption');
+		const firstRegion = first.querySelector('[role="region"]');
+		const secondRegion = second.querySelector('[role="region"]');
+
+		expect(firstCaption.id).not.toBe(secondCaption.id);
+		expect(firstRegion).toHaveAttribute('aria-labelledby', firstCaption.id);
+		expect(secondRegion).toHaveAttribute('aria-labelledby', secondCaption.id);
 	});
 
 	test('AM and PM section rows are header cells with rowgroup scope', () => {
@@ -110,10 +128,10 @@ describe('RouteScheduleTable loading state', () => {
 		const { container } = render(RouteScheduleTable, { props: { schedule } });
 
 		const region = container.querySelector('[role="region"]');
+		const caption = container.querySelector('caption');
 		expect(region).not.toHaveAttribute('aria-label');
-		expect(region).toHaveAttribute('aria-labelledby', 'schedule-table-caption');
-
-		const caption = container.querySelector('#schedule-table-caption');
+		expect(region).toHaveAttribute('aria-labelledby', caption.id);
+		expect(caption.id).toMatch(/^schedule-table-caption-/);
 		expect(caption).toHaveTextContent('');
 	});
 });

--- a/src/components/schedule-for-stop/__tests__/RouteScheduleTable.test.js
+++ b/src/components/schedule-for-stop/__tests__/RouteScheduleTable.test.js
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/svelte';
+import { expect, test, describe, vi } from 'vitest';
+import RouteScheduleTable from '../RouteScheduleTable.svelte';
+
+vi.mock('svelte-i18n', () => ({
+	t: {
+		subscribe: vi.fn((fn) => {
+			fn((key, options) => {
+				const translations = {
+					'schedule_for_stop.hour': 'Hour',
+					'schedule_for_stop.minutes': 'Minutes',
+					'schedule_for_stop.no_am_schedules_available': 'No AM schedules available',
+					'schedule_for_stop.no_pm_schedules_available': 'No PM schedules available',
+					'schedule_for_stop.schedule_table_caption': `Departure times for ${options?.values?.route ?? ''}`
+				};
+				return translations[key] ?? key;
+			});
+			return { unsubscribe: () => {} };
+		})
+	},
+	isLoading: {
+		subscribe: vi.fn((fn) => {
+			fn(false);
+			return { unsubscribe: () => {} };
+		})
+	}
+}));
+
+const schedule = {
+	tripHeadsign: '44 - University District',
+	stopTimes: {
+		8: [{ arrivalTime: '8:05AM' }, { arrivalTime: '8:25AM' }],
+		15: [{ arrivalTime: '3:10PM' }]
+	}
+};
+
+describe('RouteScheduleTable accessibility', () => {
+	test('exposes the table within a keyboard-focusable labelled region', () => {
+		render(RouteScheduleTable, { props: { schedule } });
+
+		const region = screen.getByRole('region', {
+			name: 'Departure times for 44 - University District'
+		});
+		expect(region).toHaveAttribute('tabindex', '0');
+		expect(region.querySelector('table')).toBeInTheDocument();
+	});
+
+	test('table has a caption providing context for the route', () => {
+		const { container } = render(RouteScheduleTable, { props: { schedule } });
+
+		const caption = container.querySelector('caption');
+		expect(caption).toBeInTheDocument();
+		expect(caption).toHaveTextContent('Departure times for 44 - University District');
+	});
+
+	test('AM and PM section rows are header cells with colgroup scope', () => {
+		render(RouteScheduleTable, { props: { schedule } });
+
+		const amHeader = screen.getByRole('columnheader', { name: 'AM' });
+		const pmHeader = screen.getByRole('columnheader', { name: 'PM' });
+
+		expect(amHeader.tagName).toBe('TH');
+		expect(amHeader).toHaveAttribute('scope', 'colgroup');
+		expect(pmHeader.tagName).toBe('TH');
+		expect(pmHeader).toHaveAttribute('scope', 'colgroup');
+	});
+
+	test('column headers use scope="col"', () => {
+		render(RouteScheduleTable, { props: { schedule } });
+
+		const hourHeader = screen.getByRole('columnheader', { name: 'Hour' });
+		const minutesHeader = screen.getByRole('columnheader', { name: 'Minutes' });
+
+		expect(hourHeader).toHaveAttribute('scope', 'col');
+		expect(minutesHeader).toHaveAttribute('scope', 'col');
+	});
+
+	test('renders empty-state messaging when a section has no times', () => {
+		render(RouteScheduleTable, {
+			props: { schedule: { tripHeadsign: 'Empty Route', stopTimes: {} } }
+		});
+
+		expect(screen.getByText('No AM schedules available')).toBeInTheDocument();
+		expect(screen.getByText('No PM schedules available')).toBeInTheDocument();
+	});
+});

--- a/src/locales/am.json
+++ b/src/locales/am.json
@@ -125,7 +125,8 @@
 		"route_schedules": "የመንገድ ጊዜ ሰንጠረዦች",
 		"no_schedules_available": "ምንም ጊዜ ሰንጠረዦች ለተመረጠው ቀን አልተገኙም።",
 		"stop_id": "የማቆሚያ መታወቂያ",
-		"direction": "አቅጣጫ"
+		"direction": "አቅጣጫ",
+		"schedule_table_caption": "የመነሻ ሰዓቶች ለ{route}"
 	},
 	"direction": {
 		"N": "ሰሜን",

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -125,7 +125,8 @@
 		"route_schedules": "جداول المسارات",
 		"no_schedules_available": "لا توجد جداول متاحة للتاريخ المحدد.",
 		"stop_id": "رقم المحطة",
-		"direction": "الاتجاه"
+		"direction": "الاتجاه",
+		"schedule_table_caption": "أوقات المغادرة لـ {route}"
 	},
 	"direction": {
 		"N": "شمال",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -155,7 +155,8 @@
 		"route_schedules": "Route Schedules",
 		"no_schedules_available": "No schedules available for the selected date.",
 		"stop_id": "Stop ID",
-		"direction": "Direction"
+		"direction": "Direction",
+		"schedule_table_caption": "Departure times for {route}"
 	},
 	"direction": {
 		"N": "North",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -125,7 +125,8 @@
 		"route_schedules": "Horarios de rutas",
 		"no_schedules_available": "No hay horarios disponibles para la fecha seleccionada.",
 		"stop_id": "ID de la parada",
-		"direction": "Dirección"
+		"direction": "Dirección",
+		"schedule_table_caption": "Horarios de salida para {route}"
 	},
 	"direction": {
 		"N": "Norte",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -125,7 +125,8 @@
 		"route_schedules": "برنامه زمانی خطوط",
 		"no_schedules_available": "برنامه‌ای برای تاریخ انتخاب شده موجود نیست.",
 		"stop_id": "شناسه ایستگاه",
-		"direction": "جهت"
+		"direction": "جهت",
+		"schedule_table_caption": "زمان‌های حرکت برای {route}"
 	},
 	"direction": {
 		"N": "شمال",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -125,7 +125,8 @@
 		"route_schedules": "Horaires des lignes",
 		"no_schedules_available": "Aucun horaire disponible pour la date sélectionnée.",
 		"stop_id": "ID de l'arrêt",
-		"direction": "Direction"
+		"direction": "Direction",
+		"schedule_table_caption": "Heures de départ pour {route}"
 	},
 	"direction": {
 		"N": "Nord",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -125,7 +125,8 @@
 		"route_schedules": "मार्ग समय सारणी",
 		"no_schedules_available": "चयनित तिथि के लिए कोई समय सारणी उपलब्ध नहीं।",
 		"stop_id": "स्टॉप आईडी",
-		"direction": "दिशा"
+		"direction": "दिशा",
+		"schedule_table_caption": "{route} के लिए प्रस्थान समय"
 	},
 	"direction": {
 		"N": "उत्तर",

--- a/src/locales/ht.json
+++ b/src/locales/ht.json
@@ -125,7 +125,8 @@
 		"route_schedules": "Orè Wout",
 		"no_schedules_available": "Pa gen orè disponib pou dat ou chwazi a.",
 		"stop_id": "ID Arè",
-		"direction": "Direksyon"
+		"direction": "Direksyon",
+		"schedule_table_caption": "Lè depa pou {route}"
 	},
 	"direction": {
 		"N": "Nò",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -125,7 +125,8 @@
 		"route_schedules": "路線時刻表",
 		"no_schedules_available": "選択した日付の時刻表はありません。",
 		"stop_id": "停留所ID",
-		"direction": "方面"
+		"direction": "方面",
+		"schedule_table_caption": "{route} の発車時刻"
 	},
 	"direction": {
 		"N": "北",

--- a/src/locales/km.json
+++ b/src/locales/km.json
@@ -125,7 +125,8 @@
 		"route_schedules": "កាលវិភាគផ្លូវ",
 		"no_schedules_available": "គ្មានកាលវិភាគសម្រាប់កាលបរិច្ឆេទដែលបានជ្រើសរើសទេ។",
 		"stop_id": "លេខសម្គាល់ចំណត",
-		"direction": "ទិសដៅ"
+		"direction": "ទិសដៅ",
+		"schedule_table_caption": "ម៉ោងចេញដំណើរសម្រាប់ {route}"
 	},
 	"direction": {
 		"N": "ខាងជើង",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -125,7 +125,8 @@
 		"route_schedules": "노선 시간표",
 		"no_schedules_available": "선택한 날짜의 운행 정보가 없습니다.",
 		"stop_id": "정류장 ID",
-		"direction": "방면"
+		"direction": "방면",
+		"schedule_table_caption": "{route} 출발 시간"
 	},
 	"direction": {
 		"N": "북쪽",

--- a/src/locales/lo.json
+++ b/src/locales/lo.json
@@ -125,7 +125,8 @@
 		"route_schedules": "ຕາຕະລາງເສັ້ນທາງ",
 		"no_schedules_available": "ບໍ່ມີຕາຕະລາງສຳລັບວັນທີ່ເລືອກ.",
 		"stop_id": "ລະຫັດປ້າຍ",
-		"direction": "ທິດທາງ"
+		"direction": "ທິດທາງ",
+		"schedule_table_caption": "ເວລາອອກເດີນທາງສຳລັບ {route}"
 	},
 	"direction": {
 		"N": "ເໜືອ",

--- a/src/locales/om.json
+++ b/src/locales/om.json
@@ -125,7 +125,8 @@
 		"route_schedules": "Sagantaa Sararaa",
 		"no_schedules_available": "Guyyaa filatameef sagantaan hin jiru.",
 		"stop_id": "Eenyummaa Dhaabbii",
-		"direction": "Kallattii"
+		"direction": "Kallattii",
+		"schedule_table_caption": "Yeroowwan ka'umsaa kan {route}"
 	},
 	"direction": {
 		"N": "Kaaba",

--- a/src/locales/pa.json
+++ b/src/locales/pa.json
@@ -125,7 +125,8 @@
 		"route_schedules": "ਰੂਟ ਸਮਾਂ-ਸਾਰਣੀਆਂ",
 		"no_schedules_available": "ਚੁਣੀ ਗਈ ਤਾਰੀਖ ਲਈ ਕੋਈ ਸਮਾਂ-ਸਾਰਣੀ ਉਪਲਬਧ ਨਹੀਂ।",
 		"stop_id": "ਸਟਾਪ ID",
-		"direction": "ਦਿਸ਼ਾ"
+		"direction": "ਦਿਸ਼ਾ",
+		"schedule_table_caption": "{route} ਲਈ ਰਵਾਨਗੀ ਸਮੇਂ"
 	},
 	"direction": {
 		"N": "ਉੱਤਰ",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -125,7 +125,8 @@
 		"route_schedules": "Rozkłady tras",
 		"no_schedules_available": "Brak dostępnych rozkładów na wybraną datę.",
 		"stop_id": "ID przystanku",
-		"direction": "Kierunek"
+		"direction": "Kierunek",
+		"schedule_table_caption": "Godziny odjazdów dla {route}"
 	},
 	"direction": {
 		"N": "Północ",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -125,7 +125,8 @@
 		"route_schedules": "Horários das Linhas",
 		"no_schedules_available": "Nenhum horário disponível para a data selecionada.",
 		"stop_id": "ID da Parada",
-		"direction": "Direção"
+		"direction": "Direção",
+		"schedule_table_caption": "Horários de partida para {route}"
 	},
 	"direction": {
 		"N": "Norte",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -125,7 +125,8 @@
 		"route_schedules": "Расписание маршрутов",
 		"no_schedules_available": "Нет расписания на выбранную дату.",
 		"stop_id": "ID остановки",
-		"direction": "Направление"
+		"direction": "Направление",
+		"schedule_table_caption": "Время отправления для {route}"
 	},
 	"direction": {
 		"N": "Север",

--- a/src/locales/sm.json
+++ b/src/locales/sm.json
@@ -125,7 +125,8 @@
 		"route_schedules": "Fuataga o Auala",
 		"no_schedules_available": "E leai ni fuataga o loʻo avanoa mo le aso na filifilia.",
 		"stop_id": "Numera o le Nofoaga Taofi",
-		"direction": "Itu"
+		"direction": "Itu",
+		"schedule_table_caption": "Taimi e malaga ai mo {route}"
 	},
 	"direction": {
 		"N": "Matu",

--- a/src/locales/so.json
+++ b/src/locales/so.json
@@ -125,7 +125,8 @@
 		"route_schedules": "Jadwalka waddooyinka",
 		"no_schedules_available": "Jadwal lama heli karo taariikhda la doortay.",
 		"stop_id": "Aqoonsiga joogsiga",
-		"direction": "Jihada"
+		"direction": "Jihada",
+		"schedule_table_caption": "Waqtiyada bixitaanka ee {route}"
 	},
 	"direction": {
 		"N": "Waqooyi",

--- a/src/locales/ti.json
+++ b/src/locales/ti.json
@@ -125,7 +125,8 @@
 		"route_schedules": "መደባት መስመር",
 		"no_schedules_available": "ንዝተመርጸ ዕለት ዝኾነ መደብ የለን።",
 		"stop_id": "መለለዪ መዕረፊ",
-		"direction": "ኣንፈት"
+		"direction": "ኣንፈት",
+		"schedule_table_caption": "ናይ መበገሲ ሰዓታት ን{route}"
 	},
 	"direction": {
 		"N": "ሰሜን",

--- a/src/locales/tl.json
+++ b/src/locales/tl.json
@@ -125,7 +125,8 @@
 		"route_schedules": "Mga iskedyul ng ruta",
 		"no_schedules_available": "Walang magagamit na iskedyul para sa napiling petsa.",
 		"stop_id": "ID ng hintuan",
-		"direction": "Direksyon"
+		"direction": "Direksyon",
+		"schedule_table_caption": "Mga oras ng pag-alis para sa {route}"
 	},
 	"direction": {
 		"N": "Hilaga",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -125,7 +125,8 @@
 		"route_schedules": "Розклад маршрутів",
 		"no_schedules_available": "Немає розкладу на обрану дату.",
 		"stop_id": "ID зупинки",
-		"direction": "Напрямок"
+		"direction": "Напрямок",
+		"schedule_table_caption": "Час відправлення для {route}"
 	},
 	"direction": {
 		"N": "Північ",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -125,7 +125,8 @@
 		"route_schedules": "Lịch trình tuyến đường",
 		"no_schedules_available": "Không có lịch trình nào khả dụng cho ngày đã chọn.",
 		"stop_id": "Mã điểm dừng",
-		"direction": "Hướng"
+		"direction": "Hướng",
+		"schedule_table_caption": "Giờ khởi hành cho {route}"
 	},
 	"direction": {
 		"N": "Bắc",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -125,7 +125,8 @@
 		"route_schedules": "线路时刻表",
 		"no_schedules_available": "所选日期暂无时刻表。",
 		"stop_id": "站点编号",
-		"direction": "方向"
+		"direction": "方向",
+		"schedule_table_caption": "{route} 的发车时间"
 	},
 	"direction": {
 		"N": "北",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -125,7 +125,8 @@
 		"route_schedules": "路線時刻表",
 		"no_schedules_available": "所選日期沒有班次。",
 		"stop_id": "站牌編號",
-		"direction": "方向"
+		"direction": "方向",
+		"schedule_table_caption": "{route} 的發車時間"
 	},
 	"direction": {
 		"N": "北",


### PR DESCRIPTION
## What this does

Fixes #514 
On /stops/{id}/schedule, tabbing past the route accordion used to skip the entire departure time table. Sighted keyboard users could not reach it and screen readers never entered table navigation mode. This PR closes those gaps.

## Changes

- The scrollable table is now wrapped in a focusable region (role="region", tabindex="0", aria-label). This gives keyboard users an entry point and announces what the table is when focus lands on it. I put the focus on the scroll container rather than the `<table>` element itself, which is the W3C recommended pattern for scrollable tables and also keeps the Svelte a11y linter happy.
- Added an sr-only `<caption>` so the table has a programmatic name for screen readers without changing the visual layout (the route name is already shown in the accordion header).
- The AM and PM rows are now `<th scope="colgroup">` instead of plain `<td>`, so screen readers announce them as section headers for the rows below them.
- Added scope="col" to the Hour and Minutes column headers to complete the header relationships, and removed the cursor-pointer class since those headers are not clickable.
- Added the new schedule_table_caption string to all 25 locale files.

## Screenshots
<img width="1141" height="579" alt="image" src="https://github.com/user-attachments/assets/ec9f625d-03b7-4a99-9852-16d58c96ae67" />

## Testing

- npm run lint passes
- Added src/components/schedule-for-stop/__tests__/RouteScheduleTable.test.js covering the focusable labelled region, the caption, the colgroup and col scopes, and the empty state. All pass.
- Manually verified with VoiceOver that the table is now reachable by keyboard and that headers are announced with each cell.