### PR TITLE
fix(trip-options): snap default walk distance to metric select options

### DIFF
--- a/src/components/trip-planner/TripOptionsModal.svelte
+++ b/src/components/trip-planner/TripOptionsModal.svelte
@@ -6,6 +6,8 @@
 		effectiveDistanceUnit,
 		getWalkDistanceOptions,
 		snapToClosestOption,
+		resolveWalkDistanceForUnit,
+		canonicalizeWalkDistance,
 		DEFAULT_TRIP_OPTIONS,
 		UNIT_METRIC,
 		UNIT_IMPERIAL
@@ -23,7 +25,9 @@
 	let departureDate = $state($tripOptions.departureDate || '');
 	let wheelchair = $state($tripOptions.wheelchair);
 	let optimize = $state($tripOptions.optimize);
-	let maxWalkDistance = $state($tripOptions.maxWalkDistance);
+	let maxWalkDistance = $state(
+		resolveWalkDistanceForUnit($tripOptions.maxWalkDistance, $effectiveDistanceUnit)
+	);
 	let distanceUnit = $state($tripOptions.distanceUnit); // null = auto, 'metric', or 'imperial'
 
 	// Get the effective unit for display (resolves null to actual unit)
@@ -60,7 +64,10 @@
 		// Update persisted values
 		tripOptions.setPersisted('wheelchair', wheelchair);
 		tripOptions.setPersisted('optimize', optimize);
-		tripOptions.setPersisted('maxWalkDistance', maxWalkDistance);
+		tripOptions.setPersisted(
+			'maxWalkDistance',
+			canonicalizeWalkDistance(maxWalkDistance, displayUnit)
+		);
 		tripOptions.setPersisted('distanceUnit', distanceUnit);
 
 		onDone();
@@ -84,8 +91,11 @@
 		departureDate = DEFAULT_TRIP_OPTIONS.departureDate || '';
 		wheelchair = DEFAULT_TRIP_OPTIONS.wheelchair;
 		optimize = DEFAULT_TRIP_OPTIONS.optimize;
-		maxWalkDistance = DEFAULT_TRIP_OPTIONS.maxWalkDistance;
 		distanceUnit = DEFAULT_TRIP_OPTIONS.distanceUnit;
+		maxWalkDistance = resolveWalkDistanceForUnit(
+			DEFAULT_TRIP_OPTIONS.maxWalkDistance,
+			distanceUnit ?? $effectiveDistanceUnit
+		);
 	}
 </script>
 

--- a/src/components/trip-planner/__tests__/TripOptionsModal.test.js
+++ b/src/components/trip-planner/__tests__/TripOptionsModal.test.js
@@ -165,4 +165,21 @@ describe('TripOptionsModal reset', () => {
 		expect(localStorage.removeItem).toHaveBeenCalledWith('tripOptions_distanceUnit');
 		expect(localStorage.setItem).not.toHaveBeenCalled();
 	});
+
+	it('shows a matching metric default in the walk distance select after reset', async () => {
+		const originalNavigator = global.navigator;
+		global.navigator = { language: 'de-DE' };
+
+		try {
+			render(TripOptionsModal, { props: { onClose: vi.fn(), onDone: vi.fn() } });
+
+			const walkSelect = screen.getByRole('combobox');
+			await user.selectOptions(walkSelect, '5000');
+			await user.click(screen.getByText('Reset to defaults'));
+
+			expect(walkSelect).toHaveValue('1500');
+		} finally {
+			global.navigator = originalNavigator;
+		}
+	});
 });

--- a/src/lib/__tests__/distanceUtils.test.js
+++ b/src/lib/__tests__/distanceUtils.test.js
@@ -5,6 +5,7 @@ import {
 	formatDistance,
 	getWalkDistanceOptions,
 	snapToClosestOption,
+	resolveWalkDistanceForUnit,
 	formatWalkDistanceLabel,
 	UNIT_METRIC,
 	UNIT_IMPERIAL
@@ -254,6 +255,17 @@ describe('distanceUtils', () => {
 
 			// Metric 3km (3000m) -> Imperial closest is 2 miles (3219m)
 			expect(snapToClosestOption(3000, UNIT_IMPERIAL)).toBe(3219);
+		});
+	});
+
+	describe('resolveWalkDistanceForUnit', () => {
+		it('returns the value unchanged when it matches an option', () => {
+			expect(resolveWalkDistanceForUnit(1609, UNIT_IMPERIAL)).toBe(1609);
+			expect(resolveWalkDistanceForUnit(1500, UNIT_METRIC)).toBe(1500);
+		});
+
+		it('snaps the canonical default to the closest metric option', () => {
+			expect(resolveWalkDistanceForUnit(1609, UNIT_METRIC)).toBe(1500);
 		});
 	});
 

--- a/src/lib/distanceUtils.js
+++ b/src/lib/distanceUtils.js
@@ -125,6 +125,23 @@ export function getWalkDistanceOptions(unit) {
 }
 
 /**
+ * Resolve a walk distance to a value that matches one of the unit's select options.
+ * If the distance already matches an option, it is returned unchanged; otherwise the
+ * closest option value is used.
+ *
+ * @param {number} meters - Distance in meters
+ * @param {string} unit - Target unit system ('metric' or 'imperial')
+ * @returns {number} - Matching or snapped option value
+ */
+export function resolveWalkDistanceForUnit(meters, unit) {
+	const options = getWalkDistanceOptions(unit);
+	if (options.some((option) => option.value === meters)) {
+		return meters;
+	}
+	return snapToClosestOption(meters, unit);
+}
+
+/**
  * Snap a distance value to the closest option in the given unit system.
  * Useful when switching between unit systems to find the closest equivalent.
  *

--- a/src/stores/__tests__/tripOptionsStore.test.js
+++ b/src/stores/__tests__/tripOptionsStore.test.js
@@ -69,3 +69,25 @@ describe('tripOptionsStore', () => {
 		expect(localStorage.removeItem).toHaveBeenCalledWith('tripOptions_distanceUnit');
 	});
 });
+
+describe('canonicalizeWalkDistance', () => {
+	beforeEach(async () => {
+		vi.resetModules();
+	});
+
+	it('maps a unit-specific default selection back to the canonical default meters', async () => {
+		const { canonicalizeWalkDistance, DEFAULT_TRIP_OPTIONS } = await import(
+			'../../stores/tripOptionsStore.js'
+		);
+
+		expect(canonicalizeWalkDistance(1500, 'metric')).toBe(DEFAULT_TRIP_OPTIONS.maxWalkDistance);
+		expect(canonicalizeWalkDistance(1609, 'imperial')).toBe(DEFAULT_TRIP_OPTIONS.maxWalkDistance);
+	});
+
+	it('preserves non-default selections', async () => {
+		const { canonicalizeWalkDistance } = await import('../../stores/tripOptionsStore.js');
+
+		expect(canonicalizeWalkDistance(800, 'metric')).toBe(800);
+		expect(canonicalizeWalkDistance(3219, 'imperial')).toBe(3219);
+	});
+});

--- a/src/stores/tripOptionsStore.js
+++ b/src/stores/tripOptionsStore.js
@@ -5,6 +5,7 @@ import {
 	getWalkDistanceOptions,
 	formatWalkDistanceLabel,
 	snapToClosestOption,
+	resolveWalkDistanceForUnit,
 	UNIT_METRIC,
 	UNIT_IMPERIAL
 } from '$lib/distanceUtils';
@@ -38,7 +39,29 @@ const defaults = {
 export const DEFAULT_TRIP_OPTIONS = Object.freeze({ ...defaults });
 
 // Re-export for use by components
-export { getWalkDistanceOptions, snapToClosestOption, UNIT_METRIC, UNIT_IMPERIAL };
+export {
+	getWalkDistanceOptions,
+	snapToClosestOption,
+	resolveWalkDistanceForUnit,
+	UNIT_METRIC,
+	UNIT_IMPERIAL
+};
+
+/**
+ * When persisting walk distance, map a unit-specific default selection back to the
+ * canonical default meters value so auto-detect regions stay forward-compatible.
+ *
+ * @param {number} meters - Selected distance in meters
+ * @param {string} unit - Effective unit system ('metric' or 'imperial')
+ * @returns {number}
+ */
+export function canonicalizeWalkDistance(meters, unit) {
+	const resolvedDefault = resolveWalkDistanceForUnit(DEFAULT_WALK_DISTANCE_METERS, unit);
+	if (meters === resolvedDefault) {
+		return DEFAULT_WALK_DISTANCE_METERS;
+	}
+	return meters;
+}
 
 // Legacy static options - kept for backwards compatibility
 // New code should use getWalkDistanceOptions(unit) instead


### PR DESCRIPTION
When distanceUnit is auto and the region resolves to metric, the canonical default of 1609m did not match any walk distance option in the modal select. Resolve the displayed value through the effective unit and map unit-specific defaults back to 1609m when saving.

Fixes #545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Walk-distance settings now adapt more consistently to the selected measurement unit, keeping defaults and saved values aligned across metric and imperial views.

* **Bug Fixes**
  * Resetting trip options now restores the expected walk-distance value for the current locale and unit system.
  * Saving trip options now preserves walk-distance selections in a consistent format, reducing unit-related mismatches.

* **Tests**
  * Added coverage for unit-based walk-distance behavior and reset defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->