### PR TITLE
Make selected-vehicle glow color configurable via PUBLIC_COLOR_VEHICLE_HIGHLIGHT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,9 @@ COLOR_SURFACE="#ffffff"
 # Panel text
 COLOR_SURFACE_FOREGROUND="#000000"
 
+# Glow color for the selected/highlighted vehicle marker
+PUBLIC_COLOR_VEHICLE_HIGHLIGHT="#FACC15"
+
 # Analytics
 # PUBLIC_ANALYTICS_PROVIDER selects the backend: "none" (disabled), "plausible", or "umami".
 # This replaces the old PUBLIC_ANALYTICS_ENABLED boolean — set provider to "none" to disable.

--- a/env-schema.json
+++ b/env-schema.json
@@ -171,6 +171,11 @@
 		"type": "color",
 		"description": "Panel text color (hex)"
 	},
+	"PUBLIC_COLOR_VEHICLE_HIGHLIGHT": {
+		"required": false,
+		"type": "color",
+		"description": "Glow color for the selected/highlighted vehicle marker (hex)"
+	},
 	"PUBLIC_ANALYTICS_DOMAIN": {
 		"required": false,
 		"type": "string",

--- a/src/lib/MapHelpers/__tests__/generateVehicleIcon.custom-env.test.js
+++ b/src/lib/MapHelpers/__tests__/generateVehicleIcon.custom-env.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const mockEnv = vi.hoisted(() => ({ PUBLIC_COLOR_VEHICLE_HIGHLIGHT: '#FF0000' }));
+
+vi.mock('$env/dynamic/public', () => ({
+	get env() {
+		return mockEnv;
+	}
+}));
+
+import { createVehicleIconSvg } from '$lib/MapHelpers/generateVehicleIcon.js';
+
+describe('createVehicleIconSvg with custom env color', () => {
+	it('uses configured PUBLIC_COLOR_VEHICLE_HIGHLIGHT', () => {
+		const svg = createVehicleIconSvg(0, '#007BFF', undefined, true);
+		expect(svg).toContain('#FF0000');
+		expect(svg).not.toContain('#FACC15');
+	});
+});

--- a/src/lib/MapHelpers/__tests__/generateVehicleIcon.test.js
+++ b/src/lib/MapHelpers/__tests__/generateVehicleIcon.test.js
@@ -1,4 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('$env/dynamic/public', () => ({
+	env: {}
+}));
+
 import { createVehicleIconSvg } from '$lib/MapHelpers/generateVehicleIcon.js';
 
 describe('createVehicleIconSvg', () => {

--- a/src/lib/MapHelpers/generateVehicleIcon.js
+++ b/src/lib/MapHelpers/generateVehicleIcon.js
@@ -1,3 +1,4 @@
+import { env } from '$env/dynamic/public';
 import { toDirection } from '$lib/mathUtils';
 import { generateRouteTypeSvgForDisplay, RouteType } from '$config/routeConfig';
 
@@ -23,9 +24,9 @@ function getDirectionFromOrientation(orientation) {
 }
 
 // Soft glow drawn behind the vehicle the user selected (the trip they clicked).
-// TODO: make this configurable via a COLOR_* env var (like the brand colors) so
-// deployments can match it to their theme instead of the hardcoded amber.
-const HIGHLIGHT_GLOW_COLOR = '#FACC15';
+// Configurable via PUBLIC_COLOR_VEHICLE_HIGHLIGHT env var so deployments can
+// match it to their theme instead of the hardcoded amber.
+const HIGHLIGHT_GLOW_COLOR = env.PUBLIC_COLOR_VEHICLE_HIGHLIGHT || '#FACC15';
 
 function createVehicleIconSvg(
 	orientation,


### PR DESCRIPTION
Fixes: #562 

Replaces the hardcoded amber (#FACC15) with a PUBLIC_COLOR_VEHICLE_HIGHLIGHT env var, following the existing brand-color pattern. Falls back to the original amber if unset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support for customizing the glow color of selected vehicle markers.
  * Vehicle highlights now use the configured color, with a default yellow color when no setting is provided.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->