### PR TITLE
Refine load-more empty-state copy and add test coverage

### DIFF
--- a/src/components/stops/StopPane.svelte
+++ b/src/components/stops/StopPane.svelte
@@ -53,7 +53,28 @@
 	let currentStopSurvey = $state(null);
 	let remainingSurveyQuestions = $state([]);
 
+	// Furthest arrival time (ms) observed when we last concluded "no more arrivals".
+	// A later poll that surfaces an arrival beyond this clears the stale hint.
+	let noMoreArrivalsBoundary = 0;
+
 	let abortController = null;
+
+	/**
+	 * Returns the furthest-out arrival time (ms) in the list, preferring the
+	 * predicted time and falling back to the scheduled time. Comparing this
+	 * across window widenings is more robust than a raw count: an arrival
+	 * departing the front of the list no longer masks a genuinely later one.
+	 * @param {any[]} [arrivals]
+	 * @returns {number}
+	 */
+	function furthestArrivalTime(arrivals) {
+		let furthest = 0;
+		for (const arrival of arrivals ?? []) {
+			const time = arrival.predictedArrivalTime || arrival.scheduledArrivalTime || 0;
+			if (time > furthest) furthest = time;
+		}
+		return furthest;
+	}
 	/**
 	 * Fetches arrivals for the stop within the current `minutesAfter` window.
 	 * @returns {Promise<number|null>} the number of arrivals fetched, or `null`
@@ -86,9 +107,13 @@
 			serviceAlerts = filterActiveAlerts(data.data.references.situations || []);
 			error = null; // Clear previous errors if successful
 			const count = arrivalsAndDepartures?.arrivalsAndDepartures?.length ?? 0;
-			// A refresh that returns arrivals clears a stale "no more arrivals" hint
-			// (e.g. after a 30s poll surfaces new departures).
-			if (count > 0) {
+			// Clear a stale "no more arrivals" hint only when a refresh actually
+			// surfaces an arrival further out than the window we'd exhausted — a
+			// poll returning the same (or nearer) arrivals must leave the hint up.
+			if (
+				noMoreArrivals &&
+				furthestArrivalTime(arrivalsAndDepartures?.arrivalsAndDepartures) > noMoreArrivalsBoundary
+			) {
 				noMoreArrivals = false;
 			}
 			return count;
@@ -119,7 +144,7 @@
 	// Widen the arrivals window and refetch. If the count doesn't grow, surface a
 	// "no more arrivals found" hint (the server has nothing further to show).
 	async function loadMoreArrivals() {
-		const previousCount = arrivalsAndDepartures?.arrivalsAndDepartures?.length ?? 0;
+		const previousFurthest = furthestArrivalTime(arrivalsAndDepartures?.arrivalsAndDepartures);
 
 		loadingMore = true;
 		noMoreArrivals = false;
@@ -132,7 +157,10 @@
 		loadingMore = false;
 		// Only conclude "no more arrivals" from a request that actually completed.
 		if (count !== null) {
-			noMoreArrivals = count === previousCount;
+			const newFurthest = furthestArrivalTime(arrivalsAndDepartures?.arrivalsAndDepartures);
+			// Widening the window surfaced nothing further out → nothing more to show.
+			noMoreArrivals = newFurthest <= previousFurthest;
+			if (noMoreArrivals) noMoreArrivalsBoundary = newFurthest;
 		}
 		analytics.reportArrivalClicked('Loaded more arrivals');
 	}

--- a/src/components/stops/StopPane.svelte
+++ b/src/components/stops/StopPane.svelte
@@ -293,9 +293,13 @@
 
 				{#snippet loadMoreButton(emptyResults = false)}
 					<div class="flex flex-col items-center gap-2">
-						{#if emptyResults || noMoreArrivals}
+						{#if emptyResults}
 							<p class="text-sm text-gray-600 dark:text-gray-400">
 								{$t('no_arrivals_found_in_next_minutes', { values: { minutes: minutesAfter } })}
+							</p>
+						{:else if noMoreArrivals}
+							<p class="text-sm text-gray-600 dark:text-gray-400">
+								{$t('no_more_arrivals_in_next_minutes', { values: { minutes: minutesAfter } })}
 							</p>
 						{/if}
 						<button

--- a/src/components/stops/__tests__/StopPane.test.js
+++ b/src/components/stops/__tests__/StopPane.test.js
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 import { expect, test, describe, vi, beforeEach, afterEach } from 'vitest';
 import StopPane from '../StopPane.svelte';
 import {
@@ -117,7 +118,8 @@ vi.mock('svelte-i18n', () => ({
 					routes: 'Routes',
 					'schedule_for_stop.view_schedule': 'View Schedule',
 					load_more_arrivals: 'Load more arrivals',
-					no_arrivals_found_in_next_minutes: 'No arrivals found in the next {minutes} minutes'
+					no_arrivals_found_in_next_minutes: 'No arrivals found in the next {minutes} minutes',
+					no_more_arrivals_in_next_minutes: 'No more arrivals in the next {minutes} minutes'
 				};
 				let str = translations[key] || key;
 				if (options?.values) {
@@ -504,6 +506,93 @@ describe('StopPane', () => {
 			expect(headings).toHaveLength(2);
 			expect(headings[0]).toHaveTextContent('Stop #75403');
 			expect(headings[1]).toHaveTextContent('Routes: 10, 11');
+		});
+	});
+
+	test('shows "No more arrivals" message when load-more returns no new results', async () => {
+		// First call returns arrivals
+		global.fetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => mockArrivalsAndDeparturesResponse
+		});
+
+		render(StopPane, { props: defaultProps });
+
+		await waitFor(() => {
+			expect(screen.getByText('Pine St & 3rd Ave')).toBeInTheDocument();
+		});
+
+		// Second call (load-more) returns the same data (no new arrivals)
+		global.fetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => mockArrivalsAndDeparturesResponse
+		});
+
+		await userEvent.click(screen.getByText('Load more arrivals'));
+
+		await waitFor(() => {
+			expect(screen.getByText('No more arrivals in the next 65 minutes')).toBeInTheDocument();
+		});
+	});
+
+	test('calls API with incremented minutesAfter on load-more click', async () => {
+		global.fetch.mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => mockArrivalsAndDeparturesResponse
+		});
+
+		render(StopPane, { props: defaultProps });
+
+		await waitFor(() => {
+			expect(screen.getByText('Pine St & 3rd Ave')).toBeInTheDocument();
+		});
+
+		await userEvent.click(screen.getByText('Load more arrivals'));
+
+		await waitFor(() => {
+			expect(global.fetch).toHaveBeenCalledWith(
+				'/api/oba/arrivals-and-departures-for-stop/1_75403?minutesAfter=65',
+				expect.objectContaining({
+					signal: expect.any(AbortSignal)
+				})
+			);
+		});
+	});
+
+	test('shows "No more arrivals" message when load-more returns same count', async () => {
+		global.fetch.mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => mockArrivalsAndDeparturesResponse
+		});
+
+		render(StopPane, { props: defaultProps });
+
+		await waitFor(() => {
+			expect(screen.getByText('Pine St & 3rd Ave')).toBeInTheDocument();
+		});
+
+		await userEvent.click(screen.getByText('Load more arrivals'));
+
+		await waitFor(() => {
+			expect(screen.getByText('No more arrivals in the next 65 minutes')).toBeInTheDocument();
+		});
+	});
+
+	test('shows "No arrivals found" for truly empty stop', async () => {
+		global.fetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => mockEmptyArrivalsAndDeparturesResponse
+		});
+
+		render(StopPane, { props: defaultProps });
+
+		await waitFor(() => {
+			expect(screen.getByText('No arrivals found in the next 35 minutes')).toBeInTheDocument();
 		});
 	});
 

--- a/src/components/stops/__tests__/StopPane.test.js
+++ b/src/components/stops/__tests__/StopPane.test.js
@@ -537,6 +537,59 @@ describe('StopPane', () => {
 		});
 	});
 
+	test('does not show "No more arrivals" when load-more surfaces a later arrival', async () => {
+		// Initial window returns the base arrivals.
+		global.fetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => mockArrivalsAndDeparturesResponse
+		});
+
+		render(StopPane, { props: defaultProps });
+
+		await waitFor(() => {
+			expect(screen.getByText('Pine St & 3rd Ave')).toBeInTheDocument();
+		});
+
+		// Widened window: the front arrival has departed but a genuinely later
+		// arrival appears, so the count is unchanged while more remains to show.
+		const base = mockArrivalsAndDeparturesResponse.data.entry.arrivalsAndDepartures;
+		const widenedResponse = {
+			...mockArrivalsAndDeparturesResponse,
+			data: {
+				...mockArrivalsAndDeparturesResponse.data,
+				entry: {
+					...mockArrivalsAndDeparturesResponse.data.entry,
+					arrivalsAndDepartures: [
+						...base.slice(1),
+						{
+							...base[0],
+							tripId: '1_later_trip',
+							predictedArrivalTime: null,
+							scheduledArrivalTime: Date.now() + 3600000 // 60 minutes from now
+						}
+					]
+				}
+			}
+		};
+		global.fetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => widenedResponse
+		});
+
+		await userEvent.click(screen.getByText('Load more arrivals'));
+
+		await waitFor(() => {
+			expect(global.fetch).toHaveBeenCalledWith(
+				'/api/oba/arrivals-and-departures-for-stop/1_75403?minutesAfter=65',
+				expect.any(Object)
+			);
+		});
+
+		expect(screen.queryByText('No more arrivals in the next 65 minutes')).not.toBeInTheDocument();
+	});
+
 	test('calls API with incremented minutesAfter on load-more click', async () => {
 		global.fetch.mockResolvedValue({
 			ok: true,
@@ -559,26 +612,6 @@ describe('StopPane', () => {
 					signal: expect.any(AbortSignal)
 				})
 			);
-		});
-	});
-
-	test('shows "No more arrivals" message when load-more returns same count', async () => {
-		global.fetch.mockResolvedValue({
-			ok: true,
-			status: 200,
-			json: async () => mockArrivalsAndDeparturesResponse
-		});
-
-		render(StopPane, { props: defaultProps });
-
-		await waitFor(() => {
-			expect(screen.getByText('Pine St & 3rd Ave')).toBeInTheDocument();
-		});
-
-		await userEvent.click(screen.getByText('Load more arrivals'));
-
-		await waitFor(() => {
-			expect(screen.getByText('No more arrivals in the next 65 minutes')).toBeInTheDocument();
 		});
 	});
 

--- a/src/components/stops/__tests__/StopPane.test.js
+++ b/src/components/stops/__tests__/StopPane.test.js
@@ -587,6 +587,14 @@ describe('StopPane', () => {
 			);
 		});
 
+		// Wait for the widened response to finish processing: the button only
+		// returns from its loading state after loadMoreArrivals resolves and
+		// recomputes the hint in the same tick (the arrival list itself renders
+		// through mocked children, so it exposes no DOM value to wait on).
+		await waitFor(() => {
+			expect(screen.getByRole('button', { name: 'Load more arrivals' })).toBeEnabled();
+		});
+
 		expect(screen.queryByText('No more arrivals in the next 65 minutes')).not.toBeInTheDocument();
 	});
 

--- a/src/locales/am.json
+++ b/src/locales/am.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "መግቢያዎችና መውጫዎች",
 	"load_more_arrivals": "ተጨማሪ መድረሻዎችን ጫን",
 	"no_arrivals_found_in_next_minutes": "በሚቀጥሉት {minutes} ደቂቃዎች ውስጥ ምንም መድረሻ አልተገኘም",
+	"no_more_arrivals_in_next_minutes": "በሚቀጥሉት {minutes} ደቂቃዎች ውስጥ ምንም ተጨማሪ መድረሻ የለም",
 	"stop": "ቆሻሻ",
 	"routes": "መንገዶች",
 	"route": "መንገድ",

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "الوصول والمغادرة",
 	"load_more_arrivals": "تحميل المزيد من الوصولات",
 	"no_arrivals_found_in_next_minutes": "لا توجد وصولات في الدقائق {minutes} القادمة",
+	"no_more_arrivals_in_next_minutes": "لا يوجد المزيد من الوصولات في الدقائق {minutes} القادمة",
 	"stop": "المحطة",
 	"routes": "المسارات",
 	"route": "المسار",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -129,6 +129,7 @@
 	"show_less": "Show less",
 	"load_more_arrivals": "Load more arrivals",
 	"no_arrivals_found_in_next_minutes": "No arrivals found in the next {minutes} minutes",
+	"no_more_arrivals_in_next_minutes": "No more arrivals in the next {minutes} minutes",
 	"stop": "Stop",
 	"routes": "Routes",
 	"route": "route",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "Llegadas y salidas",
 	"load_more_arrivals": "Cargar más llegadas",
 	"no_arrivals_found_in_next_minutes": "No se encontraron llegadas en los próximos {minutes} minutos",
+	"no_more_arrivals_in_next_minutes": "No hay más llegadas en los próximos {minutes} minutos",
 	"stop": "Parada",
 	"routes": "Rutas",
 	"route": "Ruta",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "ورود و خروج",
 	"load_more_arrivals": "بارگذاری ورودی‌های بیشتر",
 	"no_arrivals_found_in_next_minutes": "هیچ ورودی در {minutes} دقیقه آینده یافت نشد",
+	"no_more_arrivals_in_next_minutes": "هیچ ورودی بیشتری در {minutes} دقیقه آینده وجود ندارد",
 	"stop": "ایستگاه",
 	"routes": "خطوط",
 	"route": "خط",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "Arrivées et départs",
 	"load_more_arrivals": "Charger plus d'arrivées",
 	"no_arrivals_found_in_next_minutes": "Aucune arrivée trouvée dans les {minutes} prochaines minutes",
+	"no_more_arrivals_in_next_minutes": "Aucune autre arrivée dans les {minutes} prochaines minutes",
 	"stop": "Arrêt",
 	"routes": "Lignes",
 	"route": "ligne",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "आगमन और प्रस्थान",
 	"load_more_arrivals": "और आगमन लोड करें",
 	"no_arrivals_found_in_next_minutes": "अगले {minutes} मिनट में कोई आगमन नहीं मिला",
+	"no_more_arrivals_in_next_minutes": "अगले {minutes} मिनट में कोई और आगमन नहीं",
 	"stop": "स्टॉप",
 	"routes": "मार्ग",
 	"route": "मार्ग",

--- a/src/locales/ht.json
+++ b/src/locales/ht.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "Arive ak depa",
 	"load_more_arrivals": "Chaje plis arive",
 	"no_arrivals_found_in_next_minutes": "Pa gen arive nan {minutes} minit kap vini yo",
+	"no_more_arrivals_in_next_minutes": "Pa gen plis arive nan {minutes} minit kap vini yo",
 	"stop": "Arè",
 	"routes": "Wout",
 	"route": "wout",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "到着・出発",
 	"load_more_arrivals": "さらに到着を読み込む",
 	"no_arrivals_found_in_next_minutes": "今後{minutes}分以内に到着はありません",
+	"no_more_arrivals_in_next_minutes": "今後{minutes}分以内にこれ以上の到着はありません",
 	"stop": "停留所",
 	"routes": "路線",
 	"route": "路線",

--- a/src/locales/km.json
+++ b/src/locales/km.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "ការមកដល់និងចេញដំណើរ",
 	"load_more_arrivals": "ផ្ទុកការមកដល់បន្ថែម",
 	"no_arrivals_found_in_next_minutes": "រកមិនឃើញការមកដល់ក្នុង {minutes} នាទីខាងមុខទេ",
+	"no_more_arrivals_in_next_minutes": "មិនមានការមកដល់បន្ថែមទៀតទេក្នុង {minutes} នាទីខាងមុខ",
 	"stop": "ចំណត",
 	"routes": "ផ្លូវ",
 	"route": "ផ្លូវ",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "도착 및 출발",
 	"load_more_arrivals": "도착 정보 더 보기",
 	"no_arrivals_found_in_next_minutes": "{minutes}분 이내 도착 예정이 없습니다",
+	"no_more_arrivals_in_next_minutes": "앞으로 {minutes}분 이내에 더 이상 도착 예정이 없습니다",
 	"stop": "정류장",
 	"routes": "노선",
 	"route": "노선",

--- a/src/locales/lo.json
+++ b/src/locales/lo.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "ການມາຮອດ ແລະ ການອອກເດີນທາງ",
 	"load_more_arrivals": "ໂຫຼດການມາຮອດເພີ່ມເຕີມ",
 	"no_arrivals_found_in_next_minutes": "ບໍ່ພົບການມາຮອດໃນ {minutes} ນາທີຕໍ່ໄປ",
+	"no_more_arrivals_in_next_minutes": "ບໍ່ມີການມາຮອດເພີ່ມເຕີມໃນ {minutes} ນາທີຕໍ່ໄປ",
 	"stop": "ປ້າຍ",
 	"routes": "ເສັ້ນທາງ",
 	"route": "ເສັ້ນທາງ",

--- a/src/locales/om.json
+++ b/src/locales/om.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "Dhufaatii fi ka'umsa",
 	"load_more_arrivals": "Dhufaatii dabalataa fe'i",
 	"no_arrivals_found_in_next_minutes": "Daqiiqaa {minutes} itti aanu keessatti dhufaatiin hin argamne",
+	"no_more_arrivals_in_next_minutes": "Daqiiqaa {minutes} itti aanu keessatti dhufaataa dabalataa hin jiru",
 	"stop": "Dhaabbii",
 	"routes": "Sararawwan",
 	"route": "sarara",

--- a/src/locales/pa.json
+++ b/src/locales/pa.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "ਆਗਮਨ ਅਤੇ ਰਵਾਨਗੀਆਂ",
 	"load_more_arrivals": "ਹੋਰ ਆਗਮਨ ਲੋਡ ਕਰੋ",
 	"no_arrivals_found_in_next_minutes": "ਅਗਲੇ {minutes} ਮਿੰਟਾਂ ਵਿੱਚ ਕੋਈ ਆਗਮਨ ਨਹੀਂ ਮਿਲਿਆ",
+	"no_more_arrivals_in_next_minutes": "ਅਗਲੇ {minutes} ਮਿੰਟਾਂ ਵਿੱਚ ਹੋਰ ਕੋਈ ਆਗਮਨ ਨਹੀਂ",
 	"stop": "ਸਟਾਪ",
 	"routes": "ਰੂਟ",
 	"route": "ਰੂਟ",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "Przyjazdy i odjazdy",
 	"load_more_arrivals": "Załaduj więcej przyjazdów",
 	"no_arrivals_found_in_next_minutes": "Brak przyjazdów w ciągu najbliższych {minutes} minut",
+	"no_more_arrivals_in_next_minutes": "Brak dalszych przyjazdów w ciągu najbliższych {minutes} minut",
 	"stop": "Przystanek",
 	"routes": "Trasy",
 	"route": "trasa",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "Chegadas e partidas",
 	"load_more_arrivals": "Carregar mais chegadas",
 	"no_arrivals_found_in_next_minutes": "Nenhuma chegada encontrada nos próximos {minutes} minutos",
+	"no_more_arrivals_in_next_minutes": "Nenhuma chegada adicional nos próximos {minutes} minutos",
 	"stop": "Parada",
 	"routes": "Linhas",
 	"route": "linha",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "Прибытие и отправление",
 	"load_more_arrivals": "Загрузить больше прибытий",
 	"no_arrivals_found_in_next_minutes": "Нет прибытий в ближайшие {minutes} минут",
+	"no_more_arrivals_in_next_minutes": "Нет больше прибытий в ближайшие {minutes} минут",
 	"stop": "Остановка",
 	"routes": "Маршруты",
 	"route": "маршрут",

--- a/src/locales/sm.json
+++ b/src/locales/sm.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "Taunuʻuga ma alu atu",
 	"load_more_arrivals": "Utaina atili taunuʻuga",
 	"no_arrivals_found_in_next_minutes": "E leai ni taunuʻuga na maua i le {minutes} minute o loʻo sosoo",
+	"no_more_arrivals_in_next_minutes": "Leai ni taunuʻuga faaopoopo i le {minutes} minute o loʻo sosoo",
 	"stop": "Nofoaga Taofi",
 	"routes": "Auala",
 	"route": "auala",

--- a/src/locales/so.json
+++ b/src/locales/so.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "Imaatinka iyo baxsashada",
 	"load_more_arrivals": "Soo rar imaatinno dheeraad ah",
 	"no_arrivals_found_in_next_minutes": "Lama helin soo gaadhis {minutes} daqiiqo ee soo socda",
+	"no_more_arrivals_in_next_minutes": "Ma jiraan soo gaadhis dheeraad ah {minutes} daqiiqo ee soo socda",
 	"stop": "Joogsi",
 	"routes": "Jidadka",
 	"route": "Jidka",

--- a/src/locales/ti.json
+++ b/src/locales/ti.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "ምብጻሕን ምብጋስን",
 	"load_more_arrivals": "ተወሳኺ ምብጻሓት ጽዓን",
 	"no_arrivals_found_in_next_minutes": "ኣብ ዝመጽእ {minutes} ደቓይቕ ዝኾነ ምብጻሕ ኣይተረኽበን",
+	"no_more_arrivals_in_next_minutes": "ኣብ ዝመጽእ {minutes} ደቓይቕ ዝኾነ ተወሳኺ ምብጻሕ የለን",
 	"stop": "መዕረፊ",
 	"routes": "መስመራት",
 	"route": "መስመር",

--- a/src/locales/tl.json
+++ b/src/locales/tl.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "Mga pagdating at pag-alis",
 	"load_more_arrivals": "Mag-load pa ng mga pagdating",
 	"no_arrivals_found_in_next_minutes": "Walang nahanap na pagdating sa susunod na {minutes} minuto",
+	"no_more_arrivals_in_next_minutes": "Wala nang karagdagang pagdating sa susunod na {minutes} minuto",
 	"stop": "Hintuan",
 	"routes": "Mga ruta",
 	"route": "Ruta",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "Прибуття та відправлення",
 	"load_more_arrivals": "Завантажити більше прибуттів",
 	"no_arrivals_found_in_next_minutes": "Немає прибуттів протягом наступних {minutes} хвилин",
+	"no_more_arrivals_in_next_minutes": "Немає більше прибуттів протягом наступних {minutes} хвилин",
 	"stop": "Зупинка",
 	"routes": "Маршрути",
 	"route": "маршрут",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "Đến và đi",
 	"load_more_arrivals": "Tải thêm chuyến đến",
 	"no_arrivals_found_in_next_minutes": "Không tìm thấy chuyến đến trong {minutes} phút tới",
+	"no_more_arrivals_in_next_minutes": "Không có thêm chuyến đến trong {minutes} phút tới",
 	"stop": "Trạm dừng",
 	"routes": "Tuyến đường",
 	"route": "Tuyến đường",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "到站与发车",
 	"load_more_arrivals": "加载更多到站信息",
 	"no_arrivals_found_in_next_minutes": "未来{minutes}分钟内无到站信息",
+	"no_more_arrivals_in_next_minutes": "未来{minutes}分钟内无更多到站信息",
 	"stop": "站点",
 	"routes": "线路",
 	"route": "线路",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -90,6 +90,7 @@
 	"arrivals_and_departures": "到站與發車",
 	"load_more_arrivals": "載入更多到站班次",
 	"no_arrivals_found_in_next_minutes": "未來 {minutes} 分鐘內沒有到站班次",
+	"no_more_arrivals_in_next_minutes": "未來{minutes}分鐘內沒有更多到站班次",
 	"stop": "站牌",
 	"routes": "路線",
 	"route": "路線",


### PR DESCRIPTION
Fixes #561 

- Add no_more_arrivals_in_next_minutes i18n key for when results exist but load-more returns nothing new
- Use differentiating copy: 'No arrivals found' for truly empty stops, 'No more arrivals' when widening the window yields nothing
- Add 4 tests covering load-more click, API call with incremented minutesAfter, noMoreArrivals message, and truly empty stop message


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved arrival loading so the app accurately detects whether additional arrivals are available after expanding the time window.
  - Prevented outdated “no more arrivals” messages from persisting when later arrivals are found.
  - Distinguishes between stops with no arrivals and stops with no further arrivals.

- **Localization**
  - Added translated “No more arrivals” messaging across supported languages.

- **Tests**
  - Added coverage for expanded arrival searches, empty results, and accurate status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->