### PR TITLE
fix(a11y): polish marker accessibility follow-ups from #487

### DIFF
--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -406,8 +406,15 @@ export default class GoogleMapProvider {
 	}
 
 	removeVehicleMarker(marker) {
+		if (!marker) return;
+
 		cancelMarkerAnimation(marker);
 		marker.setMap(null);
+
+		const index = this.vehicleMarkers.indexOf(marker);
+		if (index > -1) {
+			this.vehicleMarkers.splice(index, 1);
+		}
 	}
 
 	clearVehicleMarkers() {

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -223,6 +223,31 @@ export default class OpenStreetMapProvider {
 		});
 	}
 
+	/**
+	 * Apply aria-label and keyboard activation to a Leaflet marker element.
+	 * Logs a warning when getElement() returns null so inaccessible markers are
+	 * not silently shipped during teardown or before first render.
+	 *
+	 * @param {import('leaflet').Marker} marker
+	 * @param {{ label?: string, onActivate?: () => void, context: string }} options
+	 */
+	setupMarkerAccessibility(marker, { label, onActivate, context }) {
+		const el = marker.getElement();
+		if (el) {
+			if (label) {
+				el.setAttribute('aria-label', label);
+			}
+			if (onActivate) {
+				this.attachKeyboardActivation(el, onActivate);
+			}
+			return;
+		}
+
+		console.warn(
+			`OpenStreetMapProvider: marker DOM element unavailable during ${context} accessibility setup`
+		);
+	}
+
 	addStopRouteMarker(stop, stopTime = null) {
 		if (!this.map || !this.L) return;
 
@@ -244,11 +269,11 @@ export default class OpenStreetMapProvider {
 
 		const open = () => this.openStopMarker(stop, stopTime);
 
-		const el = marker.getElement();
-		if (el) {
-			el.setAttribute('aria-label', stop.name);
-			this.attachKeyboardActivation(el, open);
-		}
+		this.setupMarkerAccessibility(marker, {
+			label: stop.name || undefined,
+			onActivate: open,
+			context: 'stop route marker'
+		});
 
 		marker.on('click', open);
 
@@ -343,12 +368,12 @@ export default class OpenStreetMapProvider {
 			title: label
 		}).addTo(this.map);
 
-		const el = marker.getElement();
-		if (el) {
-			el.setAttribute('aria-label', label);
-			// preventDefault inside attachKeyboardActivation is load-bearing here: bindPopup makes Leaflet attach its own _onKeyPress (Enter -> toggle popup) on the keypress event. Suppressing the default keydown stops that synthesized keypress, so our openPopup() doesn't double-fire and flash the popup open-then-closed. stopPropagation does NOT cover this (keydown and keypress are separate events) — do not remove preventDefault.
-			this.attachKeyboardActivation(el, () => marker.openPopup());
-		}
+		// preventDefault inside attachKeyboardActivation is load-bearing here: bindPopup makes Leaflet attach its own _onKeyPress (Enter -> toggle popup) on the keypress event. Suppressing the default keydown stops that synthesized keypress, so our openPopup() doesn't double-fire and flash the popup open-then-closed. stopPropagation does NOT cover this (keydown and keypress are separate events) — do not remove preventDefault.
+		this.setupMarkerAccessibility(marker, {
+			label,
+			onActivate: () => marker.openPopup(),
+			context: 'vehicle marker'
+		});
 
 		this.vehicleMarkers.push(marker);
 
@@ -424,6 +449,10 @@ export default class OpenStreetMapProvider {
 		if (marker) {
 			cancelMarkerAnimation(marker);
 			marker.remove();
+			const index = this.vehicleMarkers.indexOf(marker);
+			if (index > -1) {
+				this.vehicleMarkers.splice(index, 1);
+			}
 		}
 	}
 

--- a/src/tests/lib/GoogleMapProvider.test.js
+++ b/src/tests/lib/GoogleMapProvider.test.js
@@ -1,0 +1,112 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import GoogleMapProvider from '$lib/Provider/GoogleMapProvider.svelte.js';
+
+vi.mock('$components/map/StopMarker.svelte', () => ({ default: {} }));
+vi.mock('$components/map/PopupContent.svelte', () => ({ default: {} }));
+vi.mock('$components/map/VehiclePopupContent.svelte', () => ({ default: {} }));
+vi.mock('$components/map/ContextMenuPopup.svelte', () => ({ default: {} }));
+vi.mock('$components/trip-planner/tripPlanPinMarker.svelte', () => ({ default: {} }));
+vi.mock('$lib/MapHelpers/generateVehicleIcon', () => ({
+	createVehicleIconSvg: vi.fn(() => '<svg></svg>'),
+	iconHeight: 40,
+	iconWidth: 40
+}));
+vi.mock('$lib/MapHelpers/animateMarker', () => ({
+	animateMarkerTo: vi.fn(),
+	cancelMarkerAnimation: vi.fn()
+}));
+vi.mock('$lib/vehicleUtils', () => ({
+	buildVehiclePopupData: vi.fn(() => ({}))
+}));
+vi.mock('$lib/googleMaps', () => ({
+	loadGoogleMapsLibrary: vi.fn(),
+	createMap: vi.fn(),
+	nightModeStyles: vi.fn(() => [])
+}));
+vi.mock('svelte', async (importOriginal) => {
+	const actual = await importOriginal();
+	return { ...actual, mount: vi.fn(), unmount: vi.fn() };
+});
+
+const STOP = { id: 'stop_1', name: 'Market & Main', lat: 47.6, lon: -122.3 };
+
+function makeGoogleMarkerMock() {
+	return vi.fn(function GoogleMarker(options) {
+		this.options = options;
+		this.listeners = {};
+		this.addListener = vi.fn((event, handler) => {
+			this.listeners[event] = handler;
+		});
+		this.setMap = vi.fn();
+	});
+}
+
+function setupGoogleMaps(MarkerMock) {
+	global.google = {
+		maps: {
+			Marker: MarkerMock,
+			InfoWindow: vi.fn(function InfoWindow() {
+				this.open = vi.fn();
+			}),
+			SymbolPath: { CIRCLE: 0 },
+			Size: vi.fn(),
+			Point: vi.fn()
+		}
+	};
+}
+
+describe('addStopRouteMarker — accessible name', () => {
+	let provider;
+	let MarkerMock;
+
+	beforeEach(() => {
+		MarkerMock = makeGoogleMarkerMock();
+		setupGoogleMaps(MarkerMock);
+
+		provider = new GoogleMapProvider('test-key', vi.fn());
+		provider.map = {};
+		vi.spyOn(provider, 'openStopMarker').mockImplementation(() => {});
+	});
+
+	test('sets title to stop name for screen reader and tooltip access', () => {
+		provider.addStopRouteMarker(STOP);
+
+		expect(MarkerMock).toHaveBeenCalledOnce();
+		expect(MarkerMock.mock.calls[0][0]).toMatchObject({
+			title: STOP.name,
+			position: { lat: STOP.lat, lng: STOP.lon }
+		});
+	});
+});
+
+describe('removeVehicleMarker — marker tracking', () => {
+	let provider;
+	let MarkerMock;
+
+	beforeEach(() => {
+		MarkerMock = makeGoogleMarkerMock();
+		setupGoogleMaps(MarkerMock);
+
+		provider = new GoogleMapProvider('test-key', vi.fn());
+		provider.map = {};
+	});
+
+	test('removes the marker from vehicleMarkers after removal', () => {
+		const marker = provider.addVehicleMarker(
+			{
+				position: { lat: 47.6, lon: -122.3 },
+				predicted: true,
+				orientation: 90
+			},
+			{ tripHeadsign: 'Northgate' },
+			3
+		);
+
+		expect(provider.vehicleMarkers).toHaveLength(1);
+
+		provider.removeVehicleMarker(marker);
+
+		expect(marker.setMap).toHaveBeenCalledWith(null);
+		expect(provider.vehicleMarkers).toHaveLength(0);
+	});
+});

--- a/src/tests/lib/OpenStreetMapProvider.test.js
+++ b/src/tests/lib/OpenStreetMapProvider.test.js
@@ -142,6 +142,24 @@ describe('addStopRouteMarker — keyboard activation', () => {
 
 		expect(fakeMarker._el.getAttribute('aria-label')).toBe(STOP.name);
 	});
+
+	test('does not set aria-label when stop name is missing', () => {
+		provider.addStopRouteMarker({ ...STOP, name: undefined });
+
+		expect(fakeMarker._el.hasAttribute('aria-label')).toBe(false);
+	});
+
+	test('warns when marker element is unavailable during accessibility setup', () => {
+		fakeMarker.getElement.mockReturnValue(null);
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		provider.addStopRouteMarker(STOP);
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			'OpenStreetMapProvider: marker DOM element unavailable during stop route marker accessibility setup'
+		);
+		warnSpy.mockRestore();
+	});
 });
 
 describe('addMarker — primary stop markers', () => {
@@ -259,5 +277,40 @@ describe('addVehicleMarker — keyboard activation', () => {
 		fakeMarker._el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
 
 		expect(fakeMarker.openPopup).not.toHaveBeenCalled();
+	});
+
+	test('warns when vehicle marker element is unavailable during accessibility setup', () => {
+		fakeMarker.getElement.mockReturnValue(null);
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		provider.addVehicleMarker(VEHICLE, { tripHeadsign: 'Northgate' }, 3);
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			'OpenStreetMapProvider: marker DOM element unavailable during vehicle marker accessibility setup'
+		);
+		warnSpy.mockRestore();
+	});
+});
+
+describe('removeVehicleMarker — marker tracking', () => {
+	let provider;
+	let fakeMarker;
+
+	beforeEach(() => {
+		fakeMarker = makeFakeMarker();
+		fakeMarker.remove = vi.fn();
+		provider = new OpenStreetMapProvider(vi.fn());
+		provider.L = makeFakeL(fakeMarker);
+		provider.map = {};
+	});
+
+	test('removes the marker from vehicleMarkers after removal', () => {
+		provider.addVehicleMarker(VEHICLE, { tripHeadsign: 'Northgate' }, 3);
+		expect(provider.vehicleMarkers).toHaveLength(1);
+
+		provider.removeVehicleMarker(provider.vehicleMarkers[0]);
+
+		expect(fakeMarker.remove).toHaveBeenCalledOnce();
+		expect(provider.vehicleMarkers).toHaveLength(0);
 	});
 });


### PR DESCRIPTION
- Add GoogleMapProvider test that stop route markers set title to stop.name
- Guard OSM aria-label against falsy stop names via setupMarkerAccessibility
- Warn when Leaflet getElement() returns null during a11y setup
- Prune vehicleMarkers when removeVehicleMarker runs (OSM and Google)

Fixes #542