### PR TITLE
Fix remaning JSDoc gaps in dateTimeFormat.js

### DIFF
--- a/src/components/map/VehiclePopupContent.svelte
+++ b/src/components/map/VehiclePopupContent.svelte
@@ -8,7 +8,9 @@
 	const lastUpdatedText = $derived(
 		formatLastUpdated(lastUpdateTime, {
 			min: $t('time.min'),
+			mins: $t('time.mins'),
 			sec: $t('time.sec'),
+			secs: $t('time.secs'),
 			ago: $t('time.ago')
 		})
 	);

--- a/src/lib/colorUtils.js
+++ b/src/lib/colorUtils.js
@@ -10,6 +10,7 @@
  * @returns {{r: number, g: number, b: number} | null} RGB object or null if invalid
  */
 export function hexToRgb(hex) {
+	if (!hex || typeof hex !== 'string') return null;
 	hex = hex.replace(/^#/, '');
 	// Expand 3-digit hex to 6-digit
 	if (hex.length === 3) {
@@ -159,6 +160,7 @@ export function lightenColor(hexColor, amount) {
  * @returns {number} Brightness value (0-255)
  */
 export function getBrightness(rgb) {
+	if (!rgb) return 0;
 	// Standard luminance formula
 	return 0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b;
 }

--- a/src/lib/dateTimeFormat.js
+++ b/src/lib/dateTimeFormat.js
@@ -73,8 +73,8 @@ export const apiTimeFormat = new Intl.DateTimeFormat('en-US', {
  * msToTimeString(1705395900000, 'America/New_York', fourDigitTimeFormat)  // Returns '04:05 AM'
  *
  * @param {number} ms - Milliseconds since Unix epoch
- * @param {string} [timeZone] - IANA timezone. Defaults to the local timezone.
- * @param {Intl.DateTimeFormat} [dateTimeFormat] - Intl.DateTimeFormat to use for formatting. Defaults to localTimeFormat.
+ * @param {string} [timeZone=getLocalTimeZone()] - IANA timezone
+ * @param {Intl.DateTimeFormat} [dateTimeFormat=localTimeFormat] - Intl.DateTimeFormat to use for formatting
  * @returns {string} Time in the given format
  */
 export function msToTimeString(
@@ -281,7 +281,7 @@ export function parseDateInput(dateString) {
 /**
  * Format a 24-hour hour to 12-hour format
  *
- * @param {number} hour - Hour in 24-hour format
+ * @param {number|string} hour - Hour in 24-hour format (numeric strings are coerced to numbers)
  * @returns {number|null} Hour in 12-hour format, or null if invalid
  *
  * @example
@@ -289,6 +289,7 @@ export function parseDateInput(dateString) {
  * convert24HourTo12Hour(12)  // Returns 12
  * convert24HourTo12Hour(14)  // Returns 2
  * convert24HourTo12Hour(23)  // Returns 11
+ * convert24HourTo12Hour('14')  // Returns 2
  */
 export function convert24HourTo12Hour(hour) {
 	const hourNum = typeof hour === 'string' ? Number(hour) : hour;
@@ -351,15 +352,17 @@ export function formatDateForOTP(date, timeZone) {
  *
  * @param {number} timestamp - Timestamp in milliseconds since Unix epoch
  * @param {Object} translations - Object containing translation strings for minutes, seconds, and ago
- * @param {string} translations.min - Translation string for minutes
- * @param {string} translations.sec - Translation string for seconds
+ * @param {string} translations.min - Singular translation for minutes
+ * @param {string} [translations.mins] - Plural translation for minutes (falls back to min)
+ * @param {string} translations.sec - Singular translation for seconds
+ * @param {string} [translations.secs] - Plural translation for seconds (falls back to sec)
  * @param {string} translations.ago - Translation string for ago
  * @returns {string} Formatted last updated string
  *
  * @example
  * Note: The actual output of these examples depends on the current time
- * formatLastUpdated(1715894400000, { min: 'min', sec: 'sec', ago: 'ago' })  // Returns '1 min 30 sec ago'
- * formatLastUpdated(1715894400000, { min: 'minute', sec: 'second', ago: 'ago' })  // Returns '1 minute 30 second ago'
+ * formatLastUpdated(1715894400000, { min: 'min', mins: 'mins', sec: 'sec', secs: 'secs', ago: 'ago' })  // Returns '1 min 30 secs ago'
+ * formatLastUpdated(1715894400000, { min: 'minute', mins: 'minutes', sec: 'second', secs: 'seconds', ago: 'ago' })  // Returns '1 minute 30 seconds ago'
  */
 export function formatLastUpdated(timestamp, translations) {
 	if (!Number.isFinite(timestamp)) return 'N/A';
@@ -367,8 +370,10 @@ export function formatLastUpdated(timestamp, translations) {
 	const now = Temporal.Now.instant();
 	const { minutes, seconds } = now.since(date).round({ largestUnit: 'minute' });
 
-	const minutesStr = minutes > 0 ? `${minutes} ${translations.min} ` : '';
-	return `${minutesStr}${seconds} ${translations.sec} ${translations.ago}`;
+	const minutesLabel = minutes === 1 ? translations.min : (translations.mins ?? translations.min);
+	const secondsLabel = seconds === 1 ? translations.sec : (translations.secs ?? translations.sec);
+	const minutesStr = minutes > 0 ? `${minutes} ${minutesLabel} ` : '';
+	return `${minutesStr}${seconds} ${secondsLabel} ${translations.ago}`;
 }
 
 /**

--- a/src/tests/lib/colorUtils.test.js
+++ b/src/tests/lib/colorUtils.test.js
@@ -49,6 +49,13 @@ describe('colorUtils', () => {
 			expect(hexToRgb('#ff00')).toBeNull(); // 4 digits
 			expect(hexToRgb('#ff00000')).toBeNull(); // 7 digits
 		});
+
+		test('returns null for null, undefined, and non-string input', () => {
+			expect(hexToRgb(null)).toBeNull();
+			expect(hexToRgb(undefined)).toBeNull();
+			expect(hexToRgb(123456)).toBeNull();
+			expect(hexToRgb({})).toBeNull();
+		});
 	});
 
 	describe('rgbToHex', () => {
@@ -329,6 +336,11 @@ describe('colorUtils', () => {
 			const rgb = { r: 0, g: 0, b: 0 };
 			const brightness = getBrightness(rgb);
 			expect(brightness).toBe(0);
+		});
+
+		test('should return 0 for null or undefined input', () => {
+			expect(getBrightness(null)).toBe(0);
+			expect(getBrightness(undefined)).toBe(0);
 		});
 
 		test('should return 255 for pure white', () => {

--- a/src/tests/lib/dateTimeFormat.test.js
+++ b/src/tests/lib/dateTimeFormat.test.js
@@ -542,7 +542,7 @@ describe('formatLastUpdated', () => {
 		expect(result).toBe('1 min 30 segs atrás');
 	});
 
-	it('falls back to singular labels when plural forms are omitted', () => {
+	it('falls back to singular sec label when secs is omitted', () => {
 		const abbreviatedTranslations = {
 			min: 'min',
 			sec: 'sec',
@@ -551,6 +551,17 @@ describe('formatLastUpdated', () => {
 		const timestamp = new Date('2024-01-16T11:59:30Z').valueOf();
 		const result = formatLastUpdated(timestamp, abbreviatedTranslations);
 		expect(result).toBe('30 sec ago');
+	});
+
+	it('falls back to singular min label when mins is omitted', () => {
+		const abbreviatedTranslations = {
+			min: 'min',
+			sec: 'sec',
+			ago: 'ago'
+		};
+		const timestamp = new Date('2024-01-16T11:57:15Z').valueOf();
+		const result = formatLastUpdated(timestamp, abbreviatedTranslations);
+		expect(result).toBe('2 min 45 sec ago');
 	});
 
 	it('uses full-word plural forms when provided', () => {

--- a/src/tests/lib/dateTimeFormat.test.js
+++ b/src/tests/lib/dateTimeFormat.test.js
@@ -490,7 +490,9 @@ describe('formatDepartureDisplay', () => {
 describe('formatLastUpdated', () => {
 	const translations = {
 		min: 'min',
+		mins: 'mins',
 		sec: 'sec',
+		secs: 'secs',
 		ago: 'ago'
 	};
 
@@ -506,19 +508,19 @@ describe('formatLastUpdated', () => {
 	it('formats time less than a minute ago', () => {
 		const timestamp = new Date('2024-01-16T11:59:30Z').valueOf();
 		const result = formatLastUpdated(timestamp, translations);
-		expect(result).toBe('30 sec ago');
+		expect(result).toBe('30 secs ago');
 	});
 
 	it('formats time more than a minute ago', () => {
 		const timestamp = new Date('2024-01-16T11:58:30Z').valueOf();
 		const result = formatLastUpdated(timestamp, translations);
-		expect(result).toBe('1 min 30 sec ago');
+		expect(result).toBe('1 min 30 secs ago');
 	});
 
 	it('formats time multiple minutes ago', () => {
 		const timestamp = new Date('2024-01-16T11:57:15Z').valueOf();
 		const result = formatLastUpdated(timestamp, translations);
-		expect(result).toBe('2 min 45 sec ago');
+		expect(result).toBe('2 mins 45 secs ago');
 	});
 
 	it('handles just-now timestamps', () => {
@@ -530,18 +532,44 @@ describe('formatLastUpdated', () => {
 	it('works with different translation objects', () => {
 		const spanishTranslations = {
 			min: 'min',
+			mins: 'mins',
 			sec: 'seg',
+			secs: 'segs',
 			ago: 'atrás'
 		};
 		const timestamp = new Date('2024-01-16T11:58:30Z').valueOf();
 		const result = formatLastUpdated(timestamp, spanishTranslations);
-		expect(result).toBe('1 min 30 seg atrás');
+		expect(result).toBe('1 min 30 segs atrás');
+	});
+
+	it('falls back to singular labels when plural forms are omitted', () => {
+		const abbreviatedTranslations = {
+			min: 'min',
+			sec: 'sec',
+			ago: 'ago'
+		};
+		const timestamp = new Date('2024-01-16T11:59:30Z').valueOf();
+		const result = formatLastUpdated(timestamp, abbreviatedTranslations);
+		expect(result).toBe('30 sec ago');
+	});
+
+	it('uses full-word plural forms when provided', () => {
+		const fullWordTranslations = {
+			min: 'minute',
+			mins: 'minutes',
+			sec: 'second',
+			secs: 'seconds',
+			ago: 'ago'
+		};
+		const timestamp = new Date('2024-01-16T11:59:30Z').valueOf();
+		const result = formatLastUpdated(timestamp, fullWordTranslations);
+		expect(result).toBe('30 seconds ago');
 	});
 
 	it('handles zero seconds case', () => {
 		const timestamp = new Date('2024-01-16T12:00:00Z').valueOf();
 		const result = formatLastUpdated(timestamp, translations);
-		expect(result).toBe('0 sec ago');
+		expect(result).toBe('0 secs ago');
 	});
 
 	// Invalid inputs


### PR DESCRIPTION
Fixes #388 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “last updated” time messages to use proper singular and plural wording, including minute/second variants and fallback translations.
  * Made color-related utilities safer by returning sensible defaults for missing or invalid input instead of failing.
* **Tests**
  * Expanded coverage for invalid color values and pluralized time formatting cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->