### PR TITLE
fix(a11y): use brand-accent for resting CTA contrast

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -56,9 +56,9 @@
 	}
 
 	.itinerary-tab--active {
-		@apply bg-brand text-brand-foreground shadow-md;
-		@apply hover:bg-brand;
-		@apply dark:bg-brand dark:text-brand-foreground dark:hover:bg-brand;
+		@apply bg-brand-accent text-white shadow-md;
+		@apply hover:bg-brand-accent-dark;
+		@apply dark:bg-brand-accent dark:text-white dark:hover:bg-brand-accent-dark;
 	}
 
 	.close-button {
@@ -71,7 +71,7 @@
 	}
 
 	.button--primary {
-		@apply rounded-md bg-brand-accent px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-accent;
+		@apply rounded-md bg-brand-accent px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-accent-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-accent;
 	}
 
 	.rtl {

--- a/src/components/map/ContextMenuPopup.svelte
+++ b/src/components/map/ContextMenuPopup.svelte
@@ -8,14 +8,14 @@
 	<div class="flex flex-col gap-1.5">
 		<button
 			type="button"
-			class="rounded-md bg-brand px-3 py-1.5 text-sm font-medium text-brand-foreground shadow-sm transition-colors hover:bg-brand-accent"
+			class="rounded-md bg-brand-accent px-3 py-1.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-brand-accent-dark"
 			onclick={onStartHere}
 		>
 			{$t('context-menu.start_here')}
 		</button>
 		<button
 			type="button"
-			class="rounded-md bg-brand px-3 py-1.5 text-sm font-medium text-brand-foreground shadow-sm transition-colors hover:bg-brand-accent"
+			class="rounded-md bg-brand-accent px-3 py-1.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-brand-accent-dark"
 			onclick={onEndHere}
 		>
 			{$t('context-menu.end_here')}

--- a/src/components/map/PopupContent.svelte
+++ b/src/components/map/PopupContent.svelte
@@ -16,7 +16,7 @@
 	<div class="mt-auto flex justify-center">
 		<button
 			type="button"
-			class="inline-block rounded-lg border border-brand bg-brand px-3 py-1 text-sm font-medium text-white shadow-md transition duration-200 ease-in-out hover:bg-brand-accent"
+			class="inline-block rounded-lg border border-brand-accent bg-brand-accent px-3 py-1 text-sm font-medium text-white shadow-md transition duration-200 ease-in-out hover:bg-brand-accent-dark"
 			onclick={handleStopMarkerSelect}
 		>
 			{$t('view_stop_information')}

--- a/src/components/navigation/AlertsModal.svelte
+++ b/src/components/navigation/AlertsModal.svelte
@@ -46,7 +46,7 @@
 				{$t('alert.close')}
 			</Button>
 			<Button
-				class="bg-brand-accent text-white hover:bg-brand-accent dark:bg-brand dark:hover:bg-brand-accent"
+				class="bg-brand-accent text-white hover:bg-brand-accent-dark dark:bg-brand-accent dark:text-white dark:hover:bg-brand-accent-dark"
 				on:click={() => window.open(getUrlTranslation(), '_blank')}
 			>
 				{$t('alert.more_info')}

--- a/src/components/navigation/__tests__/AlertsModal.test.js
+++ b/src/components/navigation/__tests__/AlertsModal.test.js
@@ -300,8 +300,16 @@ describe('AlertsModal', () => {
 		});
 
 		const moreInfoButton = screen.getByRole('button', { name: 'More Info' });
-		expect(moreInfoButton).toHaveClass('bg-brand-accent', 'text-white', 'hover:bg-brand-accent');
-		expect(moreInfoButton).toHaveClass('dark:bg-brand', 'dark:hover:bg-brand-accent');
+		expect(moreInfoButton).toHaveClass(
+			'bg-brand-accent',
+			'text-white',
+			'hover:bg-brand-accent-dark'
+		);
+		expect(moreInfoButton).toHaveClass(
+			'dark:bg-brand-accent',
+			'dark:text-white',
+			'dark:hover:bg-brand-accent-dark'
+		);
 	});
 
 	test('modal description has correct styling', () => {

--- a/src/components/trip-planner/TripPlan.svelte
+++ b/src/components/trip-planner/TripPlan.svelte
@@ -429,12 +429,12 @@
 		<div class="flex-1"></div>
 		<button
 			onclick={planTrip}
-			class="flex items-center justify-center rounded-md bg-brand px-4 py-2 text-brand-foreground shadow-md transition-colors hover:bg-brand-accent disabled:cursor-not-allowed disabled:bg-gray-300 dark:bg-green-800 dark:hover:bg-green-900 disabled:dark:bg-gray-700/50 disabled:dark:text-gray-400"
+			class="flex items-center justify-center rounded-md bg-brand-accent px-4 py-2 text-white shadow-md transition-colors hover:bg-brand-accent-dark disabled:cursor-not-allowed disabled:bg-gray-300 dark:bg-green-800 dark:hover:bg-green-900 disabled:dark:bg-gray-700/50 disabled:dark:text-gray-400"
 			disabled={!selectedFrom || !selectedTo}
 		>
 			{#if loading}
 				<svg
-					class="mr-2 h-5 w-5 animate-spin text-brand-foreground disabled:dark:text-gray-400"
+					class="mr-2 h-5 w-5 animate-spin text-white disabled:dark:text-gray-400"
 					xmlns="http://www.w3.org/2000/svg"
 					fill="none"
 					viewBox="0 0 24 24"


### PR DESCRIPTION
Fixes #528

Several brand CTAs rested on `bg-brand` (#78aa36) with white text, which is only 2.76:1 contrast (below WCAG 2.1 AA 4.5:1 for normal text). PR #513 fixed hover on stop-page CTAs; this applies the same resting-state pattern everywhere else that had the inverse problem.

Resting state is now `bg-brand-accent` + `text-white`; hover is `hover:bg-brand-accent-dark` (token from #513).

## Changes

- **ContextMenuPopup** - Start here / End here buttons
- **PopupContent** - View stop information button on route stop popups
- **TripPlan** - Plan your trip button (and loading spinner color)
- **AlertsModal** - More info button dark mode (was still `dark:bg-brand`)
- **app.css** - Active itinerary tab and `.button--primary` hover aligned to the same pattern

## Tests
All tests passed. And I have manually verified all contrast checks for the buttons using the AxeTools extension (premium version).