### PR TITLE
fix(map): highlight selected vehicle and correct trip-details stop

### DIFF
--- a/src/components/map/RouteMap.svelte
+++ b/src/components/map/RouteMap.svelte
@@ -90,7 +90,9 @@
 			}
 
 			if (routeId && isMounted) {
-				currentIntervalId = await fetchAndUpdateVehicles(routeId, mapProvider);
+				// Highlight the vehicle serving the trip the user clicked, while still
+				// showing the other vehicles running this route.
+				currentIntervalId = await fetchAndUpdateVehicles(routeId, mapProvider, undefined, tripId);
 			}
 		} catch (error) {
 			console.error(`Error loading route data for trip ${tripId}:`, error);

--- a/src/components/oba/TripDetailsPane.svelte
+++ b/src/components/oba/TripDetailsPane.svelte
@@ -4,6 +4,7 @@
 	import { faBus, faLocationDot, faCheck } from '@fortawesome/free-solid-svg-icons';
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 	import { formatSecondsFromMidnight } from '$lib/dateTimeFormat';
+	import { resolveVehicleStopIndex } from '$lib/tripDetailsUtils';
 
 	/**
 	 * @typedef {Object} Props
@@ -20,23 +21,16 @@
 	let stopInfo = $state({});
 	let error = $state(null);
 	let interval;
-	let busPosition = $state(0);
+	let busPosition = $state(-1);
 	let abortController = null;
 
+	// Locate the vehicle along the trip using the stop IDs the server reports for
+	// exactly this purpose. `closestStop` is the stop nearest the vehicle's
+	// current position; fall back to `nextStop`. (The previous approach compared
+	// raw lat/lon ranges, which assumed stops were ordered monotonically by
+	// coordinate and so highlighted the wrong stop on most route directions.)
 	function calculateBusPosition() {
-		if (tripDetails && tripDetails.status && tripDetails.status.position) {
-			const { lat, lon } = tripDetails.status.position;
-
-			busPosition = tripDetails.schedule.stopTimes.findIndex((stop, index, array) => {
-				const nextStop = array[index + 1];
-				if (!nextStop) return true;
-				const stopLat = stopInfo[stop.stopId].lat;
-				const stopLon = stopInfo[stop.stopId].lon;
-				const nextStopLat = stopInfo[nextStop.stopId].lat;
-				const nextStopLon = stopInfo[nextStop.stopId].lon;
-				return (lat >= stopLat && lat < nextStopLat) || (lon >= stopLon && lon < nextStopLon);
-			});
-		}
+		busPosition = resolveVehicleStopIndex(tripDetails?.status, tripDetails?.schedule?.stopTimes);
 	}
 
 	async function loadTripDetails() {

--- a/src/lib/MapHelpers/__tests__/generateVehicleIcon.test.js
+++ b/src/lib/MapHelpers/__tests__/generateVehicleIcon.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { createVehicleIconSvg } from '$lib/MapHelpers/generateVehicleIcon.js';
+
+describe('createVehicleIconSvg', () => {
+	it('renders no highlight glow by default', () => {
+		const svg = createVehicleIconSvg(0);
+		expect(svg).not.toContain('vehicle-highlight-blur');
+		expect(svg).not.toContain('#FACC15');
+	});
+
+	it('renders no highlight glow when highlighted is false', () => {
+		const svg = createVehicleIconSvg(0, '#007BFF', undefined, false);
+		expect(svg).not.toContain('vehicle-highlight-blur');
+	});
+
+	it('renders the highlight glow and blur filter when highlighted', () => {
+		const svg = createVehicleIconSvg(0, '#007BFF', undefined, true);
+		expect(svg).toContain('#FACC15');
+		expect(svg).toContain('feGaussianBlur');
+		expect(svg).toContain('filter="url(#vehicle-highlight-blur)"');
+	});
+
+	it('always produces a valid <svg> element', () => {
+		expect(createVehicleIconSvg(90, '#007BFF', undefined, true)).toContain('<svg');
+		expect(createVehicleIconSvg(90)).toContain('<svg');
+	});
+});

--- a/src/lib/MapHelpers/generateVehicleIcon.js
+++ b/src/lib/MapHelpers/generateVehicleIcon.js
@@ -22,7 +22,17 @@ function getDirectionFromOrientation(orientation) {
 	return nearestDirection.icon;
 }
 
-function createVehicleIconSvg(orientation, color = '#007BFF', routeType = RouteType.BUS) {
+// Soft glow drawn behind the vehicle the user selected (the trip they clicked).
+// TODO: make this configurable via a COLOR_* env var (like the brand colors) so
+// deployments can match it to their theme instead of the hardcoded amber.
+const HIGHLIGHT_GLOW_COLOR = '#FACC15';
+
+function createVehicleIconSvg(
+	orientation,
+	color = '#007BFF',
+	routeType = RouteType.BUS,
+	highlighted = false
+) {
 	const direction = getDirectionFromOrientation(toDirection(orientation));
 	const angle = DIRECTIONS.find((d) => d.icon === direction).angle;
 
@@ -31,11 +41,27 @@ function createVehicleIconSvg(orientation, color = '#007BFF', routeType = RouteT
     <polygon points="0,-25 5,-15 -5, -15" stroke="white" stroke-width="1" transform="rotate(${angle})"/>
 `;
 
+	// A soft blurred halo behind the marker for the selected trip. Drawn first so
+	// the arrow and icon render crisply on top (no hard ring clashing with the
+	// arrow), leaving just a gentle glow around the marker.
+	const highlightDefs = highlighted
+		? `<defs><filter id="vehicle-highlight-blur" x="-100%" y="-100%" width="300%" height="300%"><feGaussianBlur stdDeviation="2.5"/></filter></defs>`
+		: '';
+	// A solid halo ring sized well beyond the white circle so it's clearly
+	// visible, softened with a blur. Drawn behind so the arrow/icon stay crisp.
+	const highlightGlow = highlighted
+		? `<circle cx="0" cy="0" r="20" fill="${HIGHLIGHT_GLOW_COLOR}" stroke="none" opacity="0.95" filter="url(#vehicle-highlight-blur)"/>`
+		: '';
+
 	const vehicleSvg = generateRouteTypeSvgForDisplay(routeType);
 
 	return `
         <svg width="${iconWidth}" height="${iconHeight}" viewBox="-28 -28 56 56" xmlns="http://www.w3.org/2000/svg">
+            ${highlightDefs}
             <g stroke="${color}" fill="${color}">
+                <!-- Highlight glow for the selected vehicle (behind everything) -->
+                ${highlightGlow}
+
                 <!-- Directional arrow -->
                 ${arrowPath}
 

--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -330,7 +330,7 @@ export default class GoogleMapProvider {
 		}
 	}
 
-	addVehicleMarker(vehicle, activeTrip, routeType) {
+	addVehicleMarker(vehicle, activeTrip, routeType, isHighlighted = false) {
 		if (!this.map) return null;
 
 		let color;
@@ -338,7 +338,12 @@ export default class GoogleMapProvider {
 			color = COLORS.VEHICLE_REAL_TIME_OFF;
 		}
 
-		const vehicleIconSvg = createVehicleIconSvg(vehicle?.orientation, color, routeType);
+		const vehicleIconSvg = createVehicleIconSvg(
+			vehicle?.orientation,
+			color,
+			routeType,
+			isHighlighted
+		);
 		const icon = {
 			url: `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(vehicleIconSvg)}`,
 			scaledSize: new google.maps.Size(iconWidth, iconHeight),
@@ -349,7 +354,7 @@ export default class GoogleMapProvider {
 			position: { lat: vehicle.position.lat, lng: vehicle.position.lon },
 			map: this.map,
 			icon: icon,
-			zIndex: 1000
+			zIndex: isHighlighted ? 2000 : 1000
 		});
 
 		this.vehicleMarkers.push(marker);
@@ -375,7 +380,7 @@ export default class GoogleMapProvider {
 		return marker;
 	}
 
-	updateVehicleMarker(marker, vehicleStatus, activeTrip, routeType) {
+	updateVehicleMarker(marker, vehicleStatus, activeTrip, routeType, isHighlighted = false) {
 		if (!this.map || !marker) return;
 
 		const current = marker.getPosition();
@@ -392,12 +397,18 @@ export default class GoogleMapProvider {
 			color = COLORS.VEHICLE_REAL_TIME_OFF;
 		}
 
-		const updatedIcon = createVehicleIconSvg(vehicleStatus.orientation, color, routeType);
+		const updatedIcon = createVehicleIconSvg(
+			vehicleStatus.orientation,
+			color,
+			routeType,
+			isHighlighted
+		);
 		marker.setIcon({
 			url: `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(updatedIcon)}`,
 			scaledSize: new google.maps.Size(iconWidth, iconHeight),
 			anchor: new google.maps.Point(iconWidth / 2, iconHeight / 2)
 		});
+		marker.setZIndex(isHighlighted ? 2000 : 1000);
 
 		Object.assign(
 			marker.vehicleData,

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -337,8 +337,7 @@ export default class OpenStreetMapProvider {
 			html: `<img alt="" src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(vehicleIconSvg)}" />`,
 			iconSize: [iconWidth, iconHeight],
 			iconAnchor: [iconWidth / 2, iconHeight / 2],
-			className: '',
-			zIndexOffset
+			className: ''
 		});
 
 		const label = getVehicleLabel(activeTrip);
@@ -403,8 +402,7 @@ export default class OpenStreetMapProvider {
 			html: `<img alt="" src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(updatedIconSvg)}" />`,
 			iconSize: [iconWidth, iconHeight],
 			iconAnchor: [iconWidth / 2, iconHeight / 2],
-			className: '',
-			zIndexOffset: isHighlighted ? 2000 : 1000
+			className: ''
 		});
 
 		const current = marker.getLatLng();
@@ -416,6 +414,9 @@ export default class OpenStreetMapProvider {
 			{ routePaths: this._getRoutePaths() }
 		);
 		marker.setIcon(updatedIcon);
+		// setIcon doesn't touch stacking order, so update the offset directly to
+		// reflect the current highlight state (divIcon ignores zIndexOffset).
+		marker.setZIndexOffset(isHighlighted ? 2000 : 1000);
 
 		// Leaflet reuses the existing <div> on setIcon and skips re-applying options.title, so refresh both the tooltip and the accessible name when the headsign changes mid-trip; otherwise the hover tooltip goes stale.
 		const updatedLabel = getVehicleLabel(activeTrip);

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -318,7 +318,7 @@ export default class OpenStreetMapProvider {
 		marker.remove();
 	}
 
-	addVehicleMarker(vehicle, activeTrip, routeType) {
+	addVehicleMarker(vehicle, activeTrip, routeType, isHighlighted = false) {
 		if (!this.map || !this.L) return null;
 
 		let color;
@@ -326,20 +326,26 @@ export default class OpenStreetMapProvider {
 			color = COLORS.VEHICLE_REAL_TIME_OFF;
 		}
 
-		const vehicleIconSvg = createVehicleIconSvg(vehicle?.orientation, color, routeType);
+		const vehicleIconSvg = createVehicleIconSvg(
+			vehicle?.orientation,
+			color,
+			routeType,
+			isHighlighted
+		);
+		const zIndexOffset = isHighlighted ? 2000 : 1000;
 		const customIcon = this.L.divIcon({
 			html: `<img alt="" src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(vehicleIconSvg)}" />`,
 			iconSize: [iconWidth, iconHeight],
 			iconAnchor: [iconWidth / 2, iconHeight / 2],
 			className: '',
-			zIndexOffset: 1000
+			zIndexOffset
 		});
 
 		const label = getVehicleLabel(activeTrip);
 
 		const marker = this.L.marker([vehicle.position.lat, vehicle.position.lon], {
 			icon: customIcon,
-			zIndexOffset: 1000,
+			zIndexOffset,
 			title: label
 		}).addTo(this.map);
 
@@ -379,7 +385,7 @@ export default class OpenStreetMapProvider {
 		return marker;
 	}
 
-	updateVehicleMarker(marker, vehicleStatus, activeTrip, routeType) {
+	updateVehicleMarker(marker, vehicleStatus, activeTrip, routeType, isHighlighted = false) {
 		if (!this.map || !this.L || !marker) return;
 
 		let color;
@@ -387,13 +393,18 @@ export default class OpenStreetMapProvider {
 			color = COLORS.VEHICLE_REAL_TIME_OFF;
 		}
 
-		const updatedIconSvg = createVehicleIconSvg(vehicleStatus.orientation, color, routeType);
+		const updatedIconSvg = createVehicleIconSvg(
+			vehicleStatus.orientation,
+			color,
+			routeType,
+			isHighlighted
+		);
 		const updatedIcon = this.L.divIcon({
 			html: `<img alt="" src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(updatedIconSvg)}" />`,
 			iconSize: [iconWidth, iconHeight],
 			iconAnchor: [iconWidth / 2, iconHeight / 2],
 			className: '',
-			zIndexOffset: 1000
+			zIndexOffset: isHighlighted ? 2000 : 1000
 		});
 
 		const current = marker.getLatLng();

--- a/src/lib/__tests__/tripDetailsUtils.test.js
+++ b/src/lib/__tests__/tripDetailsUtils.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { resolveVehicleStopIndex } from '$lib/tripDetailsUtils.js';
+
+describe('resolveVehicleStopIndex', () => {
+	const stopTimes = [{ stopId: 'a' }, { stopId: 'b' }, { stopId: 'c' }, { stopId: 'd' }];
+
+	it('uses closestStop to find the index', () => {
+		expect(resolveVehicleStopIndex({ closestStop: 'c' }, stopTimes)).toBe(2);
+	});
+
+	it('falls back to nextStop when closestStop is absent', () => {
+		expect(resolveVehicleStopIndex({ nextStop: 'b' }, stopTimes)).toBe(1);
+	});
+
+	it('prefers closestStop over nextStop', () => {
+		expect(resolveVehicleStopIndex({ closestStop: 'd', nextStop: 'a' }, stopTimes)).toBe(3);
+	});
+
+	// Regression: the old approach guessed position from raw lat/lon ranges,
+	// assuming stops were ordered monotonically by coordinate. This resolves the
+	// stop purely by id, so ordering of coordinates is irrelevant.
+	it('resolves by stop id regardless of coordinate ordering', () => {
+		const unordered = [
+			{ stopId: 'a', lat: 47.9, lon: -122.1 },
+			{ stopId: 'b', lat: 47.1, lon: -122.9 },
+			{ stopId: 'c', lat: 47.5, lon: -122.5 }
+		];
+		expect(resolveVehicleStopIndex({ closestStop: 'b' }, unordered)).toBe(1);
+	});
+
+	it('returns -1 when the target stop is not in stopTimes', () => {
+		expect(resolveVehicleStopIndex({ closestStop: 'z' }, stopTimes)).toBe(-1);
+	});
+
+	it('returns -1 when status is missing', () => {
+		expect(resolveVehicleStopIndex(null, stopTimes)).toBe(-1);
+		expect(resolveVehicleStopIndex(undefined, stopTimes)).toBe(-1);
+	});
+
+	it('returns -1 when stopTimes is missing', () => {
+		expect(resolveVehicleStopIndex({ closestStop: 'a' }, null)).toBe(-1);
+		expect(resolveVehicleStopIndex({ closestStop: 'a' }, undefined)).toBe(-1);
+	});
+
+	it('returns -1 when status has neither closestStop nor nextStop', () => {
+		expect(resolveVehicleStopIndex({}, stopTimes)).toBe(-1);
+	});
+});

--- a/src/lib/__tests__/vehicleUtils.test.js
+++ b/src/lib/__tests__/vehicleUtils.test.js
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { buildVehiclePopupData } from '$lib/vehicleUtils.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+	buildVehiclePopupData,
+	updateVehicleMarkers,
+	clearVehicleMarkersMap
+} from '$lib/vehicleUtils.js';
 
 describe('buildVehiclePopupData', () => {
 	it('returns popup data with stop name when stopsMap has the nextStop', () => {
@@ -47,5 +51,80 @@ describe('buildVehiclePopupData', () => {
 			nextStopName: undefined,
 			predicted: false
 		});
+	});
+});
+
+describe('updateVehicleMarkers highlighting', () => {
+	function makeProvider() {
+		return {
+			addVehicleMarker: vi.fn(() => ({})),
+			updateVehicleMarker: vi.fn(),
+			removeVehicleMarker: vi.fn()
+		};
+	}
+
+	function mockFetchTwoVehicles() {
+		const data = {
+			references: {
+				trips: [
+					{ id: 'trip-1', routeId: 'route-1' },
+					{ id: 'trip-2', routeId: 'route-1' }
+				]
+			},
+			list: [
+				{ status: { activeTripId: 'trip-1', status: 'SCHEDULED', orientation: 0 } },
+				{ status: { activeTripId: 'trip-2', status: 'SCHEDULED', orientation: 0 } }
+			]
+		};
+		global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data }) });
+	}
+
+	beforeEach(() => {
+		clearVehicleMarkersMap();
+		mockFetchTwoVehicles();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// addVehicleMarker(vehicleStatus, activeTrip, routeType, isHighlighted)
+	const highlightArg = (call) => call[3];
+	const tripOf = (call) => call[1].id;
+
+	it('marks only the matching trip as highlighted', async () => {
+		const provider = makeProvider();
+
+		await updateVehicleMarkers('route-1', provider, undefined, 'trip-1');
+
+		const calls = provider.addVehicleMarker.mock.calls;
+		expect(highlightArg(calls.find((c) => tripOf(c) === 'trip-1'))).toBe(true);
+		expect(highlightArg(calls.find((c) => tripOf(c) === 'trip-2'))).toBe(false);
+	});
+
+	it('highlights no vehicle when highlightedTripId is null', async () => {
+		const provider = makeProvider();
+
+		await updateVehicleMarkers('route-1', provider, undefined, null);
+
+		for (const call of provider.addVehicleMarker.mock.calls) {
+			expect(highlightArg(call)).toBe(false);
+		}
+	});
+
+	it('passes the highlight flag through to updates on subsequent refreshes', async () => {
+		const provider = makeProvider();
+
+		// First pass creates the markers.
+		await updateVehicleMarkers('route-1', provider, undefined, 'trip-2');
+		// Second pass should update the existing markers, still highlighting trip-2.
+		await updateVehicleMarkers('route-1', provider, undefined, 'trip-2');
+
+		const calls = provider.updateVehicleMarker.mock.calls;
+		// updateVehicleMarker(marker, vehicleStatus, activeTrip, routeType, isHighlighted)
+		const trip2 = calls.find((c) => c[2].id === 'trip-2');
+		const trip1 = calls.find((c) => c[2].id === 'trip-1');
+		expect(trip2[4]).toBe(true);
+		expect(trip1[4]).toBe(false);
 	});
 });

--- a/src/lib/tripDetailsUtils.js
+++ b/src/lib/tripDetailsUtils.js
@@ -1,0 +1,19 @@
+/**
+ * Locate the vehicle's current stop within a trip's ordered `stopTimes`, using
+ * the stop IDs the server reports for exactly this purpose. `closestStop` is the
+ * stop nearest the vehicle's current position; fall back to `nextStop`.
+ *
+ * This intentionally does NOT infer position from raw lat/lon: that assumed
+ * stops were ordered monotonically by coordinate, which is false on most route
+ * directions and highlighted the wrong stop.
+ *
+ * @param {{ closestStop?: string, nextStop?: string } | null | undefined} status
+ * @param {Array<{ stopId: string }> | null | undefined} stopTimes
+ * @returns {number} index into `stopTimes`, or -1 when it can't be determined
+ */
+export function resolveVehicleStopIndex(status, stopTimes) {
+	if (!status || !stopTimes) return -1;
+
+	const targetStopId = status.closestStop || status.nextStop;
+	return targetStopId ? stopTimes.findIndex((st) => st.stopId === targetStopId) : -1;
+}

--- a/src/lib/vehicleUtils.js
+++ b/src/lib/vehicleUtils.js
@@ -28,7 +28,12 @@ export async function fetchVehicles(routeId) {
 	return data;
 }
 
-export async function updateVehicleMarkers(routeId, mapProvider, routeType) {
+export async function updateVehicleMarkers(
+	routeId,
+	mapProvider,
+	routeType,
+	highlightedTripId = null
+) {
 	const data = await fetchVehicles(routeId);
 
 	const activeTripIds = new Set();
@@ -46,15 +51,28 @@ export async function updateVehicleMarkers(routeId, mapProvider, routeType) {
 		// OBA puts the trip state string on status.status (e.g. SCHEDULED, CANCELED), not on status itself
 		if (activeTrip && activeTrip.routeId === routeId && tripStatus.status?.status !== 'CANCELED') {
 			const vehicleStatus = tripStatus.status;
+			// Highlight the vehicle serving the trip the user clicked on.
+			const isHighlighted = highlightedTripId != null && activeTripId === highlightedTripId;
 
 			activeTripIds.add(activeTripId);
 
 			if (vehicleMarkersMap.has(activeTripId)) {
 				const marker = vehicleMarkersMap.get(activeTripId);
 
-				mapProvider.updateVehicleMarker(marker, vehicleStatus, activeTrip, routeType);
+				mapProvider.updateVehicleMarker(
+					marker,
+					vehicleStatus,
+					activeTrip,
+					routeType,
+					isHighlighted
+				);
 			} else {
-				const marker = mapProvider.addVehicleMarker(vehicleStatus, activeTrip, routeType);
+				const marker = mapProvider.addVehicleMarker(
+					vehicleStatus,
+					activeTrip,
+					routeType,
+					isHighlighted
+				);
 				vehicleMarkersMap.set(activeTripId, marker);
 			}
 		}
@@ -72,16 +90,21 @@ export function removeInactiveMarkers(activeTripIds, mapProvider) {
 	}
 }
 
-export async function fetchAndUpdateVehicles(routeId, mapProvider, routeType) {
+export async function fetchAndUpdateVehicles(
+	routeId,
+	mapProvider,
+	routeType,
+	highlightedTripId = null
+) {
 	try {
-		await updateVehicleMarkers(routeId, mapProvider, routeType);
+		await updateVehicleMarkers(routeId, mapProvider, routeType, highlightedTripId);
 	} catch (error) {
 		console.error('fetchAndUpdateVehicles: initial fetch failed', routeId, error);
 	}
 
 	return setInterval(async () => {
 		try {
-			await updateVehicleMarkers(routeId, mapProvider, routeType);
+			await updateVehicleMarkers(routeId, mapProvider, routeType, highlightedTripId);
 		} catch (error) {
 			console.error('fetchAndUpdateVehicles: polling update failed', routeId, error);
 		}

--- a/src/tests/lib/OpenStreetMapProvider.test.js
+++ b/src/tests/lib/OpenStreetMapProvider.test.js
@@ -219,6 +219,18 @@ describe('addVehicleMarker — accessible label', () => {
 		expect(fakeMarker._el.getAttribute('title')).toBe('Vehicle to Downtown');
 		expect(fakeMarker.options.title).toBe('Vehicle to Downtown');
 	});
+
+	// divIcon ignores zIndexOffset, so the stacking order must be updated on the
+	// marker itself to reflect the current highlight state on refresh.
+	test('raises the z-index offset when highlighted on update', () => {
+		provider.addVehicleMarker(VEHICLE, { tripHeadsign: 'Northgate' }, 3);
+
+		provider.updateVehicleMarker(fakeMarker, VEHICLE, { tripHeadsign: 'Downtown' }, 3, true);
+		expect(fakeMarker.setZIndexOffset).toHaveBeenLastCalledWith(2000);
+
+		provider.updateVehicleMarker(fakeMarker, VEHICLE, { tripHeadsign: 'Downtown' }, 3, false);
+		expect(fakeMarker.setZIndexOffset).toHaveBeenLastCalledWith(1000);
+	});
 });
 
 describe('addVehicleMarker — keyboard activation', () => {

--- a/src/tests/lib/OpenStreetMapProvider.test.js
+++ b/src/tests/lib/OpenStreetMapProvider.test.js
@@ -68,7 +68,8 @@ function makeFakeMarker() {
 		bindPopup: vi.fn().mockReturnThis(),
 		openPopup: vi.fn(),
 		setLatLng: vi.fn(),
-		setIcon: vi.fn()
+		setIcon: vi.fn(),
+		setZIndexOffset: vi.fn()
 	};
 }
 


### PR DESCRIPTION
Fixes: #520 
Fixes: #521 

Two fixes for the route/trip view:

- Trip details highlighted the wrong stop for the bus. Position was
  guessed from raw lat/lon ranges, which assumes stops are ordered
  monotonically by coordinate — wrong on most route directions. Now
  resolves the stop by the server's closestStop / nextStop id.
- Selecting an arrival showed every vehicle on the route with no way to
  tell which was yours. The clicked trip's vehicle now gets a soft glow
  and raised z-index; other route vehicles stay visible.

Tests: added regression coverage for the stop resolution, the highlight
flag threading, and the glow markup. Full suite green (1396 tests).


<img width="2443" height="1361" alt="image" src="https://github.com/user-attachments/assets/df40324d-4858-485c-bdf7-dc2271423462" />


<img width="1519" height="996" alt="image" src="https://github.com/user-attachments/assets/1c95bf77-ad7a-4a19-a65b-443edf34f006" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selected trips are now visually highlighted on the map, making it easier to follow a specific vehicle.
  * Vehicle markers now render with a distinct emphasis and stay on top of other markers when highlighted.
  * Trip details now use a more reliable stop-position lookup, improving the bus position shown for a trip.

* **Tests**
  * Added coverage for highlighted vehicle markers and stop-position resolution to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->