### PR TITLE
fix(map): key vehicle markers by vehicleId to stop markers jumping

### DIFF
--- a/src/lib/__tests__/vehicleUtils.test.js
+++ b/src/lib/__tests__/vehicleUtils.test.js
@@ -54,7 +54,7 @@ describe('buildVehiclePopupData', () => {
 	});
 });
 
-describe('updateVehicleMarkers highlighting', () => {
+describe('updateVehicleMarkers', () => {
 	function makeProvider() {
 		return {
 			addVehicleMarker: vi.fn(() => ({})),
@@ -63,68 +63,137 @@ describe('updateVehicleMarkers highlighting', () => {
 		};
 	}
 
-	function mockFetchTwoVehicles() {
-		const data = {
-			references: {
-				trips: [
-					{ id: 'trip-1', routeId: 'route-1' },
-					{ id: 'trip-2', routeId: 'route-1' }
-				]
-			},
-			list: [
-				{ status: { activeTripId: 'trip-1', status: 'SCHEDULED', orientation: 0 } },
-				{ status: { activeTripId: 'trip-2', status: 'SCHEDULED', orientation: 0 } }
-			]
-		};
+	function mockFetch(data) {
 		global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data }) });
 	}
 
-	beforeEach(() => {
-		clearVehicleMarkersMap();
-		mockFetchTwoVehicles();
-	});
-
-	afterEach(() => {
-		vi.restoreAllMocks();
-	});
+	beforeEach(() => clearVehicleMarkersMap());
+	afterEach(() => vi.restoreAllMocks());
 
 	// addVehicleMarker(vehicleStatus, activeTrip, routeType, isHighlighted)
 	const highlightArg = (call) => call[3];
 	const tripOf = (call) => call[1].id;
 
-	it('marks only the matching trip as highlighted', async () => {
-		const provider = makeProvider();
+	describe('highlighting', () => {
+		beforeEach(() => {
+			mockFetch({
+				references: {
+					trips: [
+						{ id: 'trip-1', routeId: 'route-1' },
+						{ id: 'trip-2', routeId: 'route-1' }
+					]
+				},
+				list: [
+					{ status: { activeTripId: 'trip-1', status: 'SCHEDULED', orientation: 0 } },
+					{ status: { activeTripId: 'trip-2', status: 'SCHEDULED', orientation: 0 } }
+				]
+			});
+		});
 
-		await updateVehicleMarkers('route-1', provider, undefined, 'trip-1');
+		it('marks only the matching trip as highlighted', async () => {
+			const provider = makeProvider();
 
-		const calls = provider.addVehicleMarker.mock.calls;
-		expect(highlightArg(calls.find((c) => tripOf(c) === 'trip-1'))).toBe(true);
-		expect(highlightArg(calls.find((c) => tripOf(c) === 'trip-2'))).toBe(false);
+			await updateVehicleMarkers('route-1', provider, undefined, 'trip-1');
+
+			const calls = provider.addVehicleMarker.mock.calls;
+			expect(highlightArg(calls.find((c) => tripOf(c) === 'trip-1'))).toBe(true);
+			expect(highlightArg(calls.find((c) => tripOf(c) === 'trip-2'))).toBe(false);
+		});
+
+		it('highlights no vehicle when highlightedTripId is null', async () => {
+			const provider = makeProvider();
+
+			await updateVehicleMarkers('route-1', provider, undefined, null);
+
+			for (const call of provider.addVehicleMarker.mock.calls) {
+				expect(highlightArg(call)).toBe(false);
+			}
+		});
+
+		it('passes the highlight flag through to updates on subsequent refreshes', async () => {
+			const provider = makeProvider();
+
+			await updateVehicleMarkers('route-1', provider, undefined, 'trip-2');
+			await updateVehicleMarkers('route-1', provider, undefined, 'trip-2');
+
+			const calls = provider.updateVehicleMarker.mock.calls;
+			const trip2 = calls.find((c) => c[2].id === 'trip-2');
+			const trip1 = calls.find((c) => c[2].id === 'trip-1');
+			expect(trip2[4]).toBe(true);
+			expect(trip1[4]).toBe(false);
+		});
 	});
 
-	it('highlights no vehicle when highlightedTripId is null', async () => {
-		const provider = makeProvider();
+	describe('marker keying', () => {
+		it('creates a separate marker per vehicle when two share an activeTripId', async () => {
+			mockFetch({
+				references: { trips: [{ id: 'trip-1', routeId: 'route-1' }] },
+				list: [
+					{
+						status: {
+							activeTripId: 'trip-1',
+							status: 'SCHEDULED',
+							vehicleId: 'veh-A',
+							position: { lat: 47.5233, lon: -122.26822 }
+						}
+					},
+					{
+						status: {
+							activeTripId: 'trip-1',
+							status: 'SCHEDULED',
+							vehicleId: 'veh-B',
+							position: { lat: 47.5221, lon: -122.26445 }
+						}
+					}
+				]
+			});
 
-		await updateVehicleMarkers('route-1', provider, undefined, null);
+			const provider = makeProvider();
+			await updateVehicleMarkers('route-1', provider);
 
-		for (const call of provider.addVehicleMarker.mock.calls) {
-			expect(highlightArg(call)).toBe(false);
-		}
-	});
+			expect(provider.addVehicleMarker).toHaveBeenCalledTimes(2);
+			expect(provider.updateVehicleMarker).not.toHaveBeenCalled();
+		});
 
-	it('passes the highlight flag through to updates on subsequent refreshes', async () => {
-		const provider = makeProvider();
+		it('reuses the same marker for a vehicle across refreshes', async () => {
+			const list = [
+				{
+					status: {
+						activeTripId: 'trip-1',
+						status: 'SCHEDULED',
+						vehicleId: 'veh-A',
+						position: { lat: 47.5, lon: -122.3 }
+					}
+				}
+			];
+			mockFetch({ references: { trips: [{ id: 'trip-1', routeId: 'route-1' }] }, list });
 
-		// First pass creates the markers.
-		await updateVehicleMarkers('route-1', provider, undefined, 'trip-2');
-		// Second pass should update the existing markers, still highlighting trip-2.
-		await updateVehicleMarkers('route-1', provider, undefined, 'trip-2');
+			const provider = makeProvider();
+			await updateVehicleMarkers('route-1', provider);
+			await updateVehicleMarkers('route-1', provider);
 
-		const calls = provider.updateVehicleMarker.mock.calls;
-		// updateVehicleMarker(marker, vehicleStatus, activeTrip, routeType, isHighlighted)
-		const trip2 = calls.find((c) => c[2].id === 'trip-2');
-		const trip1 = calls.find((c) => c[2].id === 'trip-1');
-		expect(trip2[4]).toBe(true);
-		expect(trip1[4]).toBe(false);
+			expect(provider.addVehicleMarker).toHaveBeenCalledTimes(1);
+			expect(provider.updateVehicleMarker).toHaveBeenCalledTimes(1);
+		});
+
+		it('falls back to activeTripId when a status has no vehicleId', async () => {
+			mockFetch({
+				references: { trips: [{ id: 'trip-1', routeId: 'route-1' }] },
+				list: [
+					{
+						status: {
+							activeTripId: 'trip-1',
+							status: 'SCHEDULED',
+							position: { lat: 47.5, lon: -122.3 }
+						}
+					}
+				]
+			});
+
+			const provider = makeProvider();
+			await updateVehicleMarkers('route-1', provider);
+
+			expect(provider.addVehicleMarker).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/src/lib/vehicleUtils.js
+++ b/src/lib/vehicleUtils.js
@@ -6,10 +6,13 @@
 const activeTripMap = new Map();
 
 /**
- * @type {Map<activeTripId, marker>}
- * using activeTripId as key instead of vehicleId
+ * @type {Map<vehicleId, marker>}
+ * Keyed by the physical vehicle id. The trips-for-route response can report the
+ * same activeTripId for two different vehicles (e.g. the vehicle actually serving
+ * the trip plus a second one still parked at the base), so keying by trip id
+ * collapsed both into one marker that flipped between their positions on every
+ * refresh. Falls back to activeTripId only when a status has no vehicleId.
  * see (https://developer.onebusaway.org/api/where/elements/trip-status)
- *
  */
 const vehicleMarkersMap = new Map();
 
@@ -36,7 +39,7 @@ export async function updateVehicleMarkers(
 ) {
 	const data = await fetchVehicles(routeId);
 
-	const activeTripIds = new Set();
+	const activeKeys = new Set();
 
 	for (const trip of data.references.trips) {
 		if (!activeTripMap.has(trip.id)) {
@@ -51,13 +54,18 @@ export async function updateVehicleMarkers(
 		// OBA puts the trip state string on status.status (e.g. SCHEDULED, CANCELED), not on status itself
 		if (activeTrip && activeTrip.routeId === routeId && tripStatus.status?.status !== 'CANCELED') {
 			const vehicleStatus = tripStatus.status;
+
 			// Highlight the vehicle serving the trip the user clicked on.
 			const isHighlighted = highlightedTripId != null && activeTripId === highlightedTripId;
 
-			activeTripIds.add(activeTripId);
+			// Key by the physical vehicle so two vehicles sharing an activeTripId
+			// don't collide into one marker that jumps between their positions.
+			const markerKey = vehicleStatus.vehicleId || activeTripId;
 
-			if (vehicleMarkersMap.has(activeTripId)) {
-				const marker = vehicleMarkersMap.get(activeTripId);
+			activeKeys.add(markerKey);
+
+			if (vehicleMarkersMap.has(markerKey)) {
+				const marker = vehicleMarkersMap.get(markerKey);
 
 				mapProvider.updateVehicleMarker(
 					marker,
@@ -73,19 +81,19 @@ export async function updateVehicleMarkers(
 					routeType,
 					isHighlighted
 				);
-				vehicleMarkersMap.set(activeTripId, marker);
+				vehicleMarkersMap.set(markerKey, marker);
 			}
 		}
 	}
 
-	removeInactiveMarkers(activeTripIds, mapProvider);
+	removeInactiveMarkers(activeKeys, mapProvider);
 }
 
-export function removeInactiveMarkers(activeTripIds, mapProvider) {
-	for (const [activeTripId, marker] of vehicleMarkersMap) {
-		if (!activeTripIds.has(activeTripId)) {
+export function removeInactiveMarkers(activeKeys, mapProvider) {
+	for (const [markerKey, marker] of vehicleMarkersMap) {
+		if (!activeKeys.has(markerKey)) {
 			mapProvider.removeVehicleMarker(marker);
-			vehicleMarkersMap.delete(activeTripId);
+			vehicleMarkersMap.delete(markerKey);
 		}
 	}
 }


### PR DESCRIPTION
Fixes: #548 

Vehicle markers were keyed by `activeTripId`, but the OBA trips-for-route
response can report the same `activeTripId` for two different vehicles (the one
serving the trip plus a second parked at the base). Both collapsed into one
marker that flipped between their positions on every ~30s refresh — the vehicle
appeared to jump forward and back.

Key markers by the physical `vehicleId` instead (falling back to `activeTripId`
only when a status has no vehicle id), so each vehicle gets its own marker and
two vehicles sharing a trip no longer collide.

Added regression tests: two vehicles sharing an activeTripId now produce two
markers (not one add + one update), a vehicle reuses its marker across
refreshes, and the no-vehicleId fallback still works.

It looks great now after testing vs android app!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vehicle marker behavior so markers stay associated with the correct vehicle, even when multiple vehicles share the same trip.
  * Prevented markers from being duplicated or reassigned incorrectly during refreshes.
  * Ensured markers are still handled correctly when vehicle details are incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->