### PR TITLE
fix: improve CompassArrow regression comments

### DIFF
--- a/src/components/controls/CompassArrow.svelte
+++ b/src/components/controls/CompassArrow.svelte
@@ -32,9 +32,10 @@
 		NW: 'rotate-225'
 	};
 
-	// Wrapping the icon in a span we control means the rotation class re-applies
-	// reactively when `stopDirection` changes, independent of how the
-	// FontAwesome component forwards its own `class` prop to the rendered SVG.
+	// Warp the icon in a span we control so the rotation class updates
+	// reactively when `stopDirection` changes. The FontAwesome component 
+	// only reads its `class` prop during initialization, so later changes
+	// aren't reflected on the rendered SVG.
 	let rotationClass = $derived(ROTATION_CLASS_BY_DIRECTION[stopDirection] ?? 'hidden');
 </script>
 

--- a/src/components/controls/CompassArrow.svelte
+++ b/src/components/controls/CompassArrow.svelte
@@ -32,8 +32,8 @@
 		NW: 'rotate-225'
 	};
 
-	// Warp the icon in a span we control so the rotation class updates
-	// reactively when `stopDirection` changes. The FontAwesome component 
+	// Wrap the icon in a span we control so the rotation class updates
+	// reactively when `stopDirection` changes. The FontAwesome component
 	// only reads its `class` prop during initialization, so later changes
 	// aren't reflected on the rendered SVG.
 	let rotationClass = $derived(ROTATION_CLASS_BY_DIRECTION[stopDirection] ?? 'hidden');

--- a/src/components/controls/__tests__/CompassArrow.test.js
+++ b/src/components/controls/__tests__/CompassArrow.test.js
@@ -41,7 +41,7 @@ describe('CompassArrow', () => {
 		expect(span).toHaveClass('hidden');
 	});
 
-	// Regression: verifies the rotation class is applied to the wrapper 
+	// Regression: verifies the rotation class is applied to the wrapper
 	// span we control and updates reactively when `stopDirection` changes,
 	// preventing stale icon rotation in `StopPageHeader`.
 	test('updates the rotation class when stopDirection changes', async () => {

--- a/src/components/controls/__tests__/CompassArrow.test.js
+++ b/src/components/controls/__tests__/CompassArrow.test.js
@@ -41,10 +41,9 @@ describe('CompassArrow', () => {
 		expect(span).toHaveClass('hidden');
 	});
 
-	// Regression: prior to wrapping the icon in a span we control, the
-	// rotation class could become stale after `stopDirection` updated
-	// (icon visible but pointing in the wrong direction on the Route
-	// Schedules tab once the async stop data resolved).
+	// Regression: verifies the rotation class is applied to the wrapper 
+	// span we control and updates reactively when `stopDirection` changes,
+	// preventing stale icon rotation in `StopPageHeader`.
 	test('updates the rotation class when stopDirection changes', async () => {
 		const { container, rerender } = render(CompassArrow, {
 			props: { stopDirection: '' }


### PR DESCRIPTION
### Description 
- Clarify the regression test comment to describe what it actually verifies.
- Reference `StopPageHeader` instead of the "Route Schedules" UI label.
- Update the `CompassArrow` rationale comment to explain the actual `FontAwesome` class reactivity behavior.

Closes #499.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how the compass arrow’s rotation updates when the stop direction changes, helping explain the expected behavior.
* **Tests**
  * Improved regression test descriptions to clearly document reactive rotation updates and wrapper-based styling, without changing test logic or assertions. These updates improve maintainability and make the intended compass behavior easier to understand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->