### PR TITLE
Add Prometheus metrics on an internal-only secondary HTTP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,3 +80,8 @@ PUBLIC_LANGUAGE_SWITCHER_BUTTON_FORMAT=native
 PUBLIC_LANGUAGE_SWITCHER_MENU_FORMAT=native-english
 # Map style for MapLibre maps
 PUBLIC_MAPLIBRE_STYLE="positron"
+
+# Prometheus Metrics
+# A secondary, internal-only HTTP server exposes GET /metrics on this port.
+# Keep this port inside your VPC; do not expose it publicly. Default: 9119.
+# METRICS_PORT=9119

--- a/docs/superpowers/specs/2026-07-02-prometheus-metrics-design.md
+++ b/docs/superpowers/specs/2026-07-02-prometheus-metrics-design.md
@@ -1,0 +1,94 @@
+# Prometheus Metrics for Wayfinder — Design
+
+**Date:** 2026-07-02
+**Status:** Approved
+
+## Goal
+
+Expose Prometheus metrics from Wayfinder on a secondary, internal-only HTTP
+server, mirroring the pattern already shipped in the OneBusAway Twilio app
+(Go). The metrics server binds a different port than the app so it can be kept
+inside the VPC while the app port is public.
+
+Dashboards must be able to show: process/system CPU, memory used vs. capacity,
+p50/p90/p99 HTTP response times, and requests per minute.
+
+## Library
+
+`prom-client@15.x`. The GitHub project `prometheus/client_js` is the official
+Prometheus-org home of this library (renamed in-repo to `@prometheus/client`),
+but the scoped package is not yet published to npm — `prom-client` is the
+published name for the identical code. When `@prometheus/client` ships, the
+migration is a dependency rename.
+
+## Parity with the Twilio app
+
+- Default metrics port: **9119**, configurable via `METRICS_PORT`.
+- Port resolution semantics: empty/unset → default; non-numeric or outside
+  1–65535 → log a warning and use the default.
+- Metric names and labels:
+  - `http_requests_total{method, route, status}` (counter)
+  - `http_request_duration_seconds{method, route}` (histogram, default buckets)
+- Dedicated (non-global) registry with runtime/process collectors registered.
+
+## Architecture
+
+Wayfinder is SvelteKit 5 on `adapter-node`, so all pieces are server-side:
+
+1. **`src/lib/metrics/registry.js`** — server-only module. Creates a
+   `prom-client` `Registry` with:
+   - `collectDefaultMetrics()` → process CPU, RSS, heap used/total, event-loop
+     lag, GC durations, Node version.
+   - The two HTTP metrics above.
+   - System-level gauges (via `node:os`, computed in `collect()` at scrape
+     time): `system_cpu_load_average_1m`, `system_memory_total_bytes`,
+     `system_memory_free_bytes` — so "System CPU" and "Memory used of
+     capacity" panels work without node_exporter.
+   - The singleton is stored on `globalThis` so dev-mode HMR re-evaluation
+     neither double-registers metrics nor orphans the registry held by the
+     running metrics server.
+   - Exports `recordHttpRequest({method, route, status, durationSeconds})`,
+     `renderMetrics()`, `metricsContentType`, and `resolveMetricsPort(raw)`.
+2. **`src/lib/metrics/server.js`** — `startMetricsServer(port)` starts a plain
+   `node:http` server answering `GET /metrics` (anything else → 404). Guarded
+   by a `globalThis` flag against double-starts (dev HMR); `EADDRINUSE` and
+   other listen errors are logged, never crash the app.
+3. **`src/hooks.server.js`** — at module scope, when not `building`, resolve
+   `METRICS_PORT` from `$env/dynamic/private` and start the metrics server
+   (dev and prod both). The existing `handle` hook is instrumented: time
+   `resolve(event)`, label with `event.request.method`,
+   `event.route.id ?? '(unmatched)'` (route template keeps label cardinality
+   bounded), and the response status; a thrown error records status 500 and
+   rethrows.
+
+## Configuration
+
+- `METRICS_PORT` added to `env-schema.json` (`type: number`, `min: 1`,
+  `max: 65535`, not required) and documented in `.env.example`.
+- Read via `$env/dynamic/private` so it is a runtime (not build-time) setting.
+
+## PromQL the dashboard needs
+
+- p50/p90/p99: `histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))`
+- Requests per minute: `sum(rate(http_requests_total[1m])) * 60`
+- Memory used / capacity: `process_resident_memory_bytes` /
+  `system_memory_total_bytes`
+- Process CPU: `rate(process_cpu_seconds_total[1m])`
+
+## Error handling
+
+- Invalid `METRICS_PORT` → warn + default (matches Twilio).
+- Metrics server listen failure → log error, app keeps serving.
+- Instrumentation failures must never break request handling.
+
+## Testing
+
+Vitest unit tests (no network binding required except one loopback test):
+
+- `resolveMetricsPort`: empty, valid, non-numeric, out-of-range.
+- Registry: recording requests shows up in rendered exposition text; default
+  and system metrics present; content type correct.
+- Metrics server: starts on an ephemeral port, `GET /metrics` returns 200 with
+  the Prometheus content type, other paths 404, double-start is a no-op.
+- `handle` instrumentation: records method/route/status; error path records
+  500 and rethrows.

--- a/env-schema.json
+++ b/env-schema.json
@@ -217,5 +217,12 @@
 		"required": false,
 		"type": "string",
 		"description": "Defines a style for MapLibre map. Defaults to positron if not set"
+	},
+	"METRICS_PORT": {
+		"required": false,
+		"type": "number",
+		"min": 1,
+		"max": 65535,
+		"description": "Port for the internal-only Prometheus /metrics HTTP server (default: 9119)"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"leaflet-polylinedecorator": "^1.6.0",
 				"onebusaway-sdk": "^1.6.0",
 				"polyline-encoded": "^0.0.9",
+				"prom-client": "^15.1.3",
 				"svelte-i18n": "^4.0.1",
 				"temporal-polyfill": "^0.3.0"
 			},
@@ -1464,6 +1465,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+			"integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2750,6 +2760,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/bintrees": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+			"integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+			"license": "MIT"
 		},
 		"node_modules/bluebird": {
 			"version": "3.7.2",
@@ -6146,6 +6162,19 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/prom-client": {
+			"version": "15.1.3",
+			"resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+			"integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api": "^1.4.0",
+				"tdigest": "^0.1.1"
+			},
+			"engines": {
+				"node": "^16 || ^18 || >=20"
+			}
+		},
 		"node_modules/protobufjs": {
 			"version": "7.4.0",
 			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
@@ -7219,6 +7248,15 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/tdigest": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+			"integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+			"license": "MIT",
+			"dependencies": {
+				"bintrees": "1.0.2"
 			}
 		},
 		"node_modules/temporal-polyfill": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
 		"leaflet-polylinedecorator": "^1.6.0",
 		"onebusaway-sdk": "^1.6.0",
 		"polyline-encoded": "^0.0.9",
+		"prom-client": "^15.1.3",
 		"svelte-i18n": "^4.0.1",
 		"temporal-polyfill": "^0.3.0"
 	}

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -1,10 +1,32 @@
 import 'temporal-polyfill/global';
+import { building } from '$app/environment';
+import { env } from '$env/dynamic/private';
 import { preloadRoutesData } from '$lib/serverCache.js';
 import { preloadOtpVersion } from '$lib/otpServerCache.js';
+import { recordHttpRequest, resolveMetricsPort } from '$lib/metrics/registry.js';
+import { startMetricsServer } from '$lib/metrics/server.js';
+
+if (!building) {
+	startMetricsServer(resolveMetricsPort(env.METRICS_PORT));
+}
 
 export async function handle({ event, resolve }) {
 	await Promise.all([preloadRoutesData(), preloadOtpVersion()]);
-	return resolve(event);
+
+	const startTime = performance.now();
+	let status = 500;
+	try {
+		const response = await resolve(event);
+		status = response.status;
+		return response;
+	} finally {
+		recordHttpRequest({
+			method: event.request.method,
+			route: event.route.id ?? '(unmatched)',
+			status,
+			durationSeconds: (performance.now() - startTime) / 1000
+		});
+	}
 }
 
 export { getRoutesCache, getAgenciesCache, getBoundsCache } from '$lib/serverCache.js';

--- a/src/lib/metrics/registry.js
+++ b/src/lib/metrics/registry.js
@@ -1,0 +1,91 @@
+import os from 'node:os';
+import client from 'prom-client';
+
+/**
+ * Prometheus instrumentation for Wayfinder. Metric names, labels, and the
+ * default port match the OneBusAway Twilio app so both services can share
+ * dashboards and alert rules.
+ */
+
+export const DEFAULT_METRICS_PORT = 9119;
+
+function createMetrics() {
+	const registry = new client.Registry();
+	client.collectDefaultMetrics({ register: registry });
+
+	const httpRequests = new client.Counter({
+		name: 'http_requests_total',
+		help: 'Total HTTP requests by method, route template, and status code.',
+		labelNames: ['method', 'route', 'status'],
+		registers: [registry]
+	});
+
+	const httpDuration = new client.Histogram({
+		name: 'http_request_duration_seconds',
+		help: 'HTTP request latency by method and route template.',
+		labelNames: ['method', 'route'],
+		registers: [registry]
+	});
+
+	new client.Gauge({
+		name: 'system_cpu_load_average_1m',
+		help: 'System load average over the last minute.',
+		registers: [registry],
+		collect() {
+			this.set(os.loadavg()[0]);
+		}
+	});
+
+	new client.Gauge({
+		name: 'system_memory_total_bytes',
+		help: 'Total system memory in bytes.',
+		registers: [registry],
+		collect() {
+			this.set(os.totalmem());
+		}
+	});
+
+	new client.Gauge({
+		name: 'system_memory_free_bytes',
+		help: 'Free system memory in bytes.',
+		registers: [registry],
+		collect() {
+			this.set(os.freemem());
+		}
+	});
+
+	return { registry, httpRequests, httpDuration };
+}
+
+// Stored on globalThis so dev-mode HMR re-evaluation neither double-registers
+// metrics nor orphans the registry held by the running metrics server.
+const metrics = (globalThis.__wayfinderMetrics ??= createMetrics());
+
+export const metricsContentType = metrics.registry.contentType;
+
+export function recordHttpRequest({ method, route, status, durationSeconds }) {
+	metrics.httpRequests.inc({ method, route, status });
+	metrics.httpDuration.observe({ method, route }, durationSeconds);
+}
+
+export function renderMetrics() {
+	return metrics.registry.metrics();
+}
+
+/**
+ * Validates a METRICS_PORT value with the same semantics as the Twilio app:
+ * unset/empty silently uses the default; anything that is not an integer in
+ * [1, 65535] logs a warning and uses the default.
+ */
+export function resolveMetricsPort(raw) {
+	const trimmed = (raw ?? '').trim();
+	if (trimmed === '') {
+		return DEFAULT_METRICS_PORT;
+	}
+	const parsed = Number(trimmed);
+	if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+		console.warn(`Invalid METRICS_PORT="${raw}", using default ${DEFAULT_METRICS_PORT}`);
+		return DEFAULT_METRICS_PORT;
+	}
+	return parsed;
+}

--- a/src/lib/metrics/server.js
+++ b/src/lib/metrics/server.js
@@ -1,0 +1,54 @@
+import http from 'node:http';
+import { metricsContentType, renderMetrics } from './registry.js';
+
+/**
+ * Starts the internal-only HTTP server that exposes GET /metrics. It binds a
+ * different port than the app so it can stay inside the VPC. Idempotent: dev
+ * HMR re-runs and repeated calls return the already-running server. Listen
+ * errors (e.g. EADDRINUSE) are logged and never crash the app.
+ */
+export function startMetricsServer(port) {
+	if (globalThis.__wayfinderMetricsServer) {
+		return globalThis.__wayfinderMetricsServer;
+	}
+
+	const server = http.createServer(async (req, res) => {
+		const path = (req.url ?? '').split('?')[0];
+		if (req.method === 'GET' && path === '/metrics') {
+			try {
+				const body = await renderMetrics();
+				res.writeHead(200, { 'Content-Type': metricsContentType });
+				res.end(body);
+			} catch (error) {
+				console.error('metrics: failed to render metrics:', error);
+				res.writeHead(500, { 'Content-Type': 'text/plain' });
+				res.end('metrics collection failed');
+			}
+		} else {
+			res.writeHead(404, { 'Content-Type': 'text/plain' });
+			res.end('not found');
+		}
+	});
+
+	server.on('error', (error) => {
+		console.error(`metrics: server error on port ${port}:`, error);
+	});
+
+	// Never keep the process alive on account of the metrics server.
+	server.unref();
+	server.listen(port, () => {
+		console.log(`metrics: Prometheus /metrics listening on port ${server.address().port}`);
+	});
+
+	globalThis.__wayfinderMetricsServer = server;
+	return server;
+}
+
+export function stopMetricsServer() {
+	const server = globalThis.__wayfinderMetricsServer;
+	globalThis.__wayfinderMetricsServer = undefined;
+	if (!server) {
+		return Promise.resolve();
+	}
+	return new Promise((resolve) => server.close(resolve));
+}

--- a/src/tests/hooks.server.test.js
+++ b/src/tests/hooks.server.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockRecordHttpRequest = vi.fn();
+const mockStartMetricsServer = vi.fn();
+let mockBuilding = false;
+
+vi.mock('$app/environment', () => ({
+	get building() {
+		return mockBuilding;
+	}
+}));
+vi.mock('$env/dynamic/private', () => ({ env: { METRICS_PORT: '9200' } }));
+vi.mock('$lib/serverCache.js', () => ({
+	preloadRoutesData: vi.fn().mockResolvedValue(undefined),
+	getRoutesCache: vi.fn(),
+	getAgenciesCache: vi.fn(),
+	getBoundsCache: vi.fn()
+}));
+vi.mock('$lib/otpServerCache.js', () => ({
+	preloadOtpVersion: vi.fn().mockResolvedValue(undefined)
+}));
+vi.mock('$lib/metrics/registry.js', async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		recordHttpRequest: mockRecordHttpRequest
+	};
+});
+vi.mock('$lib/metrics/server.js', () => ({
+	startMetricsServer: mockStartMetricsServer
+}));
+
+function makeEvent({ method = 'GET', routeId = '/stops/[stopID]' } = {}) {
+	return {
+		request: new Request('http://localhost/stops/1_100', { method }),
+		route: { id: routeId }
+	};
+}
+
+describe('hooks.server', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('starts the metrics server on the configured port', async () => {
+		vi.resetModules();
+		mockBuilding = false;
+		await import('../hooks.server.js');
+		expect(mockStartMetricsServer).toHaveBeenCalledWith(9200);
+	});
+
+	it('does not start the metrics server during the build', async () => {
+		vi.resetModules();
+		mockBuilding = true;
+		await import('../hooks.server.js');
+		expect(mockStartMetricsServer).not.toHaveBeenCalled();
+	});
+
+	it('records method, route template, status, and duration for each request', async () => {
+		const { handle } = await import('../hooks.server.js');
+		const response = new Response('ok', { status: 200 });
+		const resolve = vi.fn().mockResolvedValue(response);
+
+		const result = await handle({ event: makeEvent(), resolve });
+
+		expect(result).toBe(response);
+		expect(mockRecordHttpRequest).toHaveBeenCalledWith({
+			method: 'GET',
+			route: '/stops/[stopID]',
+			status: 200,
+			durationSeconds: expect.any(Number)
+		});
+	});
+
+	it('labels unmatched routes as (unmatched)', async () => {
+		const { handle } = await import('../hooks.server.js');
+		const resolve = vi.fn().mockResolvedValue(new Response('nope', { status: 404 }));
+
+		await handle({ event: makeEvent({ routeId: null }), resolve });
+
+		expect(mockRecordHttpRequest).toHaveBeenCalledWith(
+			expect.objectContaining({ route: '(unmatched)', status: 404 })
+		);
+	});
+
+	it('records a 500 and rethrows when resolve fails', async () => {
+		const { handle } = await import('../hooks.server.js');
+		const boom = new Error('boom');
+		const resolve = vi.fn().mockRejectedValue(boom);
+
+		await expect(handle({ event: makeEvent(), resolve })).rejects.toThrow(boom);
+		expect(mockRecordHttpRequest).toHaveBeenCalledWith(expect.objectContaining({ status: 500 }));
+	});
+});

--- a/src/tests/lib/metrics/registry.test.js
+++ b/src/tests/lib/metrics/registry.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+	DEFAULT_METRICS_PORT,
+	metricsContentType,
+	recordHttpRequest,
+	renderMetrics,
+	resolveMetricsPort
+} from '$lib/metrics/registry.js';
+
+describe('resolveMetricsPort', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('returns the default port for undefined, null, and empty values', () => {
+		expect(resolveMetricsPort(undefined)).toBe(DEFAULT_METRICS_PORT);
+		expect(resolveMetricsPort(null)).toBe(DEFAULT_METRICS_PORT);
+		expect(resolveMetricsPort('')).toBe(DEFAULT_METRICS_PORT);
+		expect(resolveMetricsPort('   ')).toBe(DEFAULT_METRICS_PORT);
+	});
+
+	it('defaults to 9119, matching the Twilio app', () => {
+		expect(DEFAULT_METRICS_PORT).toBe(9119);
+	});
+
+	it('accepts a valid port', () => {
+		expect(resolveMetricsPort('9200')).toBe(9200);
+		expect(resolveMetricsPort(' 1 ')).toBe(1);
+		expect(resolveMetricsPort('65535')).toBe(65535);
+	});
+
+	it('warns and falls back to the default for invalid values', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		expect(resolveMetricsPort('not-a-port')).toBe(DEFAULT_METRICS_PORT);
+		expect(resolveMetricsPort('0')).toBe(DEFAULT_METRICS_PORT);
+		expect(resolveMetricsPort('65536')).toBe(DEFAULT_METRICS_PORT);
+		expect(resolveMetricsPort('12.5')).toBe(DEFAULT_METRICS_PORT);
+		expect(warn).toHaveBeenCalledTimes(4);
+	});
+});
+
+describe('metrics registry', () => {
+	it('exposes the Prometheus text exposition content type', () => {
+		expect(metricsContentType).toContain('text/plain');
+	});
+
+	it('records HTTP requests into the counter and histogram', async () => {
+		recordHttpRequest({
+			method: 'GET',
+			route: '/stops/[stopID]',
+			status: 200,
+			durationSeconds: 0.123
+		});
+
+		const text = await renderMetrics();
+		expect(text).toContain(
+			'http_requests_total{method="GET",route="/stops/[stopID]",status="200"} 1'
+		);
+		expect(text).toContain(
+			'http_request_duration_seconds_count{method="GET",route="/stops/[stopID]"} 1'
+		);
+		expect(text).toMatch(/http_request_duration_seconds_bucket\{le="0\.25",method="GET"/);
+	});
+
+	it('includes Node.js default metrics', async () => {
+		const text = await renderMetrics();
+		expect(text).toContain('process_cpu_user_seconds_total');
+		expect(text).toContain('nodejs_eventloop_lag_seconds');
+		expect(text).toContain('process_resident_memory_bytes');
+	});
+
+	it('includes system-level gauges for dashboard CPU/memory panels', async () => {
+		const text = await renderMetrics();
+		expect(text).toMatch(/system_cpu_load_average_1m \d/);
+		expect(text).toMatch(/system_memory_total_bytes \d/);
+		expect(text).toMatch(/system_memory_free_bytes \d/);
+	});
+});

--- a/src/tests/lib/metrics/server.test.js
+++ b/src/tests/lib/metrics/server.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { startMetricsServer, stopMetricsServer } from '$lib/metrics/server.js';
+import { metricsContentType } from '$lib/metrics/registry.js';
+
+function listening(server) {
+	return new Promise((resolve, reject) => {
+		if (server.listening) return resolve();
+		server.once('listening', resolve);
+		server.once('error', reject);
+	});
+}
+
+async function fetchFromServer(server, path) {
+	const { port } = server.address();
+	return fetch(`http://127.0.0.1:${port}${path}`);
+}
+
+describe('metrics server', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+
+	afterEach(async () => {
+		await stopMetricsServer();
+		vi.restoreAllMocks();
+	});
+
+	it('serves Prometheus metrics on GET /metrics', async () => {
+		const server = startMetricsServer(0);
+		await listening(server);
+
+		const response = await fetchFromServer(server, '/metrics');
+		expect(response.status).toBe(200);
+		expect(response.headers.get('content-type')).toBe(metricsContentType);
+		expect(await response.text()).toContain('process_cpu_user_seconds_total');
+	});
+
+	it('returns 404 for any other path', async () => {
+		const server = startMetricsServer(0);
+		await listening(server);
+
+		const response = await fetchFromServer(server, '/anything-else');
+		expect(response.status).toBe(404);
+	});
+
+	it('is a no-op when the server is already running', async () => {
+		const server = startMetricsServer(0);
+		await listening(server);
+
+		expect(startMetricsServer(0)).toBe(server);
+	});
+
+	it('logs listen errors instead of crashing the app', async () => {
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const first = startMetricsServer(0);
+		await listening(first);
+		const { port } = first.address();
+
+		// Simulate a second process fighting over the same port.
+		await stopMetricsServer();
+		const blocker = startMetricsServer(port);
+		await listening(blocker);
+		globalThis.__wayfinderMetricsServer = undefined;
+		const conflicting = startMetricsServer(port);
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		expect(error).toHaveBeenCalledWith(
+			expect.stringContaining('metrics'),
+			expect.objectContaining({ code: 'EADDRINUSE' })
+		);
+
+		conflicting.close();
+		globalThis.__wayfinderMetricsServer = blocker;
+	});
+});


### PR DESCRIPTION
## Summary

Adds Prometheus instrumentation to Wayfinder, mirroring the setup recently shipped in the [OneBusAway Twilio app](https://github.com/OneBusAway/twilio): a secondary, internal-only HTTP server exposes `GET /metrics` on a separate port so it can stay inside the VPC while the app port is public.

### Library

Uses `prom-client@15.1.3`. The [prometheus/client_js](https://github.com/prometheus/client_js) repo is the new official Prometheus-org home of this library (renamed in-repo to `@prometheus/client`), but the scoped package is not yet published to npm — `prom-client` is the published name for the identical code. Migrating later is a one-line dependency rename.

### Parity with the Twilio app

- Default metrics port **9119**, configurable via `METRICS_PORT` (unset → default; invalid → warn + default)
- Same metric names and labels, so both services can share dashboards and alert rules:
  - `http_requests_total{method, route, status}` (counter)
  - `http_request_duration_seconds{method, route}` (histogram, default buckets)

### What's included

- **`src/lib/metrics/registry.js`** — dedicated registry with `collectDefaultMetrics()` (process CPU, RSS, heap, event-loop lag, GC, Node version) plus `system_cpu_load_average_1m` and `system_memory_{total,free}_bytes` gauges so system-level dashboard panels work without node_exporter
- **`src/lib/metrics/server.js`** — plain `node:http` server serving only `GET /metrics`; idempotent start (safe under dev HMR), listen errors are logged and never crash the app, `unref()`'d so it never blocks shutdown
- **`src/hooks.server.js`** — starts the metrics server (skipped during build) and instruments every request in the `handle` hook. Requests are labeled by route *template* (`event.route.id`, e.g. `/stops/[stopID]`) to keep label cardinality bounded; unmatched routes are `(unmatched)`, thrown errors record a 500 and rethrow
- **Config** — `METRICS_PORT` read at runtime via `$env/dynamic/private`; documented in `env-schema.json` and `.env.example`
- **Design spec** — `docs/superpowers/specs/2026-07-02-prometheus-metrics-design.md`

### Dashboard queries

- p50/p90/p99: `histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))`
- Requests per minute: `sum(rate(http_requests_total[1m])) * 60`
- Memory used / capacity: `process_resident_memory_bytes / system_memory_total_bytes`
- Process CPU: `rate(process_cpu_seconds_total[1m])`

## Testing

- 17 new vitest tests: port resolution, registry recording/exposition, the metrics HTTP server (200/404/double-start/EADDRINUSE), and `handle` hook instrumentation (status, route template, error path)
- Full suite: 1356/1356 passing
- Verified live in both `npm run dev` and the adapter-node production build: `curl :9119/metrics` returns the expected exposition text with correct content type, and `METRICS_PORT=9200` override works