### PR TITLE
feat: surface route load and polyline decode failures via toast notifications

### DIFF
--- a/src/components/MapExperience.svelte
+++ b/src/components/MapExperience.svelte
@@ -28,6 +28,7 @@
 	import SurveyLauncher from '$components/surveys/SurveyLauncher.svelte';
 	import { parseInitialCoordinates, cleanUrlParams } from '$lib/urlParams';
 	import { hasTripParams } from '$lib/urlState';
+	import { notifications } from '$stores/notificationStore';
 	import { env } from '$env/dynamic/public';
 	import TripOptionsModal from '$components/trip-planner/TripOptionsModal.svelte';
 	import { showTripOptionsModal } from '$stores/tripOptionsStore';
@@ -179,6 +180,10 @@
 				tripPlanError = null;
 			}
 			currentModal = null;
+			// The stop now owns the map, so any route/trip toast still on screen is
+			// stale — and tapping its Retry would tear down the stop's own markers
+			// and polylines. Unscoped: this supersedes whichever component raised it.
+			notifications.dismiss();
 
 			searchCollapsed = true;
 			if (browser && window.innerWidth >= 768) sheetSnap = 'full';

--- a/src/components/map/RouteMap.svelte
+++ b/src/components/map/RouteMap.svelte
@@ -3,6 +3,7 @@
 	import { clearVehicleMarkersMap, fetchAndUpdateVehicles } from '$lib/vehicleUtils';
 	import { mapContrastColor } from '$lib/colorUtils';
 	import { onMount, onDestroy } from 'svelte';
+	import { notifyRouteLoadFailed, notifyPartialRouteShape } from '$lib/routeNotifications';
 	let { mapProvider, tripId, currentSelectedStop = null } = $props();
 	let shapeId = null;
 	let tripData = null;
@@ -59,6 +60,9 @@
 			mapProvider.removeStopMarkers();
 
 			const tripResponse = await fetch(`/api/oba/trip-details/${tripId}`);
+			if (!tripResponse.ok) {
+				throw new Error(`Trip details request failed: ${tripResponse.status}`);
+			}
 			tripData = await tripResponse.json();
 
 			const tripReferences = tripData?.data?.references?.trips;
@@ -76,7 +80,10 @@
 				shapeData = await shapeResponse.json();
 				const shapePoints = shapeData?.data?.entry?.points;
 				if (shapePoints && isMounted) {
-					await mapProvider.createPolyline(shapePoints, { color: routeColor });
+					const polyline = await mapProvider.createPolyline(shapePoints, { color: routeColor });
+					if (!polyline) {
+						notifyPartialRouteShape();
+					}
 				}
 			}
 
@@ -122,6 +129,9 @@
 			}
 		} catch (error) {
 			console.error(`Error loading route data for trip ${tripId}:`, error);
+			if (isMounted) {
+				notifyRouteLoadFailed(() => loadRouteData());
+			}
 		}
 	}
 </script>

--- a/src/components/map/RouteMap.svelte
+++ b/src/components/map/RouteMap.svelte
@@ -3,13 +3,16 @@
 	import { clearVehicleMarkersMap, fetchAndUpdateVehicles } from '$lib/vehicleUtils';
 	import { mapContrastColor } from '$lib/colorUtils';
 	import { onMount, onDestroy } from 'svelte';
-	import { notifyRouteLoadFailed, notifyPartialRouteShape } from '$lib/routeNotifications';
+	import { notifyRouteLoadFailed, notifyRouteShapeFailed } from '$lib/routeNotifications';
 	import { notifications } from '$stores/notificationStore';
 	let { mapProvider, tripId, currentSelectedStop = null } = $props();
 	let shapeId = null;
 	let tripData = null;
 	let shapeData = null;
 	let isMounted = true;
+	// Id of the toast this instance raised, so teardown clears only its own and
+	// can't wipe one owned by another component.
+	let notificationId = null;
 
 	// used to clear interval api calls
 	let currentIntervalId = null;
@@ -20,11 +23,18 @@
 		await loadRouteDataPromise;
 	});
 
+	// A retry restarts the load, so it has to become the promise onDestroy
+	// awaits — otherwise teardown races an in-flight retry and the retry's
+	// camera moves land after the next view has taken over the map.
+	function retryLoadRouteData() {
+		loadRouteDataPromise = loadRouteData();
+	}
+
 	onDestroy(async () => {
 		isMounted = false;
-		// Retriable error toasts have no auto-dismiss; drop ours so a stale
-		// Retry can't clear map content owned by the next view.
-		notifications.dismiss();
+		// Drop our own toast: a stale Retry could otherwise clear map content
+		// owned by the next view.
+		notifications.dismiss(notificationId);
 		if (loadRouteDataPromise) {
 			await loadRouteDataPromise;
 		}
@@ -80,14 +90,34 @@
 			const routeColor = mapContrastColor(route?.color, { dark });
 
 			if (shapeId && isMounted) {
-				const shapeResponse = await fetch(`/api/oba/shape/${shapeId}`);
-				shapeData = await shapeResponse.json();
-				const shapePoints = shapeData?.data?.entry?.points;
-				if (shapePoints && isMounted) {
-					const polyline = await mapProvider.createPolyline(shapePoints, { color: routeColor });
-					if (!polyline) {
-						notifyPartialRouteShape();
+				// Scoped to its own try so a shape failure still leaves the stops and
+				// vehicles below to render — the trip is usable without the line.
+				let polyline = null;
+				try {
+					const shapeResponse = await fetch(`/api/oba/shape/${shapeId}`);
+					if (!shapeResponse.ok) {
+						throw new Error(`Shape request failed: ${shapeResponse.status}`);
 					}
+					shapeData = await shapeResponse.json();
+					const shapePoints = shapeData?.data?.entry?.points;
+					// createPolyline returns null when the encoded shape fails to decode.
+					polyline = shapePoints
+						? await mapProvider.createPolyline(shapePoints, { color: routeColor })
+						: null;
+				} catch (error) {
+					console.error(`Error drawing route shape for trip ${tripId}:`, error);
+				}
+
+				// Re-check after the awaits above: the user may have closed this view
+				// while the shape was in flight, in which case onDestroy has already
+				// run and a toast raised now would have no owner to dismiss it.
+				if (!isMounted) return;
+
+				// This component draws one polyline for the whole trip, so no polyline
+				// means no route line at all — a total failure worth a retry, not the
+				// subtler "a segment is missing" warning.
+				if (!polyline) {
+					notificationId = notifyRouteShapeFailed(retryLoadRouteData);
 				}
 			}
 
@@ -134,7 +164,7 @@
 		} catch (error) {
 			console.error(`Error loading route data for trip ${tripId}:`, error);
 			if (isMounted) {
-				notifyRouteLoadFailed(() => loadRouteData());
+				notificationId = notifyRouteLoadFailed(retryLoadRouteData);
 			}
 		}
 	}

--- a/src/components/map/RouteMap.svelte
+++ b/src/components/map/RouteMap.svelte
@@ -4,6 +4,7 @@
 	import { mapContrastColor } from '$lib/colorUtils';
 	import { onMount, onDestroy } from 'svelte';
 	import { notifyRouteLoadFailed, notifyPartialRouteShape } from '$lib/routeNotifications';
+	import { notifications } from '$stores/notificationStore';
 	let { mapProvider, tripId, currentSelectedStop = null } = $props();
 	let shapeId = null;
 	let tripData = null;
@@ -21,6 +22,9 @@
 
 	onDestroy(async () => {
 		isMounted = false;
+		// Retriable error toasts have no auto-dismiss; drop ours so a stale
+		// Retry can't clear map content owned by the next view.
+		notifications.dismiss();
 		if (loadRouteDataPromise) {
 			await loadRouteDataPromise;
 		}

--- a/src/components/notification/Toast.svelte
+++ b/src/components/notification/Toast.svelte
@@ -1,0 +1,59 @@
+<script>
+	import { notifications } from '$stores/notificationStore';
+	import { t } from 'svelte-i18n';
+
+	let notification = $state(null);
+
+	$effect(() => {
+		const unsubscribe = notifications.subscribe((value) => {
+			notification = value;
+		});
+		return unsubscribe;
+	});
+
+	function dismiss() {
+		notifications.dismiss();
+	}
+
+	function retry() {
+		notification?.onRetry?.();
+		notifications.dismiss();
+	}
+</script>
+
+{#if notification}
+	<div
+		class="toast pointer-events-auto fixed bottom-6 left-1/2 z-[9999] w-[min(24rem,calc(100vw-2rem))] -translate-x-1/2"
+		role={notification.variant === 'error' ? 'alert' : 'status'}
+		aria-live={notification.variant === 'error' ? 'assertive' : 'polite'}
+	>
+		<div
+			class="flex items-start gap-3 rounded-lg border px-4 py-3 shadow-lg backdrop-blur-sm
+				{notification.variant === 'error'
+				? 'border-red-200 bg-red-50/95 text-red-900 dark:border-red-800 dark:bg-red-950/95 dark:text-red-100'
+				: 'border-amber-200 bg-amber-50/95 text-amber-950 dark:border-amber-800 dark:bg-amber-950/95 dark:text-amber-100'}"
+		>
+			<p class="flex-1 text-sm leading-snug">
+				{notification.message}
+				{#if notification.onRetry}
+					{' '}
+					<button
+						type="button"
+						class="font-semibold underline hover:no-underline"
+						onclick={retry}
+					>
+						{$t('notifications.tap_to_retry')}
+					</button>
+				{/if}
+			</p>
+			<button
+				type="button"
+				class="shrink-0 text-sm opacity-70 hover:opacity-100"
+				onclick={dismiss}
+				aria-label={$t('notifications.dismiss')}
+			>
+				{$t('notifications.dismiss')}
+			</button>
+		</div>
+	</div>
+{/if}

--- a/src/components/notification/Toast.svelte
+++ b/src/components/notification/Toast.svelte
@@ -37,11 +37,7 @@
 				{notification.message}
 				{#if notification.onRetry}
 					{' '}
-					<button
-						type="button"
-						class="font-semibold underline hover:no-underline"
-						onclick={retry}
-					>
+					<button type="button" class="font-semibold underline hover:no-underline" onclick={retry}>
 						{$t('notifications.tap_to_retry')}
 					</button>
 				{/if}

--- a/src/components/notification/Toast.svelte
+++ b/src/components/notification/Toast.svelte
@@ -2,16 +2,10 @@
 	import { notifications } from '$stores/notificationStore';
 	import { t } from 'svelte-i18n';
 
-	let notification = $state(null);
-
-	$effect(() => {
-		const unsubscribe = notifications.subscribe((value) => {
-			notification = value;
-		});
-		return unsubscribe;
-	});
+	let notification = $derived($notifications);
 
 	function dismiss() {
+		// Unscoped: the user asked for this one to go away, whoever raised it.
 		notifications.dismiss();
 	}
 
@@ -19,16 +13,26 @@
 		notification?.onRetry?.();
 		notifications.dismiss();
 	}
+
+	function handleKeydown(event) {
+		if (event.key === 'Escape' && notification) {
+			dismiss();
+		}
+	}
 </script>
 
+<svelte:window onkeydown={handleKeydown} />
+
 {#if notification}
+	<!-- The wrapper is inert so it can't swallow taps aimed at the bottom sheet
+	     underneath; only the card itself is interactive. -->
 	<div
-		class="toast pointer-events-auto fixed bottom-6 left-1/2 z-[9999] w-[min(24rem,calc(100vw-2rem))] -translate-x-1/2"
+		class="toast pointer-events-none fixed bottom-6 left-1/2 z-[9999] w-[min(24rem,calc(100vw-2rem))] -translate-x-1/2"
 		role={notification.variant === 'error' ? 'alert' : 'status'}
 		aria-live={notification.variant === 'error' ? 'assertive' : 'polite'}
 	>
 		<div
-			class="flex items-start gap-3 rounded-lg border px-4 py-3 shadow-lg backdrop-blur-sm
+			class="pointer-events-auto flex items-start gap-3 rounded-lg border px-4 py-3 shadow-lg backdrop-blur-sm
 				{notification.variant === 'error'
 				? 'border-red-200 bg-red-50/95 text-red-900 dark:border-red-800 dark:bg-red-950/95 dark:text-red-100'
 				: 'border-amber-200 bg-amber-50/95 text-amber-950 dark:border-amber-800 dark:bg-amber-950/95 dark:text-amber-100'}"

--- a/src/components/notification/__tests__/Toast.test.js
+++ b/src/components/notification/__tests__/Toast.test.js
@@ -1,0 +1,108 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { get } from 'svelte/store';
+import Toast from '../Toast.svelte';
+import { notifications } from '$stores/notificationStore';
+
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
+
+vi.mock('svelte-i18n', () => {
+	const messages = {
+		'notifications.tap_to_retry': 'Tap to retry.',
+		'notifications.dismiss': 'Dismiss'
+	};
+
+	return {
+		t: {
+			subscribe: vi.fn((fn) => {
+				fn((key) => messages[key] ?? key);
+				return () => {};
+			})
+		}
+	};
+});
+
+describe('Toast', () => {
+	afterEach(() => {
+		notifications.dismiss();
+	});
+
+	test('renders nothing until a notification is shown', () => {
+		render(Toast);
+
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+		expect(screen.queryByRole('status')).not.toBeInTheDocument();
+	});
+
+	test('renders an error as an assertive alert', async () => {
+		render(Toast);
+
+		notifications.show({ message: "Couldn't load this route.", variant: 'error' });
+
+		const alert = await screen.findByRole('alert');
+		expect(alert).toHaveAttribute('aria-live', 'assertive');
+		expect(alert).toHaveTextContent("Couldn't load this route.");
+	});
+
+	test('renders a warning as a polite status', async () => {
+		render(Toast);
+
+		notifications.show({ message: 'Part of this route is missing.', variant: 'warning' });
+
+		const status = await screen.findByRole('status');
+		expect(status).toHaveAttribute('aria-live', 'polite');
+	});
+
+	test('shows the retry button only when the notification is retriable', async () => {
+		render(Toast);
+
+		notifications.show({ message: 'No retry here', variant: 'warning' });
+		await screen.findByRole('status');
+		expect(screen.queryByRole('button', { name: 'Tap to retry.' })).not.toBeInTheDocument();
+
+		notifications.dismiss();
+		notifications.show({ message: 'Retriable', variant: 'error', onRetry: vi.fn() });
+		expect(await screen.findByRole('button', { name: 'Tap to retry.' })).toBeInTheDocument();
+	});
+
+	test('retry invokes the callback and clears the toast', async () => {
+		const user = userEvent.setup();
+		const onRetry = vi.fn();
+		render(Toast);
+
+		notifications.show({ message: 'Load failed', variant: 'error', onRetry });
+		await user.click(await screen.findByRole('button', { name: 'Tap to retry.' }));
+
+		expect(onRetry).toHaveBeenCalledOnce();
+		await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+	});
+
+	test('the dismiss button clears the toast', async () => {
+		const user = userEvent.setup();
+		render(Toast);
+
+		notifications.show({ message: 'Load failed', variant: 'error', onRetry: vi.fn() });
+		await screen.findByRole('alert');
+
+		await user.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+		await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+		expect(get(notifications)).toBeNull();
+	});
+
+	test('Escape dismisses a persistent toast without needing the mouse', async () => {
+		const user = userEvent.setup();
+		render(Toast);
+
+		notifications.show({ message: 'Load failed', variant: 'error', onRetry: vi.fn() });
+		await screen.findByRole('alert');
+
+		await user.keyboard('{Escape}');
+
+		await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+		expect(get(notifications)).toBeNull();
+	});
+});

--- a/src/components/search/SearchPane.svelte
+++ b/src/components/search/SearchPane.svelte
@@ -43,6 +43,9 @@
 	// click took over (after one of its awaits) and bail instead of fighting the
 	// newer route for the camera, stop markers, and vehicle polling.
 	let routeLoadToken = 0;
+	// Id of the toast the current route load raised, so we only ever clear our
+	// own and never one owned by another component.
+	let notificationId = null;
 	let mapLoaded = $state(false);
 	let isSurveyAnswered = $state(false);
 	let activeTab = $state('stops');
@@ -113,9 +116,10 @@
 
 	async function handleRouteClick(route) {
 		const loadToken = ++routeLoadToken;
-		// Drop any prior retriable toast so a stale Retry for a previous route
+		// Drop our prior retriable toast so a stale Retry for a previous route
 		// can't wipe markers/polylines after the user has moved on.
-		notifications.dismiss();
+		notifications.dismiss(notificationId);
+		notificationId = null;
 		mapProvider.clearAllPolylines();
 		mapProvider.removeStopMarkers();
 		mapProvider.clearVehicleMarkers();
@@ -127,7 +131,7 @@
 
 			if (!response.ok) {
 				console.error(`Failed to fetch route data: ${response.status}`);
-				notifyRouteLoadFailed(() => handleRouteClick(route));
+				notificationId = notifyRouteLoadFailed(() => handleRouteClick(route));
 				return;
 			}
 
@@ -161,7 +165,7 @@
 			if (loadToken !== routeLoadToken) return;
 
 			if (segmentCount > 0 && polylines.length < segmentCount) {
-				notifyPartialRouteShape();
+				notificationId = notifyPartialRouteShape();
 			}
 
 			// Fit the view to the full route so it's always centered and visible
@@ -206,7 +210,7 @@
 		} catch (error) {
 			console.error('Error fetching route data:', error);
 			if (loadToken === routeLoadToken) {
-				notifyRouteLoadFailed(() => handleRouteClick(route));
+				notificationId = notifyRouteLoadFailed(() => handleRouteClick(route));
 			}
 		}
 	}
@@ -328,7 +332,7 @@
 	});
 
 	onDestroy(() => {
-		notifications.dismiss();
+		notifications.dismiss(notificationId);
 		if (unsubscribeMapLoaded) {
 			unsubscribeMapLoaded();
 		}

--- a/src/components/search/SearchPane.svelte
+++ b/src/components/search/SearchPane.svelte
@@ -17,6 +17,7 @@
 	import { browser } from '$app/environment';
 	import { page } from '$app/stores';
 	import { parseTripParams, hasTripParams } from '$lib/urlState';
+	import { notifyRouteLoadFailed, notifyPartialRouteShape } from '$lib/routeNotifications';
 
 	let {
 		handleRouteSelected,
@@ -122,6 +123,7 @@
 
 			if (!response.ok) {
 				console.error(`Failed to fetch route data: ${response.status}`);
+				notifyRouteLoadFailed(() => handleRouteClick(route));
 				return;
 			}
 
@@ -142,6 +144,7 @@
 			// Reset the collection so each route click rebuilds it from scratch
 			// rather than accumulating stale references from previous selections.
 			polylines = [];
+			const segmentCount = polylinesData?.length ?? 0;
 			for (const polylineData of polylinesData) {
 				const polyline = await mapProvider.createPolyline(polylineData.points);
 				if (loadToken !== routeLoadToken) return;
@@ -149,6 +152,12 @@
 				// provider); skip it so one bad segment degrades the route instead
 				// of leaving a null hole in the polylines array.
 				if (polyline) polylines.push(polyline);
+			}
+
+			if (loadToken !== routeLoadToken) return;
+
+			if (segmentCount > 0 && polylines.length < segmentCount) {
+				notifyPartialRouteShape();
 			}
 
 			// Fit the view to the full route so it's always centered and visible
@@ -192,6 +201,9 @@
 			handleRouteSelected(routeData);
 		} catch (error) {
 			console.error('Error fetching route data:', error);
+			if (loadToken === routeLoadToken) {
+				notifyRouteLoadFailed(() => handleRouteClick(route));
+			}
 		}
 	}
 

--- a/src/components/search/SearchPane.svelte
+++ b/src/components/search/SearchPane.svelte
@@ -18,6 +18,7 @@
 	import { page } from '$app/stores';
 	import { parseTripParams, hasTripParams } from '$lib/urlState';
 	import { notifyRouteLoadFailed, notifyPartialRouteShape } from '$lib/routeNotifications';
+	import { notifications } from '$stores/notificationStore';
 
 	let {
 		handleRouteSelected,
@@ -112,6 +113,9 @@
 
 	async function handleRouteClick(route) {
 		const loadToken = ++routeLoadToken;
+		// Drop any prior retriable toast so a stale Retry for a previous route
+		// can't wipe markers/polylines after the user has moved on.
+		notifications.dismiss();
 		mapProvider.clearAllPolylines();
 		mapProvider.removeStopMarkers();
 		mapProvider.clearVehicleMarkers();
@@ -324,6 +328,7 @@
 	});
 
 	onDestroy(() => {
+		notifications.dismiss();
 		if (unsubscribeMapLoaded) {
 			unsubscribeMapLoaded();
 		}

--- a/src/components/trip-planner/TripPlanModal.svelte
+++ b/src/components/trip-planner/TripPlanModal.svelte
@@ -9,6 +9,7 @@
 	import { onDestroy, onMount } from 'svelte';
 	import { t } from 'svelte-i18n';
 	import { browser } from '$app/environment';
+	import { notifyPartialRouteShape } from '$lib/routeNotifications';
 
 	/**
 	 * @typedef {Object} Props
@@ -79,13 +80,25 @@
 			return;
 		}
 
+		let drawnCount = 0;
+		let legCount = 0;
+
 		for (const leg of itineraries[activeTab].legs) {
-			const shape = leg.legGeometry.points;
+			const shape = leg.legGeometry?.points;
+			if (!shape) continue;
+			legCount++;
 			const style = getLegPolylineStyle(leg);
 			// Await: the Google provider's createPolyline is async and returns
 			// null on decode failure — skip nulls instead of tracking a Promise.
 			const polyline = await mapProvider.createPolyline(shape, style);
-			if (polyline) currPolylines.push(polyline);
+			if (polyline) {
+				currPolylines.push(polyline);
+				drawnCount++;
+			}
+		}
+
+		if (legCount > 0 && drawnCount < legCount) {
+			notifyPartialRouteShape();
 		}
 	}
 

--- a/src/components/trip-planner/TripPlanModal.svelte
+++ b/src/components/trip-planner/TripPlanModal.svelte
@@ -36,6 +36,8 @@
 	let activeTab = $state(0);
 	let itineraryTabsContainer = $state(null);
 	let prevItinerariesRef = $state(null);
+	// Id of the toast this modal raised, so closing it clears only its own.
+	let notificationId = null;
 
 	function toggleSteps(index) {
 		expandedSteps[index] = !expandedSteps[index];
@@ -85,9 +87,12 @@
 		let legCount = 0;
 
 		for (const leg of itineraries[activeTab].legs) {
+			// Counted before the geometry check: a leg with no geometry at all is
+			// just as invisible on the map as one that fails to decode, so it has
+			// to stay in the denominator or the gap goes unreported.
+			legCount++;
 			const shape = leg.legGeometry?.points;
 			if (!shape) continue;
-			legCount++;
 			const style = getLegPolylineStyle(leg);
 			// Await: the Google provider's createPolyline is async and returns
 			// null on decode failure — skip nulls instead of tracking a Promise.
@@ -99,7 +104,7 @@
 		}
 
 		if (legCount > 0 && drawnCount < legCount) {
-			notifyPartialRouteShape();
+			notificationId = notifyPartialRouteShape();
 		}
 	}
 
@@ -138,9 +143,9 @@
 	});
 
 	onDestroy(() => {
-		// Partial-shape warnings auto-dismiss, but clear immediately on close so
-		// they don't linger over the next view.
-		notifications.dismiss();
+		// Partial-shape warnings auto-dismiss, but clear ours immediately on close
+		// so it doesn't linger over the next view.
+		notifications.dismiss(notificationId);
 		if (currPolylines.length > 0) {
 			currPolylines.forEach(async (polyline) => {
 				mapProvider.removePolyline(await polyline);

--- a/src/components/trip-planner/TripPlanModal.svelte
+++ b/src/components/trip-planner/TripPlanModal.svelte
@@ -10,6 +10,7 @@
 	import { t } from 'svelte-i18n';
 	import { browser } from '$app/environment';
 	import { notifyPartialRouteShape } from '$lib/routeNotifications';
+	import { notifications } from '$stores/notificationStore';
 
 	/**
 	 * @typedef {Object} Props
@@ -137,6 +138,9 @@
 	});
 
 	onDestroy(() => {
+		// Partial-shape warnings auto-dismiss, but clear immediately on close so
+		// they don't linger over the next view.
+		notifications.dismiss();
 		if (currPolylines.length > 0) {
 			currPolylines.forEach(async (polyline) => {
 				mapProvider.removePolyline(await polyline);

--- a/src/lib/__tests__/routeNotifications.test.js
+++ b/src/lib/__tests__/routeNotifications.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { notifications } from '$stores/notificationStore';
+import { notifyRouteLoadFailed, notifyPartialRouteShape } from '../routeNotifications';
+
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
+
+vi.mock('svelte-i18n', () => ({
+	t: {
+		subscribe: vi.fn((fn) => {
+			fn((key) => {
+				const messages = {
+					'notifications.route_load_failed': "Couldn't load this route.",
+					'notifications.tap_to_retry': 'Tap to retry.',
+					'notifications.route_shape_partial':
+						"Part of this route couldn't be drawn. The map may be missing a segment."
+				};
+				return messages[key] ?? key;
+			});
+			return () => {};
+		})
+	}
+}));
+
+describe('routeNotifications', () => {
+	beforeEach(() => {
+		notifications.dismiss();
+	});
+
+	afterEach(() => {
+		notifications.dismiss();
+	});
+
+	it('notifyRouteLoadFailed shows an error with retry callback', () => {
+		const onRetry = vi.fn();
+		notifyRouteLoadFailed(onRetry);
+
+		const active = get(notifications);
+		expect(active?.variant).toBe('error');
+		expect(active?.message).toContain("Couldn't load this route");
+		expect(active?.onRetry).toBe(onRetry);
+	});
+
+	it('notifyPartialRouteShape shows a warning', () => {
+		notifyPartialRouteShape();
+
+		const active = get(notifications);
+		expect(active?.variant).toBe('warning');
+		expect(active?.message).toContain("couldn't be drawn");
+		expect(active?.onRetry).toBeNull();
+	});
+});

--- a/src/lib/__tests__/routeNotifications.test.js
+++ b/src/lib/__tests__/routeNotifications.test.js
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { get } from 'svelte/store';
 import { notifications } from '$stores/notificationStore';
-import { notifyRouteLoadFailed, notifyPartialRouteShape } from '../routeNotifications';
+import {
+	notifyRouteLoadFailed,
+	notifyRouteShapeFailed,
+	notifyPartialRouteShape
+} from '../routeNotifications';
 
 vi.mock('$app/environment', () => ({
 	browser: true
@@ -13,6 +17,7 @@ vi.mock('svelte-i18n', () => ({
 			fn((key) => {
 				const messages = {
 					'notifications.route_load_failed': "Couldn't load this route.",
+					'notifications.route_shape_failed': "Couldn't draw this route on the map.",
 					'notifications.tap_to_retry': 'Tap to retry.',
 					'notifications.route_shape_partial':
 						"Part of this route couldn't be drawn. The map may be missing a segment."
@@ -43,6 +48,16 @@ describe('routeNotifications', () => {
 		expect(active?.onRetry).toBe(onRetry);
 	});
 
+	it('notifyRouteShapeFailed shows a retriable error distinct from a partial shape', () => {
+		const onRetry = vi.fn();
+		notifyRouteShapeFailed(onRetry);
+
+		const active = get(notifications);
+		expect(active?.variant).toBe('error');
+		expect(active?.message).toContain("Couldn't draw this route");
+		expect(active?.onRetry).toBe(onRetry);
+	});
+
 	it('notifyPartialRouteShape shows a warning', () => {
 		notifyPartialRouteShape();
 
@@ -50,5 +65,13 @@ describe('routeNotifications', () => {
 		expect(active?.variant).toBe('warning');
 		expect(active?.message).toContain("couldn't be drawn");
 		expect(active?.onRetry).toBeNull();
+	});
+
+	it('each notify helper returns an id usable for a scoped dismiss', () => {
+		const id = notifyPartialRouteShape();
+		expect(id).toBe(get(notifications).id);
+
+		notifications.dismiss(id);
+		expect(get(notifications)).toBeNull();
 	});
 });

--- a/src/lib/routeNotifications.js
+++ b/src/lib/routeNotifications.js
@@ -1,0 +1,25 @@
+import { get } from 'svelte/store';
+import { t } from 'svelte-i18n';
+import { notifications } from '$stores/notificationStore';
+
+/**
+ * Surfaces a total route-load failure with an optional retry action.
+ *
+ * @param {() => void} [onRetry]
+ */
+export function notifyRouteLoadFailed(onRetry) {
+	notifications.show({
+		message: get(t)('notifications.route_load_failed'),
+		variant: 'error',
+		onRetry: onRetry ?? null
+	});
+}
+
+/** Surfaces a partial route shape decode (some segments missing on the map). */
+export function notifyPartialRouteShape() {
+	notifications.show({
+		message: get(t)('notifications.route_shape_partial'),
+		variant: 'warning',
+		duration: 6000
+	});
+}

--- a/src/lib/routeNotifications.js
+++ b/src/lib/routeNotifications.js
@@ -6,18 +6,38 @@ import { notifications } from '$stores/notificationStore';
  * Surfaces a total route-load failure with an optional retry action.
  *
  * @param {() => void} [onRetry]
+ * @returns {number | null} the notification's id, for a scoped dismiss
  */
 export function notifyRouteLoadFailed(onRetry) {
-	notifications.show({
+	return notifications.show({
 		message: get(t)('notifications.route_load_failed'),
 		variant: 'error',
 		onRetry: onRetry ?? null
 	});
 }
 
-/** Surfaces a partial route shape decode (some segments missing on the map). */
+/**
+ * Surfaces a route whose shape couldn't be drawn at all — the stops and
+ * vehicles are on the map but the route line is missing entirely.
+ *
+ * @param {() => void} [onRetry]
+ * @returns {number | null} the notification's id, for a scoped dismiss
+ */
+export function notifyRouteShapeFailed(onRetry) {
+	return notifications.show({
+		message: get(t)('notifications.route_shape_failed'),
+		variant: 'error',
+		onRetry: onRetry ?? null
+	});
+}
+
+/**
+ * Surfaces a partial route shape decode (some segments missing on the map).
+ *
+ * @returns {number | null} the notification's id, for a scoped dismiss
+ */
 export function notifyPartialRouteShape() {
-	notifications.show({
+	return notifications.show({
 		message: get(t)('notifications.route_shape_partial'),
 		variant: 'warning',
 		duration: 6000

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -137,6 +137,12 @@
 	"routes": "Routes",
 	"route": "route",
 	"route_modal_title": "Route {name}",
+	"notifications": {
+		"route_load_failed": "Couldn't load this route.",
+		"route_shape_partial": "Part of this route couldn't be drawn. The map may be missing a segment.",
+		"tap_to_retry": "Tap to retry.",
+		"dismiss": "Dismiss"
+	},
 	"loading": "Loading",
 	"arrives": "arrives",
 	"NA": "N/A",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -139,6 +139,7 @@
 	"route_modal_title": "Route {name}",
 	"notifications": {
 		"route_load_failed": "Couldn't load this route.",
+		"route_shape_failed": "Couldn't draw this route on the map.",
 		"route_shape_partial": "Part of this route couldn't be drawn. The map may be missing a segment.",
 		"tap_to_retry": "Tap to retry.",
 		"dismiss": "Dismiss"

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,6 +11,7 @@
 	import analytics from '$lib/Insights';
 	import { initSystemTheme } from '$lib/systemTheme.js';
 	import { env } from '$env/dynamic/public';
+	import Toast from '$components/notification/Toast.svelte';
 
 	const faviconUrl = env.PUBLIC_FAVICON_URL || '/favicon.png';
 	const appleTouchIconUrl = env.PUBLIC_APPLE_TOUCH_ICON_URL || '/apple-touch-icon.png';
@@ -56,4 +57,5 @@
 	<main id="main-content" tabindex="-1" class="relative flex-1 overflow-hidden dark:bg-black">
 		{@render children?.()}
 	</main>
+	<Toast />
 </div>

--- a/src/stores/__tests__/notificationStore.test.js
+++ b/src/stores/__tests__/notificationStore.test.js
@@ -21,11 +21,17 @@ describe('notificationStore', () => {
 		notifications.show({ message: 'Something failed', variant: 'error' });
 
 		expect(get(notifications)).toEqual({
-			id: expect.any(String),
+			id: expect.any(Number),
 			message: 'Something failed',
 			variant: 'error',
 			onRetry: null
 		});
+	});
+
+	it('returns the id of the notification it showed', () => {
+		const id = notifications.show({ message: 'Load failed', variant: 'error' });
+
+		expect(id).toBe(get(notifications).id);
 	});
 
 	it('auto-dismisses warnings after the default duration', () => {
@@ -36,17 +42,64 @@ describe('notificationStore', () => {
 		expect(get(notifications)).toBeNull();
 	});
 
-	it('keeps retriable errors visible until dismissed', () => {
+	it('keeps retriable errors visible long enough to act on, then expires them', () => {
 		const onRetry = vi.fn();
 		notifications.show({ message: 'Load failed', variant: 'error', onRetry });
 
-		vi.advanceTimersByTime(30000);
+		// Well past the warning duration, so the retry affordance is still there...
+		vi.advanceTimersByTime(19000);
 		expect(get(notifications)).not.toBeNull();
+
+		// ...but it doesn't sit on top of the bottom-anchored UI forever.
+		vi.advanceTimersByTime(1000);
+		expect(get(notifications)).toBeNull();
 	});
 
 	it('dismiss clears the active notification', () => {
 		notifications.show({ message: 'Load failed', variant: 'error' });
 		notifications.dismiss();
 		expect(get(notifications)).toBeNull();
+	});
+
+	it('dismiss with an id only clears that notification', () => {
+		const stale = notifications.show({ message: 'First', variant: 'error' });
+		notifications.dismiss();
+		const current = notifications.show({ message: 'Second', variant: 'error' });
+
+		notifications.dismiss(stale);
+		expect(get(notifications)?.message).toBe('Second');
+
+		notifications.dismiss(current);
+		expect(get(notifications)).toBeNull();
+	});
+
+	it('dismiss with a null id (nothing was ever shown) clears nothing', () => {
+		notifications.show({ message: 'Someone else caused this', variant: 'error' });
+
+		notifications.dismiss(null);
+
+		expect(get(notifications)?.message).toBe('Someone else caused this');
+	});
+
+	it('does not let a warning clobber a retriable error', () => {
+		const onRetry = vi.fn();
+		notifications.show({ message: 'Load failed', variant: 'error', onRetry });
+
+		const suppressed = notifications.show({ message: 'Partial shape', variant: 'warning' });
+
+		expect(suppressed).toBeNull();
+		expect(get(notifications)?.message).toBe('Load failed');
+
+		// The retry affordance still works, and its timer wasn't reset by the
+		// suppressed call.
+		get(notifications).onRetry();
+		expect(onRetry).toHaveBeenCalledOnce();
+	});
+
+	it('lets a new retriable error replace an existing one', () => {
+		notifications.show({ message: 'First route failed', variant: 'error', onRetry: vi.fn() });
+		notifications.show({ message: 'Second route failed', variant: 'error', onRetry: vi.fn() });
+
+		expect(get(notifications)?.message).toBe('Second route failed');
 	});
 });

--- a/src/stores/__tests__/notificationStore.test.js
+++ b/src/stores/__tests__/notificationStore.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { notifications } from '../notificationStore';
+
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
+
+describe('notificationStore', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		notifications.dismiss();
+	});
+
+	afterEach(() => {
+		notifications.dismiss();
+		vi.useRealTimers();
+	});
+
+	it('shows a notification with message and variant', () => {
+		notifications.show({ message: 'Something failed', variant: 'error' });
+
+		expect(get(notifications)).toEqual({
+			id: expect.any(String),
+			message: 'Something failed',
+			variant: 'error',
+			onRetry: null
+		});
+	});
+
+	it('auto-dismisses warnings after the default duration', () => {
+		notifications.show({ message: 'Partial shape', variant: 'warning' });
+
+		expect(get(notifications)).not.toBeNull();
+		vi.advanceTimersByTime(8000);
+		expect(get(notifications)).toBeNull();
+	});
+
+	it('keeps retriable errors visible until dismissed', () => {
+		const onRetry = vi.fn();
+		notifications.show({ message: 'Load failed', variant: 'error', onRetry });
+
+		vi.advanceTimersByTime(30000);
+		expect(get(notifications)).not.toBeNull();
+	});
+
+	it('dismiss clears the active notification', () => {
+		notifications.show({ message: 'Load failed', variant: 'error' });
+		notifications.dismiss();
+		expect(get(notifications)).toBeNull();
+	});
+});

--- a/src/stores/notificationStore.js
+++ b/src/stores/notificationStore.js
@@ -1,23 +1,28 @@
-import { writable } from 'svelte/store';
+import { writable, get } from 'svelte/store';
 import { browser } from '$app/environment';
 
 /** @typedef {'error' | 'warning'} NotificationVariant */
 
 /**
  * @typedef {Object} Notification
- * @property {string} id
+ * @property {number} id
  * @property {string} message
  * @property {NotificationVariant} variant
  * @property {(() => void) | null} onRetry
  */
 
 const DEFAULT_AUTO_DISMISS_MS = 8000;
+// Retriable errors stay up long enough to be read and acted on, but still
+// expire: the toast is bottom-anchored and interactive, so a permanent one
+// would sit on top of the stop sheet / trip planner controls indefinitely.
+const RETRIABLE_AUTO_DISMISS_MS = 20000;
 
 function createNotificationStore() {
 	/** @type {import('svelte/store').Writable<Notification | null>} */
 	const { subscribe, set } = writable(null);
 
 	let autoDismissTimer = null;
+	let nextId = 0;
 
 	function clearAutoDismiss() {
 		if (autoDismissTimer !== null) {
@@ -30,22 +35,32 @@ function createNotificationStore() {
 		subscribe,
 
 		/**
-		 * Show a toast notification. Retriable errors omit auto-dismiss so the
-		 * user can tap Retry; warnings auto-dismiss after a few seconds.
+		 * Show a toast notification and return its id, or null if nothing was
+		 * shown. Pass the id back to `dismiss` so a component only ever clears
+		 * the notification it raised.
+		 *
+		 * A retriable error outranks a plain one: while a retry affordance is on
+		 * screen an incoming non-retriable notification is dropped rather than
+		 * clobbering the slot, so a background warning can't destroy the only
+		 * way the user has to recover from a failed load.
 		 *
 		 * @param {Object} options
 		 * @param {string} options.message
 		 * @param {NotificationVariant} [options.variant]
 		 * @param {(() => void) | null} [options.onRetry]
 		 * @param {number | null} [options.duration] - Ms until auto-dismiss; null keeps it open
+		 * @returns {number | null} the new notification's id
 		 */
 		show: ({ message, variant = 'error', onRetry = null, duration = undefined }) => {
-			if (!browser) return;
+			if (!browser) return null;
+
+			const current = get({ subscribe });
+			if (current?.onRetry && !onRetry) return null;
 
 			clearAutoDismiss();
 
 			const notification = {
-				id: crypto.randomUUID(),
+				id: ++nextId,
 				message,
 				variant,
 				onRetry
@@ -54,7 +69,11 @@ function createNotificationStore() {
 			set(notification);
 
 			const dismissAfter =
-				duration !== undefined ? duration : onRetry ? null : DEFAULT_AUTO_DISMISS_MS;
+				duration !== undefined
+					? duration
+					: onRetry
+						? RETRIABLE_AUTO_DISMISS_MS
+						: DEFAULT_AUTO_DISMISS_MS;
 
 			if (dismissAfter !== null) {
 				autoDismissTimer = setTimeout(() => {
@@ -62,9 +81,22 @@ function createNotificationStore() {
 					set(null);
 				}, dismissAfter);
 			}
+
+			return notification.id;
 		},
 
-		dismiss: () => {
+		/**
+		 * Clear the current notification. Pass the id returned by `show` to clear
+		 * it only if it's still the one on screen; omit the id to clear whatever
+		 * is showing (user-initiated dismissal).
+		 *
+		 * @param {number | null} [id]
+		 */
+		dismiss: (id = undefined) => {
+			if (id !== undefined) {
+				const current = get({ subscribe });
+				if (!current || current.id !== id) return;
+			}
 			clearAutoDismiss();
 			set(null);
 		}

--- a/src/stores/notificationStore.js
+++ b/src/stores/notificationStore.js
@@ -1,0 +1,74 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+/** @typedef {'error' | 'warning'} NotificationVariant */
+
+/**
+ * @typedef {Object} Notification
+ * @property {string} id
+ * @property {string} message
+ * @property {NotificationVariant} variant
+ * @property {(() => void) | null} onRetry
+ */
+
+const DEFAULT_AUTO_DISMISS_MS = 8000;
+
+function createNotificationStore() {
+	/** @type {import('svelte/store').Writable<Notification | null>} */
+	const { subscribe, set } = writable(null);
+
+	let autoDismissTimer = null;
+
+	function clearAutoDismiss() {
+		if (autoDismissTimer !== null) {
+			clearTimeout(autoDismissTimer);
+			autoDismissTimer = null;
+		}
+	}
+
+	return {
+		subscribe,
+
+		/**
+		 * Show a toast notification. Retriable errors omit auto-dismiss so the
+		 * user can tap Retry; warnings auto-dismiss after a few seconds.
+		 *
+		 * @param {Object} options
+		 * @param {string} options.message
+		 * @param {NotificationVariant} [options.variant]
+		 * @param {(() => void) | null} [options.onRetry]
+		 * @param {number | null} [options.duration] - Ms until auto-dismiss; null keeps it open
+		 */
+		show: ({ message, variant = 'error', onRetry = null, duration = undefined }) => {
+			if (!browser) return;
+
+			clearAutoDismiss();
+
+			const notification = {
+				id: crypto.randomUUID(),
+				message,
+				variant,
+				onRetry
+			};
+
+			set(notification);
+
+			const dismissAfter =
+				duration !== undefined ? duration : onRetry ? null : DEFAULT_AUTO_DISMISS_MS;
+
+			if (dismissAfter !== null) {
+				autoDismissTimer = setTimeout(() => {
+					autoDismissTimer = null;
+					set(null);
+				}, dismissAfter);
+			}
+		},
+
+		dismiss: () => {
+			clearAutoDismiss();
+			set(null);
+		}
+	};
+}
+
+export const notifications = createNotificationStore();


### PR DESCRIPTION
Fixes #530 

Introduces a lightweight toast notification primitive and surfaces route load/polyline decode failures that were previously console-only.

- Total failures: red toast with Retry (SearchPane route click, RouteMap trip overlay)
- Partial decode failures: amber warning when some shape segments fail to draw
  (SearchPane, RouteMap, TripPlanModal)

Screenshot:
<img width="1322" height="733" alt="Screenshot 2026-07-05 at 9 33 46 PM" src="https://github.com/user-attachments/assets/c59753ba-c51d-4464-9b66-bfa2dc13154e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global toast notifications for route loading and rendering issues, including tap-to-retry (when available) and dismiss controls.
  * Introduced route notification helpers and new localized notification text.
* **Bug Fixes**
  * Route and trip-detail loading now surface failures to users (with retry) instead of only logging.
  * Users are warned when only part of the route shape/geometry can be drawn.
  * Notifications are cleared on teardown to prevent stale messages across navigation/retries.
* **Tests**
  * Added coverage for the notification store and route notification helpers, including timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->