### PR TITLE
feat: add shareable trip plan URLs

### DIFF
--- a/src/components/MapContainer.svelte
+++ b/src/components/MapContainer.svelte
@@ -15,6 +15,7 @@
 		mapProvider = $bindable(),
 		stop,
 		initialCoords = null,
+		startInTripPlanMode = false,
 		...restProps
 	} = $props();
 
@@ -30,7 +31,14 @@
 </script>
 
 {#if mapProvider}
-	<MapView {handleStopMarkerSelect} {mapProvider} {stop} {initialCoords} {...restProps} />
+	<MapView
+		{handleStopMarkerSelect}
+		{mapProvider}
+		{stop}
+		{initialCoords}
+		{startInTripPlanMode}
+		{...restProps}
+	/>
 {:else}
 	<FullPageLoadingSpinner />
 {/if}

--- a/src/components/MapExperience.svelte
+++ b/src/components/MapExperience.svelte
@@ -27,7 +27,7 @@
 	import { analyticsDistanceToStop } from '$lib/Insights/insightsUtils';
 	import SurveyLauncher from '$components/surveys/SurveyLauncher.svelte';
 	import { parseInitialCoordinates, cleanUrlParams } from '$lib/urlParams';
-	import { parseTripParams } from '$lib/urlState';
+	import { hasTripParams } from '$lib/urlState';
 	import { env } from '$env/dynamic/public';
 	import TripOptionsModal from '$components/trip-planner/TripOptionsModal.svelte';
 	import { showTripOptionsModal } from '$stores/tripOptionsStore';
@@ -48,10 +48,10 @@
 				Number(PUBLIC_OBA_REGION_CENTER_LNG)
 			);
 
-	// Shared trip links should enter trip-plan mode before the map loads stops,
-	// so region-center markers are never painted and then stuck on the map.
+	// Any shared-trip URL (valid or broken) should enter trip-plan mode before the
+	// map loads stops, so region-center markers are never painted and then stuck.
 	const startInTripPlanMode =
-		browser && !!env.PUBLIC_OTP_SERVER_URL && !!parseTripParams(initialPage.url.searchParams);
+		browser && !!env.PUBLIC_OTP_SERVER_URL && hasTripParams(initialPage.url.searchParams);
 
 	let currentModal = $state(null);
 	let selectedTrip = $state(null);

--- a/src/components/MapExperience.svelte
+++ b/src/components/MapExperience.svelte
@@ -27,6 +27,8 @@
 	import { analyticsDistanceToStop } from '$lib/Insights/insightsUtils';
 	import SurveyLauncher from '$components/surveys/SurveyLauncher.svelte';
 	import { parseInitialCoordinates, cleanUrlParams } from '$lib/urlParams';
+	import { parseTripParams } from '$lib/urlState';
+	import { env } from '$env/dynamic/public';
 	import TripOptionsModal from '$components/trip-planner/TripOptionsModal.svelte';
 	import { showTripOptionsModal } from '$stores/tripOptionsStore';
 	import { mapStopPath } from '$lib/mapStopUrl.js';
@@ -45,6 +47,11 @@
 				Number(PUBLIC_OBA_REGION_CENTER_LAT),
 				Number(PUBLIC_OBA_REGION_CENTER_LNG)
 			);
+
+	// Shared trip links should enter trip-plan mode before the map loads stops,
+	// so region-center markers are never painted and then stuck on the map.
+	const startInTripPlanMode =
+		browser && !!env.PUBLIC_OTP_SERVER_URL && !!parseTripParams(initialPage.url.searchParams);
 
 	let currentModal = $state(null);
 	let selectedTrip = $state(null);
@@ -567,6 +574,7 @@
 		{isRouteSelected}
 		{showRouteMap}
 		{initialCoords}
+		{startInTripPlanMode}
 		{activeRoutes}
 		{routeColors}
 		bind:mapProvider

--- a/src/components/map/MapView.svelte
+++ b/src/components/map/MapView.svelte
@@ -24,6 +24,7 @@
 	 * @property {any} [mapProvider]
 	 * @property {any} [stop] - Currently selected stop to preserve visual context
 	 * @property {{ lat: number, lng: number } | null} [initialCoords] - Optional initial coordinates from URL params
+	 * @property {boolean} [startInTripPlanMode] - Skip initial stop load when opening a shared trip link
 	 */
 
 	/** @type {Props} */
@@ -37,7 +38,8 @@
 		stop = null,
 		initialCoords = null,
 		activeRoutes = [],
-		routeColors = new Map()
+		routeColors = new Map(),
+		startInTripPlanMode = false
 	} = $props();
 
 	let routeStopIds = $state(new Map());
@@ -72,7 +74,7 @@
 		}
 	});
 
-	let isTripPlanModeActive = $state(false);
+	let isTripPlanModeActive = $state(startInTripPlanMode);
 	let mapInstance = $state(null);
 	let mapElement = $state();
 	let allStops = $state([]);
@@ -86,8 +88,9 @@
 		ROUTE: 'route'
 	};
 
-	let mapMode = $state(Modes.NORMAL);
+	let mapMode = $state(startInTripPlanMode ? Modes.TRIP_PLAN : Modes.NORMAL);
 	let modeChangeTimeout = null;
+	let pendingMarkerBatch = null;
 
 	$effect(() => {
 		let newMode;
@@ -114,13 +117,32 @@
 		}
 	});
 
+	let previousMapMode = startInTripPlanMode ? Modes.TRIP_PLAN : Modes.NORMAL;
+
 	$effect(() => {
 		if (!mapInstance) return;
-		if (mapMode === Modes.NORMAL) {
-			batchAddMarkers(allStops);
+		const mode = mapMode;
+		// Read allStops synchronously so this effect keeps re-rendering markers as
+		// the list grows on subsequent map pans, regardless of which branch runs.
+		const stops = allStops;
+		if (mode === Modes.NORMAL) {
+			// Returning from route/trip mode: the map may have moved far from
+			// where stops were last loaded (e.g. opening a shared trip link
+			// recenters the map), and stop loading is skipped while off NORMAL.
+			// Refresh stops for the current viewport so the area isn't empty.
+			if (previousMapMode !== Modes.NORMAL) {
+				const center = mapInstance.getCenter();
+				const zoomLevel = mapInstance.map.getZoom();
+				loadStopsAndAddMarkers(center.lat, center.lng, false, zoomLevel)
+					.then(() => batchAddMarkers(allStops))
+					.catch((error) => console.error('Error refreshing stops on return to map:', error));
+			} else {
+				batchAddMarkers(stops);
+			}
 		} else {
 			clearAllMarkers();
 		}
+		previousMapMode = mode;
 	});
 
 	function cacheKey(zoomLevel, boundingBox) {
@@ -191,7 +213,11 @@
 			// dot on it or seed the userLocation store (which feeds the analytics
 			// distance-to-stop bucket) with coordinates that aren't the user's.
 
-			await loadStopsAndAddMarkers(mapCenterLat, mapCenterLng, true);
+			// Shared trip links enter trip-plan mode immediately; loading region-center
+			// stops here would race with the itinerary and leave stray markers on the map.
+			if (!startInTripPlanMode) {
+				await loadStopsAndAddMarkers(mapCenterLat, mapCenterLng, true);
+			}
 
 			const debouncedLoadMarkers = debounce(async () => {
 				if (mapMode !== Modes.NORMAL) {
@@ -237,6 +263,10 @@
 	}
 
 	function clearAllMarkers() {
+		if (pendingMarkerBatch !== null) {
+			cancelAnimationFrame(pendingMarkerBatch);
+			pendingMarkerBatch = null;
+		}
 		if (mapInstance && mapInstance.clearAllStopMarkers) {
 			mapInstance.clearAllStopMarkers();
 		}
@@ -244,21 +274,33 @@
 
 	// Batch operation to add multiple markers efficiently
 	function batchAddMarkers(stops) {
+		if (!mapInstance || mapMode !== Modes.NORMAL) {
+			return;
+		}
+
 		const stopsToAdd = stops.filter((s) => !mapInstance.hasMarker(s.id));
 
 		if (stopsToAdd.length === 0) {
 			return;
 		}
 
-		// Group DOM operations to minimize reflows/repaints
-		requestAnimationFrame(() => {
+		if (pendingMarkerBatch !== null) {
+			cancelAnimationFrame(pendingMarkerBatch);
+		}
+
+		// Group DOM operations to minimize reflows/repaints. Re-check map mode when
+		// the frame runs so a pending batch cannot repaint stops after trip mode clears them.
+		pendingMarkerBatch = requestAnimationFrame(() => {
+			pendingMarkerBatch = null;
+			if (!mapInstance || mapMode !== Modes.NORMAL) {
+				return;
+			}
 			stopsToAdd.forEach((s) => addMarker(s));
 		});
 	}
 
 	function addMarker(s) {
-		if (!mapInstance) {
-			console.error('Map not initialized yet');
+		if (!mapInstance || mapMode !== Modes.NORMAL) {
 			return;
 		}
 
@@ -339,6 +381,11 @@
 
 		if (modeChangeTimeout) {
 			clearTimeout(modeChangeTimeout);
+		}
+
+		if (pendingMarkerBatch !== null) {
+			cancelAnimationFrame(pendingMarkerBatch);
+			pendingMarkerBatch = null;
 		}
 
 		clearAllMarkers();

--- a/src/components/map/MapView.svelte
+++ b/src/components/map/MapView.svelte
@@ -24,7 +24,8 @@
 	 * @property {any} [mapProvider]
 	 * @property {any} [stop] - Currently selected stop to preserve visual context
 	 * @property {{ lat: number, lng: number } | null} [initialCoords] - Optional initial coordinates from URL params
-	 * @property {boolean} [startInTripPlanMode] - Skip initial stop load when opening a shared trip link
+	 * @property {boolean} [startInTripPlanMode] - Seeds the map's starting mode as trip-plan (not just the initial
+	 *   stop load skip below) so a shared trip link never briefly renders in NORMAL mode before switching.
 	 */
 
 	/** @type {Props} */
@@ -131,8 +132,14 @@
 			// recenters the map), and stop loading is skipped while off NORMAL.
 			// Refresh stops for the current viewport so the area isn't empty.
 			if (previousMapMode !== Modes.NORMAL) {
+				// Re-add whatever stops are already cached immediately (a no-op when
+				// empty, e.g. a shared trip link that skipped the initial load) so
+				// the map isn't left blank for the duration of the refresh below.
+				// The refresh corrects this once the current viewport's stops land.
+				batchAddMarkers(stops);
+
 				const center = mapInstance.getCenter();
-				const zoomLevel = mapInstance.map.getZoom();
+				const zoomLevel = mapInstance.getZoom();
 				loadStopsAndAddMarkers(center.lat, center.lng, false, zoomLevel)
 					.then(() => batchAddMarkers(allStops))
 					.catch((error) => console.error('Error refreshing stops on return to map:', error));
@@ -225,7 +232,7 @@
 				}
 
 				const center = mapInstance.getCenter();
-				const zoomLevel = mapInstance.map.getZoom();
+				const zoomLevel = mapInstance.getZoom();
 				await loadStopsAndAddMarkers(center.lat, center.lng, false, zoomLevel);
 			}, 300);
 

--- a/src/components/search/SearchPane.svelte
+++ b/src/components/search/SearchPane.svelte
@@ -16,7 +16,7 @@
 	import { removeAgencyPrefix } from '$lib/utils';
 	import { browser } from '$app/environment';
 	import { page } from '$app/stores';
-	import { parseTripParams } from '$lib/urlState';
+	import { parseTripParams, hasTripParams } from '$lib/urlState';
 
 	let {
 		handleRouteSelected,
@@ -266,20 +266,37 @@
 	// Restore a trip shared via the URL. Waits for the map so TripPlan can drop
 	// pins, then opens the Plan tab and hands the parsed trip to TripPlan. The
 	// parsed trip is captured up front because planTripTabClicked resets the URL
-	// to "/" (the planned trip rewrites it once the itinerary loads).
+	// to "/" (the planned trip rewrites it once the itinerary loads). Wrapped in
+	// try/catch since this runs from an isMapLoaded subscription callback with no
+	// caller to report failures to.
 	async function maybeRestoreSharedTrip() {
 		if (hasRestoredSharedTrip || !env.PUBLIC_OTP_SERVER_URL) return;
 
-		const trip = parseTripParams($page.url.searchParams);
-		if (!trip) return;
+		const searchParams = $page.url.searchParams;
+		const trip = parseTripParams(searchParams);
+
+		// "from"/"to" present but unparsable (truncated, corrupted, out of range):
+		// tell the recipient the link didn't work instead of silently falling
+		// back to the default map with no explanation.
+		if (!trip && !hasTripParams(searchParams)) return;
 
 		hasRestoredSharedTrip = true;
-		activeTab = 'plan';
-		await tick();
-		// Mirror a real Plan tab click so the map hides stop markers and enters
-		// trip-plan mode. Dispatched after tick so MapView's listener is ready.
-		window.dispatchEvent(new CustomEvent('planTripTabClicked'));
-		window.dispatchEvent(new CustomEvent('loadSharedTrip', { detail: trip }));
+		try {
+			activeTab = 'plan';
+			// tick() also lets the Plan tab mount so TripPlan's loadSharedTrip /
+			// invalidSharedTrip listeners are registered before either is dispatched.
+			await tick();
+			// Mirror a real Plan tab click so the map hides stop markers and enters
+			// trip-plan mode. Dispatched after tick so MapView's listener is ready.
+			window.dispatchEvent(new CustomEvent('planTripTabClicked'));
+			if (trip) {
+				window.dispatchEvent(new CustomEvent('loadSharedTrip', { detail: trip }));
+			} else {
+				window.dispatchEvent(new CustomEvent('invalidSharedTrip'));
+			}
+		} catch (error) {
+			console.error('Failed to restore shared trip from URL:', error);
+		}
 	}
 
 	onMount(() => {

--- a/src/components/search/SearchPane.svelte
+++ b/src/components/search/SearchPane.svelte
@@ -15,6 +15,8 @@
 	import { answeredSurveys, surveyStore } from '$stores/surveyStore';
 	import { removeAgencyPrefix } from '$lib/utils';
 	import { browser } from '$app/environment';
+	import { page } from '$app/stores';
+	import { parseTripParams } from '$lib/urlState';
 
 	let {
 		handleRouteSelected,
@@ -259,9 +261,33 @@
 		isContextMenuTrigger = false;
 	}
 
+	let hasRestoredSharedTrip = false;
+
+	// Restore a trip shared via the URL. Waits for the map so TripPlan can drop
+	// pins, then opens the Plan tab and hands the parsed trip to TripPlan. The
+	// parsed trip is captured up front because planTripTabClicked resets the URL
+	// to "/" (the planned trip rewrites it once the itinerary loads).
+	async function maybeRestoreSharedTrip() {
+		if (hasRestoredSharedTrip || !env.PUBLIC_OTP_SERVER_URL) return;
+
+		const trip = parseTripParams($page.url.searchParams);
+		if (!trip) return;
+
+		hasRestoredSharedTrip = true;
+		activeTab = 'plan';
+		await tick();
+		// Mirror a real Plan tab click so the map hides stop markers and enters
+		// trip-plan mode. Dispatched after tick so MapView's listener is ready.
+		window.dispatchEvent(new CustomEvent('planTripTabClicked'));
+		window.dispatchEvent(new CustomEvent('loadSharedTrip', { detail: trip }));
+	}
+
 	onMount(() => {
 		unsubscribeMapLoaded = isMapLoaded.subscribe((value) => {
 			mapLoaded = value;
+			if (value && mapProvider) {
+				maybeRestoreSharedTrip();
+			}
 		});
 
 		window.addEventListener('routeSelectedFromModal', handleRouteSelectedFromModal);

--- a/src/components/search/__tests__/SearchPane.test.js
+++ b/src/components/search/__tests__/SearchPane.test.js
@@ -33,9 +33,22 @@ vi.mock('$stores/surveyStore', () => ({
 	answeredSurveys: createMockStore({ 'survey-1': false })
 }));
 
+// Mutable so individual tests can simulate opening the app with a shared-trip
+// URL (?from=...&to=...) without re-declaring the mock per test file.
+let mockPublicEnv = { PUBLIC_OTP_SERVER_URL: 'https://otp.example.com' };
 vi.mock('$env/dynamic/public', () => ({
-	env: {
-		PUBLIC_OTP_SERVER_URL: 'https://otp.example.com'
+	get env() {
+		return mockPublicEnv;
+	}
+}));
+
+let mockPageUrl = new URL('https://example.com/');
+vi.mock('$app/stores', () => ({
+	page: {
+		subscribe: vi.fn((fn) => {
+			fn({ url: mockPageUrl });
+			return () => {};
+		})
 	}
 }));
 
@@ -68,6 +81,9 @@ describe('SearchPane', () => {
 	let mockFetch;
 
 	beforeEach(() => {
+		mockPageUrl = new URL('https://example.com/');
+		mockPublicEnv = { PUBLIC_OTP_SERVER_URL: 'https://otp.example.com' };
+
 		// Mock map provider
 		mockMapProvider = {
 			panTo: vi.fn(),
@@ -370,6 +386,90 @@ describe('SearchPane', () => {
 			const { container } = render(SearchPane, { props: mockProps });
 
 			expect(container.querySelector('.modal-pane')).not.toHaveClass('hidden');
+		});
+	});
+
+	describe('Shared trip URL restore', () => {
+		test('dispatches planTripTabClicked and loadSharedTrip when the URL has valid trip params', async () => {
+			mockPageUrl = new URL(
+				'https://example.com/?from=47.6,-122.3&to=47.7,-122.4&fromName=Home&toName=Work'
+			);
+
+			render(SearchPane, { props: mockProps });
+
+			await waitFor(() => {
+				expect(global.dispatchEvent).toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'planTripTabClicked' })
+				);
+			});
+
+			expect(global.dispatchEvent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'loadSharedTrip',
+					detail: {
+						selectedFrom: { lat: 47.6, lng: -122.3 },
+						selectedTo: { lat: 47.7, lng: -122.4 },
+						fromPlace: 'Home',
+						toPlace: 'Work'
+					}
+				})
+			);
+		});
+
+		test('dispatches invalidSharedTrip when trip params are present but unparsable', async () => {
+			mockPageUrl = new URL('https://example.com/?from=bad&to=also-bad');
+
+			render(SearchPane, { props: mockProps });
+
+			await waitFor(() => {
+				expect(global.dispatchEvent).toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'planTripTabClicked' })
+				);
+			});
+
+			expect(global.dispatchEvent).toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'invalidSharedTrip' })
+			);
+			expect(global.dispatchEvent).not.toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'loadSharedTrip' })
+			);
+		});
+
+		test('does nothing when the URL has no trip params', async () => {
+			mockPageUrl = new URL('https://example.com/');
+			vi.mocked(global.dispatchEvent).mockClear();
+
+			render(SearchPane, { props: mockProps });
+
+			await waitFor(() => {
+				expect(screen.getByText('Stops & Stations')).toBeInTheDocument();
+			});
+
+			const sharedTripEvents = vi
+				.mocked(global.dispatchEvent)
+				.mock.calls.filter(([event]) =>
+					['planTripTabClicked', 'loadSharedTrip', 'invalidSharedTrip'].includes(event.type)
+				);
+			expect(sharedTripEvents).toHaveLength(0);
+		});
+
+		test('does nothing when OTP is not configured', async () => {
+			mockPublicEnv = { PUBLIC_OTP_SERVER_URL: '' };
+			mockPageUrl = new URL('https://example.com/?from=47.6,-122.3&to=47.7,-122.4');
+			vi.mocked(global.dispatchEvent).mockClear();
+
+			render(SearchPane, { props: mockProps });
+
+			await waitFor(() => {
+				expect(screen.getByText('Stops & Stations')).toBeInTheDocument();
+			});
+
+			const sharedTripEvents = vi
+				.mocked(global.dispatchEvent)
+				.mock.calls.filter(([event]) =>
+					['planTripTabClicked', 'loadSharedTrip', 'invalidSharedTrip'].includes(event.type)
+				);
+			expect(sharedTripEvents).toHaveLength(0);
 		});
 	});
 });

--- a/src/components/trip-planner/TripPlan.svelte
+++ b/src/components/trip-planner/TripPlan.svelte
@@ -174,13 +174,20 @@
 		toMarker = result.toMarker;
 	}
 
+	// Always resolves to an OTP-response-shaped object ({ plan } or { error }),
+	// never null. A shared link recipient has no context to recover from a
+	// silent failure, so every failure path here (bad coordinates, network
+	// error, non-2xx response) is surfaced as an { error } result instead of
+	// being swallowed — the caller can then always call handleTripPlan and let
+	// the itinerary modal show a message rather than leaving a blank screen.
 	async function fetchTripPlan(from, to) {
 		const fromValidation = validateCoordinates(from);
 		const toValidation = validateCoordinates(to);
 
 		if (!fromValidation.valid || !toValidation.valid) {
-			console.error('Invalid coordinates:', fromValidation.error || toValidation.error);
-			return null;
+			const message = fromValidation.error || toValidation.error;
+			console.error('Invalid coordinates:', message);
+			return { error: { id: 'INVALID_COORDINATES', msg: $t('trip-planner.request_failed') } };
 		}
 
 		try {
@@ -199,24 +206,35 @@
 			return data;
 		} catch (error) {
 			console.error(error.message);
-			return null;
+			return { error: { id: 'REQUEST_FAILED', msg: $t('trip-planner.request_failed') } };
 		}
 	}
 
 	// Reflect the planned trip in the URL so it can be copied and shared. Uses
 	// replaceState to keep the shareable link current without stacking history.
+	// Guarded: replaceState throws if called before SvelteKit's router has
+	// initialized, and failing to update the shareable link should never break
+	// the actual trip the user just planned.
 	function syncTripUrl() {
 		if (!browser) return;
-		const url = new URL($page.url);
-		applyTripParams(url, { selectedFrom, selectedTo, fromPlace, toPlace });
-		replaceState(url, {});
+		try {
+			const url = new URL($page.url);
+			applyTripParams(url, { selectedFrom, selectedTo, fromPlace, toPlace });
+			replaceState(url, {});
+		} catch (e) {
+			console.warn('Failed to update shareable trip URL:', e);
+		}
 	}
 
 	function clearTripUrl() {
 		if (!browser) return;
-		const url = new URL($page.url);
-		removeTripParams(url);
-		replaceState(url, {});
+		try {
+			const url = new URL($page.url);
+			removeTripParams(url);
+			replaceState(url, {});
+		} catch (e) {
+			console.warn('Failed to clear shareable trip URL:', e);
+		}
 	}
 
 	async function planTrip() {
@@ -238,13 +256,15 @@
 			fromMarker = mapProvider.addPinMarker(selectedFrom, $t('trip-planner.from'));
 			toMarker = mapProvider.addPinMarker(selectedTo, $t('trip-planner.to'));
 
+			// fetchTripPlan always resolves (never null/throws), so the itinerary
+			// modal opens either with results or a visible error — a shared-link
+			// recipient never lands on a blank, dead-end map.
 			const data = await fetchTripPlan(selectedFrom, selectedTo);
+			handleTripPlan({ data });
 
-			if (data) {
-				handleTripPlan({ data });
+			if (!data.error) {
 				syncTripUrl();
 
-				// Save to recent trips
 				try {
 					recentTrips.addTrip({
 						fromPlace,
@@ -256,6 +276,8 @@
 					console.warn('Failed to save trip to recent history:', e);
 				}
 			}
+		} catch (error) {
+			console.error('Unexpected error while planning trip:', error);
 		} finally {
 			loading = false;
 		}
@@ -299,19 +321,36 @@
 	}
 
 	// Restore a shared trip from the URL: hydrate the form, drop the pins, and run
-	// the search so the recipient lands on the same itinerary.
+	// the search so the recipient lands on the same itinerary. Wrapped in
+	// try/catch: this runs from a window event with no caller to report to, so a
+	// malformed detail payload must not become an unhandled rejection — planTrip
+	// itself already can't throw, but this also guards the destructuring above it.
 	async function handleLoadSharedTrip(e) {
-		const { selectedFrom: from, selectedTo: to, fromPlace: fp, toPlace: tp } = e.detail;
-		fromPlace = fp;
-		toPlace = tp;
-		selectedFrom = from;
-		selectedTo = to;
-		fromResults = [];
-		toResults = [];
-		await planTrip();
+		try {
+			const { selectedFrom: from, selectedTo: to, fromPlace: fp, toPlace: tp } = e.detail;
+			fromPlace = fp;
+			toPlace = tp;
+			selectedFrom = from;
+			selectedTo = to;
+			fromResults = [];
+			toResults = [];
+			await planTrip();
+		} catch (error) {
+			console.error('Failed to restore shared trip:', error);
+		}
+	}
+
+	// A shared link had a "from"/"to" param present but it didn't parse (broken,
+	// truncated, out of range). Surface that in the same itinerary modal used for
+	// every other trip-planning failure rather than leaving a silent blank map.
+	function handleInvalidSharedTrip() {
+		handleTripPlan({
+			data: { error: { id: 'INVALID_SHARED_LINK', msg: $t('trip-planner.invalid_shared_link') } }
+		});
 	}
 
 	let loadSharedTripHandler;
+	let invalidSharedTripHandler;
 
 	onMount(() => {
 		if (browser) {
@@ -322,10 +361,12 @@
 			setTripPlanLocationHandler = handleSetTripPlanLocation;
 			tripPlanModalClosedHandler = handleTripPlanModalClosed;
 			loadSharedTripHandler = handleLoadSharedTrip;
+			invalidSharedTripHandler = handleInvalidSharedTrip;
 			window.addEventListener('tabSwitched', tabSwitchedHandler);
 			window.addEventListener('setTripPlanLocation', setTripPlanLocationHandler);
 			window.addEventListener('tripPlanModalClosed', tripPlanModalClosedHandler);
 			window.addEventListener('loadSharedTrip', loadSharedTripHandler);
+			window.addEventListener('invalidSharedTrip', invalidSharedTripHandler);
 		}
 	});
 
@@ -348,6 +389,9 @@
 			}
 			if (loadSharedTripHandler) {
 				window.removeEventListener('loadSharedTrip', loadSharedTripHandler);
+			}
+			if (invalidSharedTripHandler) {
+				window.removeEventListener('invalidSharedTrip', invalidSharedTripHandler);
 			}
 		}
 	});

--- a/src/components/trip-planner/TripPlan.svelte
+++ b/src/components/trip-planner/TripPlan.svelte
@@ -20,6 +20,9 @@
 	import { swapTripLocations, clearTripPlanPins } from '$lib/tripPlanUtils';
 	import { recentTrips } from '$stores/recentTripsStore';
 	import RecentTripsList from './RecentTripsList.svelte';
+	import { replaceState } from '$app/navigation';
+	import { page } from '$app/stores';
+	import { applyTripParams, removeTripParams } from '$lib/urlState';
 
 	const regionTz = env.PUBLIC_OBA_TIMEZONE || undefined;
 
@@ -148,6 +151,7 @@
 			}
 		}
 		clearTripItineraries();
+		clearTripUrl();
 	}
 
 	function swapLocations() {
@@ -199,6 +203,22 @@
 		}
 	}
 
+	// Reflect the planned trip in the URL so it can be copied and shared. Uses
+	// replaceState to keep the shareable link current without stacking history.
+	function syncTripUrl() {
+		if (!browser) return;
+		const url = new URL($page.url);
+		applyTripParams(url, { selectedFrom, selectedTo, fromPlace, toPlace });
+		replaceState(url, {});
+	}
+
+	function clearTripUrl() {
+		if (!browser) return;
+		const url = new URL($page.url);
+		removeTripParams(url);
+		replaceState(url, {});
+	}
+
 	async function planTrip() {
 		if (!selectedFrom || !selectedTo) {
 			return;
@@ -222,6 +242,7 @@
 
 			if (data) {
 				handleTripPlan({ data });
+				syncTripUrl();
 
 				// Save to recent trips
 				try {
@@ -277,6 +298,21 @@
 		}
 	}
 
+	// Restore a shared trip from the URL: hydrate the form, drop the pins, and run
+	// the search so the recipient lands on the same itinerary.
+	async function handleLoadSharedTrip(e) {
+		const { selectedFrom: from, selectedTo: to, fromPlace: fp, toPlace: tp } = e.detail;
+		fromPlace = fp;
+		toPlace = tp;
+		selectedFrom = from;
+		selectedTo = to;
+		fromResults = [];
+		toResults = [];
+		await planTrip();
+	}
+
+	let loadSharedTripHandler;
+
 	onMount(() => {
 		if (browser) {
 			tabSwitchedHandler = () => {
@@ -285,9 +321,11 @@
 			};
 			setTripPlanLocationHandler = handleSetTripPlanLocation;
 			tripPlanModalClosedHandler = handleTripPlanModalClosed;
+			loadSharedTripHandler = handleLoadSharedTrip;
 			window.addEventListener('tabSwitched', tabSwitchedHandler);
 			window.addEventListener('setTripPlanLocation', setTripPlanLocationHandler);
 			window.addEventListener('tripPlanModalClosed', tripPlanModalClosedHandler);
+			window.addEventListener('loadSharedTrip', loadSharedTripHandler);
 		}
 	});
 
@@ -307,6 +345,9 @@
 			}
 			if (tripPlanModalClosedHandler) {
 				window.removeEventListener('tripPlanModalClosed', tripPlanModalClosedHandler);
+			}
+			if (loadSharedTripHandler) {
+				window.removeEventListener('loadSharedTrip', loadSharedTripHandler);
 			}
 		}
 	});

--- a/src/components/trip-planner/__tests__/TripPlan.test.js
+++ b/src/components/trip-planner/__tests__/TripPlan.test.js
@@ -1,13 +1,21 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render } from '@testing-library/svelte';
+import { render, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
 import TripPlan from '../TripPlan.svelte';
+import * as navigation from '$app/navigation';
 
 vi.mock('$app/environment', () => ({
 	browser: true,
 	dev: false,
 	building: false,
 	version: '1.0.0'
+}));
+
+vi.mock('$app/navigation', () => ({
+	replaceState: vi.fn(),
+	pushState: vi.fn(),
+	goto: vi.fn()
 }));
 
 vi.mock('@fortawesome/svelte-fontawesome', () => ({
@@ -87,5 +95,149 @@ describe('TripPlan pin cleanup', () => {
 		expect(mapProvider.removePinMarker).toHaveBeenCalledTimes(2);
 		expect(mapProvider.removePinMarker).toHaveBeenCalledWith(fromMarker);
 		expect(mapProvider.removePinMarker).toHaveBeenCalledWith(toMarker);
+	});
+});
+
+describe('TripPlan shared URL round trip', () => {
+	let mapProvider;
+	let props;
+	const sharedTrip = {
+		selectedFrom: { lat: 47.6, lng: -122.3 },
+		selectedTo: { lat: 47.7, lng: -122.4 },
+		fromPlace: 'Home',
+		toPlace: 'Work'
+	};
+
+	beforeEach(() => {
+		let markerId = 0;
+		mapProvider = {
+			addPinMarker: vi.fn(() => ({ id: `marker-${++markerId}` })),
+			removePinMarker: vi.fn(),
+			clearAllPolylines: vi.fn()
+		};
+		props = {
+			handleTripPlan: vi.fn(),
+			clearTripItineraries: vi.fn(),
+			mapProvider
+		};
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+		delete global.fetch;
+	});
+
+	function mockPlanSuccess() {
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: () => Promise.resolve({ plan: { itineraries: [{ id: 'itin-1' }] } })
+		});
+	}
+
+	function mockPlanNetworkFailure() {
+		global.fetch = vi.fn().mockRejectedValue(new Error('Network failure'));
+	}
+
+	it('restores a shared trip and re-syncs the URL once the itinerary loads', async () => {
+		mockPlanSuccess();
+		const { unmount } = render(TripPlan, { props });
+
+		window.dispatchEvent(new CustomEvent('loadSharedTrip', { detail: sharedTrip }));
+
+		await waitFor(() => expect(props.handleTripPlan).toHaveBeenCalled());
+
+		expect(props.handleTripPlan).toHaveBeenCalledWith({
+			data: { plan: { itineraries: [{ id: 'itin-1' }] } }
+		});
+
+		expect(navigation.replaceState).toHaveBeenCalled();
+		const url = navigation.replaceState.mock.calls.at(-1)[0];
+		expect(url.searchParams.get('from')).toBe('47.6,-122.3');
+		expect(url.searchParams.get('to')).toBe('47.7,-122.4');
+		expect(url.searchParams.get('fromName')).toBe('Home');
+		expect(url.searchParams.get('toName')).toBe('Work');
+
+		unmount();
+	});
+
+	it('clears trip params from the URL when an input is cleared', async () => {
+		mockPlanSuccess();
+		const { container, unmount } = render(TripPlan, { props });
+
+		window.dispatchEvent(new CustomEvent('loadSharedTrip', { detail: sharedTrip }));
+		await waitFor(() => expect(navigation.replaceState).toHaveBeenCalled());
+
+		const user = userEvent.setup();
+		const clearButtons = container.querySelectorAll('#from-location-input ~ button');
+		await user.click(clearButtons[0]);
+
+		await waitFor(() => {
+			const url = navigation.replaceState.mock.calls.at(-1)[0];
+			expect(url.searchParams.has('from')).toBe(false);
+			expect(url.searchParams.has('to')).toBe(false);
+		});
+
+		unmount();
+	});
+
+	it('surfaces an error via handleTripPlan instead of a blank state when the request fails outright', async () => {
+		mockPlanNetworkFailure();
+		const { unmount } = render(TripPlan, { props });
+
+		window.dispatchEvent(new CustomEvent('loadSharedTrip', { detail: sharedTrip }));
+
+		await waitFor(() => expect(props.handleTripPlan).toHaveBeenCalled());
+
+		expect(props.handleTripPlan).toHaveBeenCalledWith({
+			data: { error: { id: 'REQUEST_FAILED', msg: expect.any(String) } }
+		});
+		// A failed plan must not be treated as shareable/recent
+		expect(navigation.replaceState).not.toHaveBeenCalled();
+
+		unmount();
+	});
+
+	it('surfaces an error via handleTripPlan when a shared link has broken/invalid params', async () => {
+		const { unmount } = render(TripPlan, { props });
+
+		window.dispatchEvent(new CustomEvent('invalidSharedTrip'));
+		await tick();
+
+		expect(props.handleTripPlan).toHaveBeenCalledWith({
+			data: { error: { id: 'INVALID_SHARED_LINK', msg: expect.any(String) } }
+		});
+
+		unmount();
+	});
+
+	it('does not throw when a loadSharedTrip event has a malformed detail payload', async () => {
+		const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const { unmount } = render(TripPlan, { props });
+
+		expect(() => {
+			window.dispatchEvent(new CustomEvent('loadSharedTrip', { detail: null }));
+		}).not.toThrow();
+		await tick();
+
+		expect(props.handleTripPlan).not.toHaveBeenCalled();
+		consoleSpy.mockRestore();
+		unmount();
+	});
+
+	it('still saves the trip when replaceState throws before the router is initialized', async () => {
+		mockPlanSuccess();
+		const setItemSpy = vi.spyOn(global.localStorage, 'setItem');
+		vi.mocked(navigation.replaceState).mockImplementationOnce(() => {
+			throw new Error('Cannot call replaceState(...) before the router is initialized');
+		});
+		const { unmount } = render(TripPlan, { props });
+
+		window.dispatchEvent(new CustomEvent('loadSharedTrip', { detail: sharedTrip }));
+
+		await waitFor(() => expect(props.handleTripPlan).toHaveBeenCalled());
+		await waitFor(() => expect(setItemSpy).toHaveBeenCalled());
+
+		setItemSpy.mockRestore();
+		unmount();
 	});
 });

--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -540,6 +540,10 @@ export default class GoogleMapProvider {
 		return { lat: center.lat(), lng: center.lng() };
 	}
 
+	getZoom() {
+		return this.map.getZoom();
+	}
+
 	addListener(event, callback) {
 		this.map.addListener(event, callback);
 	}

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -617,6 +617,11 @@ export default class OpenStreetMapProvider {
 		return { lat: center.lat, lng: center.lng };
 	}
 
+	getZoom() {
+		if (!browser || !this.map) return 0;
+		return this.map.getZoom();
+	}
+
 	removeMarker(marker) {
 		if (!browser || !this.map || !marker) return;
 		this.map.removeLayer(marker);

--- a/src/lib/__tests__/urlState.test.js
+++ b/src/lib/__tests__/urlState.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import {
+	formatCoord,
+	parseCoord,
+	parseTripParams,
+	applyTripParams,
+	removeTripParams
+} from '../urlState';
+
+describe('formatCoord', () => {
+	it('rounds to 5 decimal places', () => {
+		expect(formatCoord({ lat: 32.715739, lng: -117.161084 })).toBe('32.71574,-117.16108');
+	});
+
+	it('keeps the equator and prime meridian (0 values)', () => {
+		expect(formatCoord({ lat: 0, lng: 0 })).toBe('0,0');
+	});
+
+	it('returns null for missing or invalid coords', () => {
+		expect(formatCoord(null)).toBeNull();
+		expect(formatCoord(undefined)).toBeNull();
+		expect(formatCoord({ lat: 91, lng: 0 })).toBeNull();
+		expect(formatCoord({ lat: 0, lng: 181 })).toBeNull();
+		expect(formatCoord({ lat: NaN, lng: 0 })).toBeNull();
+		expect(formatCoord({ lat: 'x', lng: 0 })).toBeNull();
+	});
+});
+
+describe('parseCoord', () => {
+	it('parses a valid "lat,lng" string', () => {
+		expect(parseCoord('32.71574,-117.16108')).toEqual({ lat: 32.71574, lng: -117.16108 });
+	});
+
+	it('returns null for malformed input', () => {
+		expect(parseCoord('')).toBeNull();
+		expect(parseCoord(null)).toBeNull();
+		expect(parseCoord('32.71574')).toBeNull();
+		expect(parseCoord('32.71574,-117,5')).toBeNull();
+		expect(parseCoord('abc,def')).toBeNull();
+	});
+
+	it('returns null for out-of-range coordinates', () => {
+		expect(parseCoord('200,0')).toBeNull();
+		expect(parseCoord('0,200')).toBeNull();
+	});
+});
+
+describe('parseTripParams', () => {
+	it('returns a restored trip when from and to are present', () => {
+		const params = new URLSearchParams('from=32.7,-117.1&to=32.8,-117.2&fromName=Home&toName=Work');
+		expect(parseTripParams(params)).toEqual({
+			selectedFrom: { lat: 32.7, lng: -117.1 },
+			selectedTo: { lat: 32.8, lng: -117.2 },
+			fromPlace: 'Home',
+			toPlace: 'Work'
+		});
+	});
+
+	it('falls back to the formatted coord when names are missing', () => {
+		const params = new URLSearchParams('from=32.7,-117.1&to=32.8,-117.2');
+		const result = parseTripParams(params);
+		expect(result.fromPlace).toBe('32.7,-117.1');
+		expect(result.toPlace).toBe('32.8,-117.2');
+	});
+
+	it('returns null when either endpoint is missing or invalid', () => {
+		expect(parseTripParams(new URLSearchParams('from=32.7,-117.1'))).toBeNull();
+		expect(parseTripParams(new URLSearchParams('to=32.8,-117.2'))).toBeNull();
+		expect(parseTripParams(new URLSearchParams('from=bad&to=32.8,-117.2'))).toBeNull();
+		expect(parseTripParams(new URLSearchParams())).toBeNull();
+		expect(parseTripParams(null)).toBeNull();
+	});
+});
+
+describe('applyTripParams', () => {
+	it('writes from, to, and names', () => {
+		const url = new URL('https://example.com/');
+		applyTripParams(url, {
+			selectedFrom: { lat: 32.7, lng: -117.1 },
+			selectedTo: { lat: 32.8, lng: -117.2 },
+			fromPlace: 'Home',
+			toPlace: 'Work'
+		});
+		expect(url.searchParams.get('from')).toBe('32.7,-117.1');
+		expect(url.searchParams.get('to')).toBe('32.8,-117.2');
+		expect(url.searchParams.get('fromName')).toBe('Home');
+		expect(url.searchParams.get('toName')).toBe('Work');
+	});
+
+	it('round-trips through parseTripParams', () => {
+		const url = new URL('https://example.com/');
+		const trip = {
+			selectedFrom: { lat: 32.71574, lng: -117.16108 },
+			selectedTo: { lat: 32.8, lng: -117.2 },
+			fromPlace: 'A',
+			toPlace: 'B'
+		};
+		applyTripParams(url, trip);
+		expect(parseTripParams(url.searchParams)).toEqual(trip);
+	});
+
+	it('does not write anything when coordinates are invalid', () => {
+		const url = new URL('https://example.com/');
+		applyTripParams(url, { selectedFrom: null, selectedTo: { lat: 32.8, lng: -117.2 } });
+		expect(url.searchParams.has('from')).toBe(false);
+		expect(url.searchParams.has('to')).toBe(false);
+	});
+
+	it('clears name params when labels are absent', () => {
+		const url = new URL('https://example.com/?fromName=Old&toName=Stale');
+		applyTripParams(url, {
+			selectedFrom: { lat: 32.7, lng: -117.1 },
+			selectedTo: { lat: 32.8, lng: -117.2 }
+		});
+		expect(url.searchParams.has('fromName')).toBe(false);
+		expect(url.searchParams.has('toName')).toBe(false);
+	});
+});
+
+describe('removeTripParams', () => {
+	it('strips every trip param but leaves others intact', () => {
+		const url = new URL('https://example.com/?from=1,1&to=2,2&fromName=A&toName=B&lat=32&lng=-117');
+		removeTripParams(url);
+		expect(url.searchParams.has('from')).toBe(false);
+		expect(url.searchParams.has('to')).toBe(false);
+		expect(url.searchParams.has('fromName')).toBe(false);
+		expect(url.searchParams.has('toName')).toBe(false);
+		expect(url.searchParams.get('lat')).toBe('32');
+		expect(url.searchParams.get('lng')).toBe('-117');
+	});
+});

--- a/src/lib/__tests__/urlState.test.js
+++ b/src/lib/__tests__/urlState.test.js
@@ -4,7 +4,8 @@ import {
 	parseCoord,
 	parseTripParams,
 	applyTripParams,
-	removeTripParams
+	removeTripParams,
+	hasTripParams
 } from '../urlState';
 
 describe('formatCoord', () => {
@@ -42,6 +43,19 @@ describe('parseCoord', () => {
 	it('returns null for out-of-range coordinates', () => {
 		expect(parseCoord('200,0')).toBeNull();
 		expect(parseCoord('0,200')).toBeNull();
+	});
+
+	it('rejects trailing garbage instead of truncating it like parseFloat would', () => {
+		// parseFloat('47.6xyz') === 47.6, which would silently reinterpret a
+		// corrupted-but-in-range link as valid. Number() must reject it outright.
+		expect(parseCoord('47.6xyz,-122.3junk')).toBeNull();
+		expect(parseCoord('47.6,-122.3 ')).toEqual({ lat: 47.6, lng: -122.3 });
+	});
+
+	it('rejects a missing endpoint around the comma', () => {
+		expect(parseCoord(',-117.1')).toBeNull();
+		expect(parseCoord('32.7,')).toBeNull();
+		expect(parseCoord(' , ')).toBeNull();
 	});
 });
 
@@ -87,16 +101,23 @@ describe('applyTripParams', () => {
 		expect(url.searchParams.get('toName')).toBe('Work');
 	});
 
-	it('round-trips through parseTripParams', () => {
+	it('round-trips through parseTripParams, rounding to 5 decimal places on write', () => {
 		const url = new URL('https://example.com/');
-		const trip = {
-			selectedFrom: { lat: 32.71574, lng: -117.16108 },
-			selectedTo: { lat: 32.8, lng: -117.2 },
+		// Deliberately un-rounded (6+ decimal places) input, so this actually
+		// exercises applyTripParams's rounding instead of asserting a
+		// losslessness that only holds for already-rounded coordinates.
+		applyTripParams(url, {
+			selectedFrom: { lat: 32.715739, lng: -117.161084 },
+			selectedTo: { lat: 32.800001, lng: -117.200009 },
 			fromPlace: 'A',
 			toPlace: 'B'
-		};
-		applyTripParams(url, trip);
-		expect(parseTripParams(url.searchParams)).toEqual(trip);
+		});
+		expect(parseTripParams(url.searchParams)).toEqual({
+			selectedFrom: { lat: 32.71574, lng: -117.16108 },
+			selectedTo: { lat: 32.8, lng: -117.20001 },
+			fromPlace: 'A',
+			toPlace: 'B'
+		});
 	});
 
 	it('does not write anything when coordinates are invalid', () => {
@@ -127,5 +148,19 @@ describe('removeTripParams', () => {
 		expect(url.searchParams.has('toName')).toBe(false);
 		expect(url.searchParams.get('lat')).toBe('32');
 		expect(url.searchParams.get('lng')).toBe('-117');
+	});
+});
+
+describe('hasTripParams', () => {
+	it('returns true when from or to is present, even if unparsable', () => {
+		expect(hasTripParams(new URLSearchParams('from=bad&to=32.8,-117.2'))).toBe(true);
+		expect(hasTripParams(new URLSearchParams('from=1,1'))).toBe(true);
+		expect(hasTripParams(new URLSearchParams('to=1,1'))).toBe(true);
+	});
+
+	it('returns false when neither is present', () => {
+		expect(hasTripParams(new URLSearchParams())).toBe(false);
+		expect(hasTripParams(new URLSearchParams('lat=32&lng=-117'))).toBe(false);
+		expect(hasTripParams(null)).toBe(false);
 	});
 });

--- a/src/lib/urlState.js
+++ b/src/lib/urlState.js
@@ -1,0 +1,129 @@
+/**
+ * Centralized serialization and parsing of shareable URL state.
+ *
+ * These are pure functions with no Svelte or DOM dependencies, so the query
+ * string contract for shareable links stays in one place and is easy to test.
+ *
+ * Trip params: `from` and `to` are "lat,lng" strings; `fromName` and `toName`
+ * are optional human readable labels.
+ */
+
+/** Number of decimal places kept for coordinates (about 1 meter precision). */
+const COORD_PRECISION = 5;
+
+/**
+ * Rounds a coordinate pair and renders it as a compact "lat,lng" string.
+ *
+ * @param {{ lat: number, lng: number } | null | undefined} coords
+ * @returns {string | null} The "lat,lng" string, or null if coords are invalid
+ */
+export function formatCoord(coords) {
+	if (!coords) return null;
+	const { lat, lng } = coords;
+	if (!isValidLat(lat) || !isValidLng(lng)) return null;
+	return `${round(lat)},${round(lng)}`;
+}
+
+/**
+ * Parses a "lat,lng" string into a validated coordinate object.
+ *
+ * @param {string | null | undefined} value
+ * @returns {{ lat: number, lng: number } | null} The coordinates, or null if invalid
+ */
+export function parseCoord(value) {
+	if (!value || typeof value !== 'string') return null;
+
+	const parts = value.split(',');
+	if (parts.length !== 2) return null;
+
+	const lat = parseFloat(parts[0]);
+	const lng = parseFloat(parts[1]);
+
+	if (!isValidLat(lat) || !isValidLng(lng)) return null;
+
+	return { lat, lng };
+}
+
+/**
+ * Reads trip context from URL search params.
+ *
+ * @param {URLSearchParams} searchParams
+ * @returns {{ selectedFrom: { lat: number, lng: number }, selectedTo: { lat: number, lng: number }, fromPlace: string, toPlace: string } | null}
+ *          The restored trip, or null when from/to are missing or invalid
+ */
+export function parseTripParams(searchParams) {
+	if (!searchParams) return null;
+
+	const selectedFrom = parseCoord(searchParams.get('from'));
+	const selectedTo = parseCoord(searchParams.get('to'));
+
+	if (!selectedFrom || !selectedTo) return null;
+
+	const fromName = searchParams.get('fromName');
+	const toName = searchParams.get('toName');
+
+	return {
+		selectedFrom,
+		selectedTo,
+		fromPlace: fromName || formatCoord(selectedFrom),
+		toPlace: toName || formatCoord(selectedTo)
+	};
+}
+
+/**
+ * Writes trip context onto a URL's search params in place. Skips writing when
+ * either coordinate is invalid so a broken link is never produced.
+ *
+ * @param {URL} url - URL whose searchParams will be mutated
+ * @param {{ selectedFrom: object, selectedTo: object, fromPlace?: string, toPlace?: string }} trip
+ * @returns {URL} The same url, for chaining
+ */
+export function applyTripParams(url, trip) {
+	const from = formatCoord(trip?.selectedFrom);
+	const to = formatCoord(trip?.selectedTo);
+
+	if (!from || !to) return url;
+
+	url.searchParams.set('from', from);
+	url.searchParams.set('to', to);
+
+	if (trip.fromPlace) {
+		url.searchParams.set('fromName', trip.fromPlace);
+	} else {
+		url.searchParams.delete('fromName');
+	}
+
+	if (trip.toPlace) {
+		url.searchParams.set('toName', trip.toPlace);
+	} else {
+		url.searchParams.delete('toName');
+	}
+
+	return url;
+}
+
+/**
+ * Removes all trip params from a URL's search params in place.
+ *
+ * @param {URL} url - URL whose searchParams will be mutated
+ * @returns {URL} The same url, for chaining
+ */
+export function removeTripParams(url) {
+	url.searchParams.delete('from');
+	url.searchParams.delete('to');
+	url.searchParams.delete('fromName');
+	url.searchParams.delete('toName');
+	return url;
+}
+
+function round(value) {
+	return Number(value.toFixed(COORD_PRECISION));
+}
+
+function isValidLat(lat) {
+	return typeof lat === 'number' && isFinite(lat) && lat >= -90 && lat <= 90;
+}
+
+function isValidLng(lng) {
+	return typeof lng === 'number' && isFinite(lng) && lng >= -180 && lng <= 180;
+}

--- a/src/lib/urlState.js
+++ b/src/lib/urlState.js
@@ -36,12 +36,32 @@ export function parseCoord(value) {
 	const parts = value.split(',');
 	if (parts.length !== 2) return null;
 
-	const lat = parseFloat(parts[0]);
-	const lng = parseFloat(parts[1]);
+	const [latStr, lngStr] = parts.map((p) => p.trim());
+	if (latStr === '' || lngStr === '') return null;
+
+	// Number() (unlike parseFloat) rejects trailing garbage such as "47.6xyz"
+	// instead of silently truncating it to a plausible-looking coordinate.
+	const lat = Number(latStr);
+	const lng = Number(lngStr);
 
 	if (!isValidLat(lat) || !isValidLng(lng)) return null;
 
 	return { lat, lng };
+}
+
+/**
+ * Returns true when the URL has an attempt at trip params (`from` or `to`
+ * present), regardless of whether they parse successfully. Lets callers
+ * distinguish "no shared trip" from "a shared trip link that didn't parse" so
+ * a broken link can surface feedback instead of silently falling back to the
+ * default map with no explanation.
+ *
+ * @param {URLSearchParams} searchParams
+ * @returns {boolean}
+ */
+export function hasTripParams(searchParams) {
+	if (!searchParams) return false;
+	return searchParams.has('from') || searchParams.has('to');
 }
 
 /**

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -58,7 +58,9 @@
 		"remove_recent_trip": "Remove recent trip",
 		"recent_trip": "Use recent trip from {from} to {to}",
 		"recent_searches": "Recent Searches",
-		"clear_all": "Clear All"
+		"clear_all": "Clear All",
+		"request_failed": "We couldn't reach the trip planning service. Please try again.",
+		"invalid_shared_link": "This shared trip link looks broken. Try planning the trip again."
 	},
 	"tabs": {
 		"stops-and-stations": "Stops and Stations",


### PR DESCRIPTION
Part of #533 (stop/map-position work is still separate).

## Summary
Riders can now copy and share a link to a planned trip. When someone opens that link, the app restores the same from/to locations and runs the trip search automatically. For ex- http://localhost:5173/?from=47.44359%2C-122.29607&to=47.47969%2C-122.20792&fromName=SeaTac%2C+WA%2C+USA&toName=Renton%2C+WA%2C+USA.

## What changed

- Added `src/lib/urlState.js` to read and write trip params in the URL (`from`, `to`, `fromName`, `toName`)
- After a successful trip plan, the URL updates with `replaceState` so the link stays shareable without cluttering browser history
- On load, `SearchPane` detects trip params, opens the Plan a Trip tab, and restores the itinerary
- Fixed map behavior for shared links: stop markers no longer stick around when opening a trip URL (race in `batchAddMarkers` + skip initial region-center stop load when a shared trip is present)

## Repro

1. Open the app and go to Plan a Trip
2. Pick a from and to location and press Plan
3. Copy the URL from the address bar (should include `from`, `to`, and optional name params) (For ex: [http://localhost:5173/?from=47.44359%2C-122.29607&to=47.47969%2C-122.20792&fromName=SeaTac%2C+WA%2C+USA&toName=Renton%2C+WA%2C+USA](http://localhost:5173/?from=47.44359%2C-122.29607&to=47.47969%2C-122.20792&fromName=SeaTac%2C+WA%2C+USA&toName=Renton%2C+WA%2C+USA))
4. Open that URL in a new incognito window
5. Confirm the Plan tab opens, the trip runs, and stop markers are hidden on the map
6. Switch to Stops and Stations and confirm stops load for the trip area
7. Clear a from/to field and confirm trip params are removed from the URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shareable trip links that preserve “from/to” coordinates and place names in the URL.
  - Shared links now restore trip inputs and open trip-planning mode automatically.
- **Bug Fixes**
  - Improved map marker timing and stability when switching between trip-planning and normal modes.
  - Added clearer feedback for invalid shared links and trip-planning request failures.
- **Tests**
  - Expanded automated coverage for URL parsing/sync, shared-link restore flows, and map/trip-planner behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->