### PR TITLE
Fix/load spinners

### DIFF
--- a/src/components/trip-planner/TripPlan.svelte
+++ b/src/components/trip-planner/TripPlan.svelte
@@ -438,6 +438,7 @@
 					xmlns="http://www.w3.org/2000/svg"
 					fill="none"
 					viewBox="0 0 24 24"
+					aria-hidden="true"
 				>
 					<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
 					></circle>


### PR DESCRIPTION
The plan trip button already announces its loading state via visible text, so the spinner SVG should be ignored by assistive tech.

Fixes #526