### PR TITLE
Redesign stop arrival/departure cards to match mockup

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,5 @@ yarn.lock
 
 # Cursor IDE
 .cursor/
+# Superpowers scratch (git-ignored)
+.superpowers/

--- a/docs/superpowers/plans/2026-07-22-arrival-departure-redesign.md
+++ b/docs/superpowers/plans/2026-07-22-arrival-departure-redesign.md
@@ -1,0 +1,655 @@
+# Stop UI Arrival/Departure Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the stop pane's arrivals/departures UI (route badge, headsign, colored `time · status` sub-line, large compact ETA with live/schedule icon, "ARRIVALS & DEPARTURES" section header, and a restyled trip-detail timeline) to match the provided mockup.
+
+**Architecture:** Add a reusable `RouteBadge.svelte`. Redesign `ArrivalDeparture.svelte`'s markup, ETA format, and scheduled-color while preserving all existing status/frequency/canceled logic. `StopPane.svelte` derives a `routeId → route` color map and adds a section header. `TripDetailsPane.svelte` gets a "Live · vehicle {id}" heading and mockup-style timeline markers. New i18n strings go in the English fallback locale.
+
+**Tech Stack:** SvelteKit 5 (Svelte 5 runes), Tailwind CSS, FontAwesome (`@fortawesome/svelte-fontawesome` + `free-solid-svg-icons`), `svelte-i18n`, Vitest + `@testing-library/svelte`.
+
+## Global Constraints
+
+- **Svelte 5 runes only** — `$props`, `$state`, `$derived`, `$effect`. Never write `$state` from inside an `$effect` for pure derivations; use `$derived`.
+- **Dynamic hex colors via inline `style`, never Tailwind arbitrary classes** — `class="bg-[#{color}]"` fails silently (Tailwind is build-time). Use `style="background-color: {bg}"`.
+- **FontAwesome icons imported from `@fortawesome/free-solid-svg-icons`** — `faTowerBroadcast` exists only in free-solid; `faClock` is in solid too. Import both from solid.
+- **WCAG AA contrast** — scheduled gray is `text-gray-500 dark:text-gray-400`. Never `text-gray-400` in light mode (~2.9:1 fails).
+- **All user-facing strings localized** — add keys to `src/locales/en.json` (synchronous fallback); interpolate values, never concatenate literals.
+- **Test runner:** `npx vitest run <path>` (do NOT use `npm run test` — it hangs in non-TTY).
+- **Route colors** are hex strings without `#` on `references.routes[].color` / `.textColor`, joined to arrivals by `routeId`. The arrival object itself has no color.
+
+---
+
+### Task 1: `RouteBadge.svelte` component
+
+**Files:**
+- Create: `src/components/RouteBadge.svelte`
+- Test: `src/components/__tests__/RouteBadge.test.js`
+
+**Interfaces:**
+- Produces: `RouteBadge` Svelte component with props `{ shortName: string, color?: string, textColor?: string }`. Renders a `<div>` containing `shortName` with inline `style="background-color: <bg>; color: <fg>;"` where `bg = color ? '#'+color : '#374151'` and `fg = textColor ? '#'+textColor : '#ffffff'`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/__tests__/RouteBadge.test.js`:
+
+```js
+import { render, screen } from '@testing-library/svelte';
+import { expect, test, describe } from 'vitest';
+import RouteBadge from '../RouteBadge.svelte';
+
+describe('RouteBadge', () => {
+	test('renders the route short name', () => {
+		render(RouteBadge, { props: { shortName: 'C Line' } });
+		expect(screen.getByText('C Line')).toBeInTheDocument();
+	});
+
+	test('uses the route color as background and text color when provided', () => {
+		render(RouteBadge, { props: { shortName: '10', color: 'FF0000', textColor: '00FF00' } });
+		const badge = screen.getByText('10');
+		expect(badge).toHaveStyle('background-color: #FF0000');
+		expect(badge).toHaveStyle('color: #00FF00');
+	});
+
+	test('falls back to dark slate background and white text when color is absent', () => {
+		render(RouteBadge, { props: { shortName: '21' } });
+		const badge = screen.getByText('21');
+		expect(badge).toHaveStyle('background-color: #374151');
+		expect(badge).toHaveStyle('color: #ffffff');
+	});
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/components/__tests__/RouteBadge.test.js`
+Expected: FAIL — cannot resolve `../RouteBadge.svelte` (file does not exist).
+
+- [ ] **Step 3: Create the component**
+
+Create `src/components/RouteBadge.svelte`:
+
+```svelte
+<script>
+	/**
+	 * @typedef {Object} Props
+	 * @property {string} shortName - Route short name (e.g. "C Line", "21")
+	 * @property {string} [color] - Route color as a hex string without "#" (from references.routes)
+	 * @property {string} [textColor] - Route text color as a hex string without "#"
+	 */
+
+	/** @type {Props} */
+	let { shortName, color = null, textColor = null } = $props();
+
+	let bg = $derived(color ? `#${color}` : '#374151');
+	let fg = $derived(textColor ? `#${textColor}` : '#ffffff');
+</script>
+
+<div
+	class="flex h-14 w-16 shrink-0 items-center justify-center rounded-lg break-words px-1 text-center text-sm font-bold leading-tight"
+	style="background-color: {bg}; color: {fg};"
+>
+	{shortName}
+</div>
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/components/__tests__/RouteBadge.test.js`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Verify Svelte correctness (optional but recommended)**
+
+Use the Svelte MCP `svelte-autofixer` on `src/components/RouteBadge.svelte`. Expected: no issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/RouteBadge.svelte src/components/__tests__/RouteBadge.test.js
+git commit -m "feat: add reusable RouteBadge component"
+```
+
+---
+
+### Task 2: Redesign `ArrivalDeparture.svelte`
+
+**Files:**
+- Modify: `src/locales/en.json` (add `time.min_compact`)
+- Modify: `src/components/ArrivalDeparture.svelte` (props, `computeColor`, `computeTimeLabel`, markup, imports)
+- Test: `src/components/__tests__/ArrivalDeparture.test.js` (new)
+
+**Interfaces:**
+- Consumes: `RouteBadge` from Task 1.
+- Produces: `ArrivalDeparture` now accepts an added prop `route` (`{ color?: string, textColor?: string } | null`, default `null`). Its `arrivalInfo` derived object keeps its existing fields (`displayTime`, `color`, `statusText`, `timeText`, `isPredicted`, ...). `timeText` is now the compact form (`"19m"`, `"now"`, `"-3m"`). `color` for non-predicted arrivals is now `text-gray-500 dark:text-gray-400`.
+
+- [ ] **Step 1: Add the compact-ETA i18n key**
+
+In `src/locales/en.json`, find the `"time"` block (around line 139) and add a `min_compact` entry:
+
+```json
+	"time": {
+		"ago": "ago",
+		"now": "now",
+		"sec": "sec",
+		"secs": "secs",
+		"min": "min",
+		"mins": "mins",
+		"minutes": "minutes",
+		"min_compact": "{n}m"
+	},
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/components/__tests__/ArrivalDeparture.test.js`. It uses a local `svelte-i18n` mock that interpolates so the compact ETA and status keys render real text:
+
+```js
+import { render, screen } from '@testing-library/svelte';
+import { expect, test, describe, vi } from 'vitest';
+
+// Local i18n mock that interpolates {name} values (the global setup mock returns keys)
+vi.mock('svelte-i18n', () => ({
+	t: {
+		subscribe: (fn) => {
+			fn((key, options) => {
+				let str = key;
+				if (options?.values) {
+					for (const [name, value] of Object.entries(options.values)) {
+						str = str.replace(`{${name}}`, value);
+					}
+				}
+				return str;
+			});
+			return () => {};
+		}
+	}
+}));
+
+import ArrivalDeparture from '../ArrivalDeparture.svelte';
+
+const MIN = 60000;
+
+function baseArrival(overrides = {}) {
+	return {
+		routeShortName: '10',
+		tripHeadsign: 'Downtown Seattle',
+		stopSequence: 1,
+		predicted: true,
+		scheduledArrivalTime: Date.now() + 10 * MIN,
+		predictedArrivalTime: Date.now() + 10 * MIN,
+		scheduledDepartureTime: Date.now() + 10 * MIN,
+		predictedDepartureTime: Date.now() + 10 * MIN,
+		tripStatus: null,
+		frequency: null,
+		...overrides
+	};
+}
+
+describe('ArrivalDeparture', () => {
+	test('renders the headsign and a route badge with the short name', () => {
+		render(ArrivalDeparture, {
+			props: { arrivalDeparture: baseArrival(), route: { color: 'FF0000', textColor: 'FFFFFF' } }
+		});
+		expect(screen.getByText('Downtown Seattle')).toBeInTheDocument();
+		const badge = screen.getByText('10');
+		expect(badge).toHaveStyle('background-color: #FF0000');
+	});
+
+	test('renders a compact ETA like "10m"', () => {
+		render(ArrivalDeparture, { props: { arrivalDeparture: baseArrival() } });
+		expect(screen.getByText('10m')).toBeInTheDocument();
+	});
+
+	test('uses gray for scheduled (not predicted) arrivals', () => {
+		render(ArrivalDeparture, {
+			props: {
+				arrivalDeparture: baseArrival({ predicted: false, predictedArrivalTime: null })
+			}
+		});
+		const eta = screen.getByText('10m');
+		expect(eta.className).toContain('text-gray-500');
+	});
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npx vitest run src/components/__tests__/ArrivalDeparture.test.js`
+Expected: FAIL — the current component renders `10 - Downtown Seattle` and `10 mins`, so `getByText('10m')` and the badge lookup fail.
+
+- [ ] **Step 4: Update imports and the `route` prop**
+
+In `src/components/ArrivalDeparture.svelte`, replace the top of the `<script>` (lines 1–4) with:
+
+```svelte
+<script>
+	import { t } from 'svelte-i18n';
+	import { msToLocalArrivalDepartureTimeString } from '$lib/dateTimeFormat';
+	import RouteBadge from '$components/RouteBadge.svelte';
+	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
+	import { faTowerBroadcast, faClock } from '@fortawesome/free-solid-svg-icons';
+	let { arrivalDeparture, includeArrivalDepartureInStatusLabel = true, route = null } = $props();
+```
+
+- [ ] **Step 5: Change scheduled color to gray in `computeColor`**
+
+In `computeColor` (lines 18–34), replace the not-predicted branch:
+
+```js
+		if (!isPredicted) {
+			return 'text-blue-600 dark:text-blue-400';
+		}
+```
+
+with:
+
+```js
+		if (!isPredicted) {
+			// Scheduled (no real-time) arrivals read fully muted, per the mockup.
+			// gray-500 passes WCAG AA on white; gray-400 passes on the dark gray-800 surface.
+			return 'text-gray-500 dark:text-gray-400';
+		}
+```
+
+- [ ] **Step 6: Make `computeTimeLabel` produce the compact form**
+
+Replace the whole `computeTimeLabel` function (lines 191–201) with:
+
+```js
+	function computeTimeLabel(eta) {
+		if (eta === 0) {
+			return $t('time.now');
+		}
+		// Compact minute form (e.g. "19m", "1m", "-3m"). Unit is localizable.
+		return $t('time.min_compact', { values: { n: eta } });
+	}
+```
+
+- [ ] **Step 7: Replace the markup**
+
+Replace the entire markup block (lines 216–231, the two `<div>`s after `</script>`) with:
+
+```svelte
+<div class="flex items-center gap-3">
+	<RouteBadge shortName={routeShortName} color={route?.color} textColor={route?.textColor} />
+
+	<div class="min-w-0 flex-1">
+		<p class="truncate text-lg font-semibold text-gray-900 dark:text-white">
+			{tripHeadsign}
+		</p>
+		<p class="truncate text-sm">
+			<span class="text-gray-500 dark:text-gray-400"
+				>{msToLocalArrivalDepartureTimeString(arrivalInfo.displayTime)}</span
+			>
+			<span class="text-gray-500 dark:text-gray-400"> · </span>
+			<span class={arrivalInfo.color}>{arrivalInfo.statusText}</span>
+		</p>
+	</div>
+
+	<div class="flex shrink-0 items-start gap-0.5">
+		<span class="text-3xl font-bold leading-none {arrivalInfo.color}">{arrivalInfo.timeText}</span>
+		<FontAwesomeIcon
+			icon={arrivalInfo.isPredicted ? faTowerBroadcast : faClock}
+			class="text-xs {arrivalInfo.color}"
+		/>
+	</div>
+</div>
+```
+
+- [ ] **Step 8: Run the test to verify it passes**
+
+Run: `npx vitest run src/components/__tests__/ArrivalDeparture.test.js`
+Expected: PASS (3 tests).
+
+- [ ] **Step 9: Run the format/lint check on the changed files**
+
+Run: `npx prettier --check src/components/ArrivalDeparture.svelte src/components/__tests__/ArrivalDeparture.test.js src/locales/en.json`
+Expected: all matched files pass. If not, run `npx prettier --write` on them and re-check.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/components/ArrivalDeparture.svelte src/components/__tests__/ArrivalDeparture.test.js src/locales/en.json
+git commit -m "feat: redesign ArrivalDeparture card with badge, compact ETA, and muted scheduled color"
+```
+
+---
+
+### Task 3: `StopPane.svelte` — route-color plumbing + section header
+
+**Files:**
+- Modify: `src/components/stops/StopPane.svelte`
+- Test: `src/components/stops/__tests__/StopPane.test.js`
+
+**Interfaces:**
+- Consumes: `ArrivalDeparture`'s new `route` prop (Task 2).
+- Produces: renders an "ARRIVALS & DEPARTURES" header (i18n key `arrivals_and_departures`) above the accordion when arrivals exist; passes `route={routeById.get(arrival.routeId)}` to each `ArrivalDeparture`.
+
+- [ ] **Step 1: Add the header assertion to the existing test**
+
+In `src/components/stops/__tests__/StopPane.test.js`, add `arrivals_and_departures` to the local translations map (inside the `vi.mock('svelte-i18n', ...)` block, the `translations` object near line 113):
+
+```js
+				const translations = {
+					stop: 'Stop',
+					routes: 'Routes',
+					arrivals_and_departures: 'Arrivals and departures',
+					'schedule_for_stop.view_schedule': 'View Schedule',
+					load_more_arrivals: 'Load more arrivals',
+					no_arrivals_found_in_next_minutes: 'No arrivals found in the next {minutes} minutes'
+				};
+```
+
+Then add a new test (place it after the existing "renders arrivals" style test, e.g. near line 270):
+
+```js
+	test('renders the ARRIVALS & DEPARTURES section header when arrivals exist', async () => {
+		render(StopPane, { props: { stop: mockStopData } });
+		await waitFor(() => {
+			expect(screen.getByText('Arrivals and departures')).toBeInTheDocument();
+		});
+	});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/components/stops/__tests__/StopPane.test.js -t "section header"`
+Expected: FAIL — "Arrivals and departures" is not in the document yet.
+
+- [ ] **Step 3: Add the `routeById` derived map**
+
+In `src/components/stops/StopPane.svelte`, just after the `routeShortNames` derived (line 159), add:
+
+```js
+	// references.routes carries the per-route color/textColor; the arrival objects
+	// only carry routeId, so build a lookup to feed RouteBadge via ArrivalDeparture.
+	let routeById = $derived(
+		new Map(
+			(arrivalsAndDeparturesResponse?.data?.references?.routes ?? []).map((r) => [r.id, r])
+		)
+	);
+```
+
+- [ ] **Step 4: Add the section header and pass the route down**
+
+In the arrivals-present branch (the `{:else}` at line 316), replace:
+
+```svelte
+				{:else}
+					{#key arrivalsAndDepartures.stopId}
+						<Accordion {handleAccordionSelectionChanged}>
+							{#each arrivalsAndDepartures.arrivalsAndDepartures as arrival}
+								<AccordionItem data={arrival}>
+									{#snippet header()}
+										<span>
+											<ArrivalDeparture arrivalDeparture={arrival} />
+										</span>
+									{/snippet}
+```
+
+with:
+
+```svelte
+				{:else}
+					<h2
+						class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+					>
+						{$isLoading ? '' : $t('arrivals_and_departures')}
+					</h2>
+					{#key arrivalsAndDepartures.stopId}
+						<Accordion {handleAccordionSelectionChanged}>
+							{#each arrivalsAndDepartures.arrivalsAndDepartures as arrival}
+								<AccordionItem data={arrival}>
+									{#snippet header()}
+										<span class="block flex-1">
+											<ArrivalDeparture
+												arrivalDeparture={arrival}
+												route={routeById.get(arrival.routeId)}
+											/>
+										</span>
+									{/snippet}
+```
+
+(The `flex-1` on the wrapper lets the card fill the accordion header row so the chevron sits at the far right.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run src/components/stops/__tests__/StopPane.test.js`
+Expected: PASS (all existing tests plus the new one).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/stops/StopPane.svelte src/components/stops/__tests__/StopPane.test.js
+git commit -m "feat: add arrivals section header and route colors to StopPane"
+```
+
+---
+
+### Task 4: `TripDetailsPane.svelte` — live-vehicle heading + timeline restyle
+
+**Files:**
+- Modify: `src/locales/en.json` (add `trip_details.live_vehicle`)
+- Modify: `src/components/oba/TripDetailsPane.svelte` (heading, markers, imports)
+- Test: `src/components/oba/__tests__/TripDetailsPane.test.js` (new)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: heading shows "Live · vehicle {vehicleId}" (icon `faTowerBroadcast`) when `tripDetails.status?.vehicleId` is present; otherwise the existing route heading. Timeline markers: intermediate = empty ring, vehicle position = filled dark square with bus, your stop = filled pin.
+
+- [ ] **Step 1: Add the i18n key**
+
+In `src/locales/en.json`, find the `"trip_details"` block and add a `live_vehicle` entry alongside the existing keys (`route`, `no_stops`, `loading`):
+
+```json
+		"live_vehicle": "Live · vehicle {vehicleId}"
+```
+
+(Add a comma to the preceding entry as needed to keep valid JSON.)
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/components/oba/__tests__/TripDetailsPane.test.js`:
+
+```js
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { expect, test, describe, vi, beforeEach, afterEach } from 'vitest';
+
+// Local i18n mock that interpolates {vehicleId}
+vi.mock('svelte-i18n', () => ({
+	_: {
+		subscribe: (fn) => {
+			fn((key, options) => {
+				let str = key;
+				if (options?.values) {
+					for (const [name, value] of Object.entries(options.values)) {
+						str = str.replace(`{${name}}`, value);
+					}
+				}
+				return str;
+			});
+			return () => {};
+		}
+	}
+}));
+
+import TripDetailsPane from '../TripDetailsPane.svelte';
+
+const stop = { id: '1_75403', name: 'Fauntleroy Way SW & SW Myrtle St' };
+
+function mockTripResponse({ vehicleId }) {
+	return {
+		data: {
+			entry: {
+				routeId: '1_100479',
+				status: vehicleId ? { vehicleId, closestStop: '1_75403' } : null,
+				schedule: {
+					stopTimes: [{ stopId: '1_75403', arrivalTime: 41400 }]
+				}
+			},
+			references: {
+				routes: [{ id: '1_100479', shortName: 'C Line' }],
+				stops: [{ id: '1_75403', name: 'Fauntleroy Way SW & SW Myrtle St' }]
+			}
+		}
+	};
+}
+
+describe('TripDetailsPane', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	test('shows a "Live · vehicle {id}" heading when a vehicle is present', async () => {
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => mockTripResponse({ vehicleId: '1_8129001' })
+		});
+
+		render(TripDetailsPane, { props: { stop, tripId: '1_trip', serviceDate: 123 } });
+
+		await waitFor(() => {
+			expect(screen.getByText('trip_details.live_vehicle 1_8129001')).toBeInTheDocument();
+		});
+	});
+});
+```
+
+Note: with the interpolating mock, `trip_details.live_vehicle` = `"Live · vehicle {vehicleId}"` is not in the mock's table, so the key text is returned with `{vehicleId}` replaced — asserting the id was interpolated. (The literal prefix differs from prod, but the test proves the vehicle id renders.)
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npx vitest run src/components/oba/__tests__/TripDetailsPane.test.js`
+Expected: FAIL — current heading renders `trip_details.route C Line`, not the live-vehicle text.
+
+- [ ] **Step 4: Update imports**
+
+In `src/components/oba/TripDetailsPane.svelte`, change the icon import (line 4) to add the broadcast icon:
+
+```js
+	import { faBus, faLocationDot, faCheck, faTowerBroadcast } from '@fortawesome/free-solid-svg-icons';
+```
+
+- [ ] **Step 5: Replace the heading**
+
+Replace the route-heading block (lines 101–106):
+
+```svelte
+			{#if routeInfo}
+				<h2 class="h2">
+					{$_('trip_details.route')}
+					{routeInfo.shortName}
+				</h2>
+			{/if}
+```
+
+with a live-vehicle heading that falls back to the route heading:
+
+```svelte
+			{#if tripDetails.status?.vehicleId}
+				<h2 class="h2 flex items-center gap-2">
+					<FontAwesomeIcon icon={faTowerBroadcast} class="text-brand" />
+					{$_('trip_details.live_vehicle', { values: { vehicleId: tripDetails.status.vehicleId } })}
+				</h2>
+			{:else if routeInfo}
+				<h2 class="h2">
+					{$_('trip_details.route')}
+					{routeInfo.shortName}
+				</h2>
+			{/if}
+```
+
+- [ ] **Step 6: Restyle the timeline markers**
+
+Replace the marker `<div>` (lines 113–134, the `relative flex size-8 ...` block and its icon logic) with mockup-style markers — filled dark square + bus at the vehicle position, filled pin at your stop, empty ring otherwise:
+
+```svelte
+						{#if index === busPosition}
+							<div
+								class="relative flex size-8 items-center justify-center rounded-md bg-neutral-800 dark:bg-neutral-200"
+							>
+								<FontAwesomeIcon icon={faBus} class="text-sm text-white dark:text-neutral-900" />
+								{#if tripStop.stopId === stop.id}
+									<FontAwesomeIcon
+										icon={faCheck}
+										class="absolute -right-1 -top-1 rounded-full border border-white bg-brand p-1 text-xs text-white"
+									/>
+								{/if}
+							</div>
+						{:else if tripStop.stopId === stop.id}
+							<div class="flex size-8 items-center justify-center">
+								<FontAwesomeIcon icon={faLocationDot} class="text-xl text-brand-accent" />
+							</div>
+						{:else}
+							<div class="flex size-8 items-center justify-center">
+								<div class="size-4 rounded-full border-2 border-neutral-400 bg-white dark:bg-neutral-800"></div>
+							</div>
+						{/if}
+```
+
+Then, so the "your stop" row reads as the emphasized destination (mockup bold), update the stop-name `<div>` (line 136) to bold your stop:
+
+```svelte
+							<div
+								class="text-md dark:text-white"
+								class:font-bold={tripStop.stopId === stop.id}
+								class:font-semibold={tripStop.stopId !== stop.id}
+							>
+								{stopInfo[tripStop.stopId] ? stopInfo[tripStop.stopId].name : tripStop.stopId}
+							</div>
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `npx vitest run src/components/oba/__tests__/TripDetailsPane.test.js`
+Expected: PASS.
+
+- [ ] **Step 8: Run prettier on the changed files**
+
+Run: `npx prettier --check src/components/oba/TripDetailsPane.svelte src/components/oba/__tests__/TripDetailsPane.test.js src/locales/en.json`
+Expected: pass (else `--write` and re-check).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/components/oba/TripDetailsPane.svelte src/components/oba/__tests__/TripDetailsPane.test.js src/locales/en.json
+git commit -m "feat: restyle trip timeline with live-vehicle heading and mockup markers"
+```
+
+---
+
+### Task 5: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npx vitest run`
+Expected: all tests pass (no regressions in StopPane, RouteItem, dateTimeFormat, etc.).
+
+- [ ] **Step 2: Lint & format**
+
+Run: `npm run lint`
+Expected: passes. If formatting fails, run `npm run format` then re-run `npm run lint`.
+
+- [ ] **Step 3: Production build sanity check**
+
+Run: `npm run build`
+Expected: build succeeds (catches any Svelte/import errors the unit tests miss).
+
+- [ ] **Step 4: Manual visual check (recommended)**
+
+Run `npm run dev`, open a stop with mixed real-time and scheduled arrivals, and confirm against the mockup: colored route badges (red C Line, dark numbered routes), bold headsign, gray `time · status` with colored status, large compact ETA (`19m`) with broadcast/clock icon, the "ARRIVALS & DEPARTURES" header, and an expanded row showing the "Live · vehicle …" heading with the restyled timeline. Verify light and dark mode.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** RouteBadge (Task 1), ArrivalDeparture redesign incl. compact ETA + gray scheduled + icons (Task 2), StopPane route-color map + section header (Task 3), TripDetailsPane heading + timeline (Task 4), tests + i18n keys throughout, full verification (Task 5). "Past · N" counter intentionally deferred per spec. ✓
+- **Type/name consistency:** `route` prop shape `{ color, textColor }` is produced by `routeById.get(...)` in Task 3 and consumed by `RouteBadge` in Task 1 via Task 2; `routeById` used consistently. ✓
+- **No placeholders:** every code step shows complete code and exact commands. ✓
+- **Note on existing tests:** there was no pre-existing `ArrivalDeparture.svelte` or `TripDetailsPane.svelte` test, and `StopPane.test.js` mocks both child components — so the redesign creates new tests rather than breaking old assertions.

--- a/docs/superpowers/plans/2026-07-22-arrival-departure-redesign.md
+++ b/docs/superpowers/plans/2026-07-22-arrival-departure-redesign.md
@@ -23,10 +23,12 @@
 ### Task 1: `RouteBadge.svelte` component
 
 **Files:**
+
 - Create: `src/components/RouteBadge.svelte`
 - Test: `src/components/__tests__/RouteBadge.test.js`
 
 **Interfaces:**
+
 - Produces: `RouteBadge` Svelte component with props `{ shortName: string, color?: string, textColor?: string }`. Renders a `<div>` containing `shortName` with inline `style="background-color: <bg>; color: <fg>;"` where `bg = color ? '#'+color : '#374151'` and `fg = textColor ? '#'+textColor : '#ffffff'`.
 
 - [ ] **Step 1: Write the failing test**
@@ -86,7 +88,7 @@ Create `src/components/RouteBadge.svelte`:
 </script>
 
 <div
-	class="flex h-14 w-16 shrink-0 items-center justify-center rounded-lg break-words px-1 text-center text-sm font-bold leading-tight"
+	class="flex h-14 w-16 shrink-0 items-center justify-center break-words rounded-lg px-1 text-center text-sm font-bold leading-tight"
 	style="background-color: {bg}; color: {fg};"
 >
 	{shortName}
@@ -114,11 +116,13 @@ git commit -m "feat: add reusable RouteBadge component"
 ### Task 2: Redesign `ArrivalDeparture.svelte`
 
 **Files:**
+
 - Modify: `src/locales/en.json` (add `time.min_compact`)
 - Modify: `src/components/ArrivalDeparture.svelte` (props, `computeColor`, `computeTimeLabel`, markup, imports)
 - Test: `src/components/__tests__/ArrivalDeparture.test.js` (new)
 
 **Interfaces:**
+
 - Consumes: `RouteBadge` from Task 1.
 - Produces: `ArrivalDeparture` now accepts an added prop `route` (`{ color?: string, textColor?: string } | null`, default `null`). Its `arrivalInfo` derived object keeps its existing fields (`displayTime`, `color`, `statusText`, `timeText`, `isPredicted`, ...). `timeText` is now the compact form (`"19m"`, `"now"`, `"-3m"`). `color` for non-predicted arrivals is now `text-gray-500 dark:text-gray-400`.
 
@@ -236,19 +240,19 @@ In `src/components/ArrivalDeparture.svelte`, replace the top of the `<script>` (
 In `computeColor` (lines 18–34), replace the not-predicted branch:
 
 ```js
-		if (!isPredicted) {
-			return 'text-blue-600 dark:text-blue-400';
-		}
+if (!isPredicted) {
+	return 'text-blue-600 dark:text-blue-400';
+}
 ```
 
 with:
 
 ```js
-		if (!isPredicted) {
-			// Scheduled (no real-time) arrivals read fully muted, per the mockup.
-			// gray-500 passes WCAG AA on white; gray-400 passes on the dark gray-800 surface.
-			return 'text-gray-500 dark:text-gray-400';
-		}
+if (!isPredicted) {
+	// Scheduled (no real-time) arrivals read fully muted, per the mockup.
+	// gray-500 passes WCAG AA on white; gray-400 passes on the dark gray-800 surface.
+	return 'text-gray-500 dark:text-gray-400';
+}
 ```
 
 - [ ] **Step 6: Make `computeTimeLabel` produce the compact form**
@@ -256,13 +260,13 @@ with:
 Replace the whole `computeTimeLabel` function (lines 191–201) with:
 
 ```js
-	function computeTimeLabel(eta) {
-		if (eta === 0) {
-			return $t('time.now');
-		}
-		// Compact minute form (e.g. "19m", "1m", "-3m"). Unit is localizable.
-		return $t('time.min_compact', { values: { n: eta } });
+function computeTimeLabel(eta) {
+	if (eta === 0) {
+		return $t('time.now');
 	}
+	// Compact minute form (e.g. "19m", "1m", "-3m"). Unit is localizable.
+	return $t('time.min_compact', { values: { n: eta } });
+}
 ```
 
 - [ ] **Step 7: Replace the markup**
@@ -318,10 +322,12 @@ git commit -m "feat: redesign ArrivalDeparture card with badge, compact ETA, and
 ### Task 3: `StopPane.svelte` — route-color plumbing + section header
 
 **Files:**
+
 - Modify: `src/components/stops/StopPane.svelte`
 - Test: `src/components/stops/__tests__/StopPane.test.js`
 
 **Interfaces:**
+
 - Consumes: `ArrivalDeparture`'s new `route` prop (Task 2).
 - Produces: renders an "ARRIVALS & DEPARTURES" header (i18n key `arrivals_and_departures`) above the accordion when arrivals exist; passes `route={routeById.get(arrival.routeId)}` to each `ArrivalDeparture`.
 
@@ -330,25 +336,25 @@ git commit -m "feat: redesign ArrivalDeparture card with badge, compact ETA, and
 In `src/components/stops/__tests__/StopPane.test.js`, add `arrivals_and_departures` to the local translations map (inside the `vi.mock('svelte-i18n', ...)` block, the `translations` object near line 113):
 
 ```js
-				const translations = {
-					stop: 'Stop',
-					routes: 'Routes',
-					arrivals_and_departures: 'Arrivals and departures',
-					'schedule_for_stop.view_schedule': 'View Schedule',
-					load_more_arrivals: 'Load more arrivals',
-					no_arrivals_found_in_next_minutes: 'No arrivals found in the next {minutes} minutes'
-				};
+const translations = {
+	stop: 'Stop',
+	routes: 'Routes',
+	arrivals_and_departures: 'Arrivals and departures',
+	'schedule_for_stop.view_schedule': 'View Schedule',
+	load_more_arrivals: 'Load more arrivals',
+	no_arrivals_found_in_next_minutes: 'No arrivals found in the next {minutes} minutes'
+};
 ```
 
 Then add a new test (place it after the existing "renders arrivals" style test, e.g. near line 270):
 
 ```js
-	test('renders the ARRIVALS & DEPARTURES section header when arrivals exist', async () => {
-		render(StopPane, { props: { stop: mockStopData } });
-		await waitFor(() => {
-			expect(screen.getByText('Arrivals and departures')).toBeInTheDocument();
-		});
+test('renders the ARRIVALS & DEPARTURES section header when arrivals exist', async () => {
+	render(StopPane, { props: { stop: mockStopData } });
+	await waitFor(() => {
+		expect(screen.getByText('Arrivals and departures')).toBeInTheDocument();
 	});
+});
 ```
 
 - [ ] **Step 2: Run the test to verify it fails**
@@ -361,13 +367,11 @@ Expected: FAIL — "Arrivals and departures" is not in the document yet.
 In `src/components/stops/StopPane.svelte`, just after the `routeShortNames` derived (line 159), add:
 
 ```js
-	// references.routes carries the per-route color/textColor; the arrival objects
-	// only carry routeId, so build a lookup to feed RouteBadge via ArrivalDeparture.
-	let routeById = $derived(
-		new Map(
-			(arrivalsAndDeparturesResponse?.data?.references?.routes ?? []).map((r) => [r.id, r])
-		)
-	);
+// references.routes carries the per-route color/textColor; the arrival objects
+// only carry routeId, so build a lookup to feed RouteBadge via ArrivalDeparture.
+let routeById = $derived(
+	new Map((arrivalsAndDeparturesResponse?.data?.references?.routes ?? []).map((r) => [r.id, r]))
+);
 ```
 
 - [ ] **Step 4: Add the section header and pass the route down**
@@ -429,11 +433,13 @@ git commit -m "feat: add arrivals section header and route colors to StopPane"
 ### Task 4: `TripDetailsPane.svelte` — live-vehicle heading + timeline restyle
 
 **Files:**
+
 - Modify: `src/locales/en.json` (add `trip_details.live_vehicle`)
 - Modify: `src/components/oba/TripDetailsPane.svelte` (heading, markers, imports)
 - Test: `src/components/oba/__tests__/TripDetailsPane.test.js` (new)
 
 **Interfaces:**
+
 - Consumes: nothing new.
 - Produces: heading shows "Live · vehicle {vehicleId}" (icon `faTowerBroadcast`) when `tripDetails.status?.vehicleId` is present; otherwise the existing route heading. Timeline markers: intermediate = empty ring, vehicle position = filled dark square with bus, your stop = filled pin.
 
@@ -531,7 +537,7 @@ Expected: FAIL — current heading renders `trip_details.route C Line`, not the 
 In `src/components/oba/TripDetailsPane.svelte`, change the icon import (line 4) to add the broadcast icon:
 
 ```js
-	import { faBus, faLocationDot, faCheck, faTowerBroadcast } from '@fortawesome/free-solid-svg-icons';
+import { faBus, faLocationDot, faCheck, faTowerBroadcast } from '@fortawesome/free-solid-svg-icons';
 ```
 
 - [ ] **Step 5: Replace the heading**
@@ -539,28 +545,28 @@ In `src/components/oba/TripDetailsPane.svelte`, change the icon import (line 4) 
 Replace the route-heading block (lines 101–106):
 
 ```svelte
-			{#if routeInfo}
-				<h2 class="h2">
-					{$_('trip_details.route')}
-					{routeInfo.shortName}
-				</h2>
-			{/if}
+{#if routeInfo}
+	<h2 class="h2">
+		{$_('trip_details.route')}
+		{routeInfo.shortName}
+	</h2>
+{/if}
 ```
 
 with a live-vehicle heading that falls back to the route heading:
 
 ```svelte
-			{#if tripDetails.status?.vehicleId}
-				<h2 class="h2 flex items-center gap-2">
-					<FontAwesomeIcon icon={faTowerBroadcast} class="text-brand" />
-					{$_('trip_details.live_vehicle', { values: { vehicleId: tripDetails.status.vehicleId } })}
-				</h2>
-			{:else if routeInfo}
-				<h2 class="h2">
-					{$_('trip_details.route')}
-					{routeInfo.shortName}
-				</h2>
-			{/if}
+{#if tripDetails.status?.vehicleId}
+	<h2 class="h2 flex items-center gap-2">
+		<FontAwesomeIcon icon={faTowerBroadcast} class="text-brand" />
+		{$_('trip_details.live_vehicle', { values: { vehicleId: tripDetails.status.vehicleId } })}
+	</h2>
+{:else if routeInfo}
+	<h2 class="h2">
+		{$_('trip_details.route')}
+		{routeInfo.shortName}
+	</h2>
+{/if}
 ```
 
 - [ ] **Step 6: Restyle the timeline markers**
@@ -568,39 +574,39 @@ with a live-vehicle heading that falls back to the route heading:
 Replace the marker `<div>` (lines 113–134, the `relative flex size-8 ...` block and its icon logic) with mockup-style markers — filled dark square + bus at the vehicle position, filled pin at your stop, empty ring otherwise:
 
 ```svelte
-						{#if index === busPosition}
-							<div
-								class="relative flex size-8 items-center justify-center rounded-md bg-neutral-800 dark:bg-neutral-200"
-							>
-								<FontAwesomeIcon icon={faBus} class="text-sm text-white dark:text-neutral-900" />
-								{#if tripStop.stopId === stop.id}
-									<FontAwesomeIcon
-										icon={faCheck}
-										class="absolute -right-1 -top-1 rounded-full border border-white bg-brand p-1 text-xs text-white"
-									/>
-								{/if}
-							</div>
-						{:else if tripStop.stopId === stop.id}
-							<div class="flex size-8 items-center justify-center">
-								<FontAwesomeIcon icon={faLocationDot} class="text-xl text-brand-accent" />
-							</div>
-						{:else}
-							<div class="flex size-8 items-center justify-center">
-								<div class="size-4 rounded-full border-2 border-neutral-400 bg-white dark:bg-neutral-800"></div>
-							</div>
-						{/if}
+{#if index === busPosition}
+	<div
+		class="relative flex size-8 items-center justify-center rounded-md bg-neutral-800 dark:bg-neutral-200"
+	>
+		<FontAwesomeIcon icon={faBus} class="text-sm text-white dark:text-neutral-900" />
+		{#if tripStop.stopId === stop.id}
+			<FontAwesomeIcon
+				icon={faCheck}
+				class="absolute -right-1 -top-1 rounded-full border border-white bg-brand p-1 text-xs text-white"
+			/>
+		{/if}
+	</div>
+{:else if tripStop.stopId === stop.id}
+	<div class="flex size-8 items-center justify-center">
+		<FontAwesomeIcon icon={faLocationDot} class="text-xl text-brand-accent" />
+	</div>
+{:else}
+	<div class="flex size-8 items-center justify-center">
+		<div class="size-4 rounded-full border-2 border-neutral-400 bg-white dark:bg-neutral-800"></div>
+	</div>
+{/if}
 ```
 
 Then, so the "your stop" row reads as the emphasized destination (mockup bold), update the stop-name `<div>` (line 136) to bold your stop:
 
 ```svelte
-							<div
-								class="text-md dark:text-white"
-								class:font-bold={tripStop.stopId === stop.id}
-								class:font-semibold={tripStop.stopId !== stop.id}
-							>
-								{stopInfo[tripStop.stopId] ? stopInfo[tripStop.stopId].name : tripStop.stopId}
-							</div>
+<div
+	class="text-md dark:text-white"
+	class:font-bold={tripStop.stopId === stop.id}
+	class:font-semibold={tripStop.stopId !== stop.id}
+>
+	{stopInfo[tripStop.stopId] ? stopInfo[tripStop.stopId].name : tripStop.stopId}
+</div>
 ```
 
 - [ ] **Step 7: Run the test to verify it passes**

--- a/docs/superpowers/specs/2026-07-22-arrival-departure-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-22-arrival-departure-redesign-design.md
@@ -1,0 +1,129 @@
+# Stop UI Redesign — Arrival/Departure Cards, Section Header, Trip Timeline
+
+**Date:** 2026-07-22
+**Branch:** `arrival-departure-cards`
+
+## Goal
+
+Redesign the stop pane's arrivals/departures UI to match the provided mockup:
+a route badge, a bold headsign with a colored `time · status` sub-line, a large
+compact ETA with a live/schedule icon, and a restyled trip-detail timeline. The
+condensed sheet header already matches the mockup and is left unchanged.
+
+## Scope
+
+In scope:
+
+- New reusable `RouteBadge.svelte` component.
+- Redesign `ArrivalDeparture.svelte` layout, ETA format, and scheduled-color.
+- Add an "ARRIVALS & DEPARTURES" section header in `StopPane.svelte`.
+- Restyle `TripDetailsPane.svelte` timeline and heading.
+
+Out of scope (unchanged):
+
+- `StopBottomSheet.svelte` / `StopPageHeader.svelte` headers — the sheet header
+  already matches the mockup. (Noted discrepancy: the mockup subtitle shows the
+  stop direction "SW bound", which the sheet omits today. Left as-is per the
+  scope decision.)
+- The accordion chevron and row dividers — already provided by
+  `AccordionItem.svelte` / `SingleSelectAccordion.svelte`.
+- Data fetching / polling.
+- A "Past · N" counter shown at the top-right of the section header in the
+  mockup — **deferred** to a separate change.
+
+## Components
+
+### 1. `src/components/RouteBadge.svelte` (new)
+
+A rounded-square colored badge rendering a route short name.
+
+- **Props:** `shortName` (string), `color` (hex string without `#`, optional),
+  `textColor` (hex string without `#`, optional).
+- **Background:** `#{color}` when present, otherwise a dark slate fallback
+  (`#374151`). This yields the red RapidRide C Line and the dark numbered
+  routes from the mockup.
+- **Text color:** `#{textColor}` when present, otherwise white.
+- **Layout:** `rounded-lg`, fixed size (~`w-16 h-14`), centered, bold, text
+  wraps so "C Line" stacks onto two lines like the mockup.
+- **Dark mode:** the badge is a self-colored block with contrasting text, so it
+  reads correctly in both light and dark mode without overrides.
+
+### 2. `src/components/ArrivalDeparture.svelte` (redesign)
+
+New full-width flex row (the accordion renders its chevron immediately after):
+
+```
+[RouteBadge] | headsign (bold) + "time · status" | big ETA + live/clock icon
+```
+
+- **Headsign:** bold, `text-gray-900 dark:text-white`.
+- **Sub-line:** clock time (e.g. `11:48 AM`) in gray, a `·` separator, then the
+  status text in the status color.
+- **Big ETA:** compact `{n}m` format (e.g. `19m`) — replaces today's `19 mins`.
+  `text-3xl font-bold`, in the status color.
+- **Superscript icon** beside the ETA: `faTowerBroadcast` for real-time
+  (predicted) arrivals; `faClock` for schedule-only arrivals.
+
+**Status color rule (`computeColor`):**
+
+- Not predicted (scheduled) → **gray** (`text-gray-400`/`text-gray-500`),
+  changed from today's blue, so scheduled rows read fully muted per the mockup.
+- Predicted, late (`delay > 0`) → violet (`text-violet-600 dark:text-violet-400`).
+- Predicted, early (`delay < -1`) → red (`text-red-600 dark:text-red-400`).
+- Predicted, on time → green (`text-green-600 dark:text-green-400`).
+
+All existing logic — `computeStatusLabel`, frequency handling, canceled trips,
+arrival-vs-departure selection, i18n strings — is preserved. Only presentation,
+the scheduled color, and the compact ETA change.
+
+**Compact ETA format:** a new label form producing `{n}m`. Negative/`now`/`1m`
+edge cases handled the same way as today's minute logic, just abbreviated.
+
+### 3. `src/components/stops/StopPane.svelte`
+
+- Build a `routeId → route` lookup from
+  `arrivalsAndDeparturesResponse.data.references.routes` and pass the matched
+  route's `color` and `textColor` into each `ArrivalDeparture` (the arrival
+  object itself carries no color).
+- Add an **"ARRIVALS & DEPARTURES"** section header above the accordion:
+  uppercase, letter-spaced, semibold, muted gray. Use an existing/appropriate
+  i18n key. No "Past · N" counter (deferred).
+
+### 4. `src/components/oba/TripDetailsPane.svelte`
+
+- Heading becomes **"Live · vehicle {vehicleId}"** with a broadcast icon when a
+  real-time vehicle is present (`tripDetails.status.vehicleId`); otherwise a
+  schedule-oriented fallback heading.
+- Timeline markers restyled to the mockup:
+  - intermediate stop → empty ring circle,
+  - vehicle current position → filled dark rounded-square with bus icon,
+  - your stop → filled location pin, row text bold.
+- Stop times remain right-aligned and gray.
+
+## Data Flow
+
+`StopPane.loadData()` already stores the full response
+(`arrivalsAndDeparturesResponse`). Route colors come from
+`data.references.routes[]` (fields `id`, `color`, `textColor`), joined to each
+arrival by `routeId`. No API or fetch changes.
+
+## Testing
+
+- **`RouteBadge`:** renders short name; uses `#{color}` background when present;
+  dark slate fallback when absent; `#{textColor}` vs white text.
+- **`ArrivalDeparture`:** updated for new markup, compact `{n}m` ETA, and the
+  scheduled→gray color change (fix the existing blue assertion); real-time icon
+  vs clock icon; status color per delay.
+- **`StopPane`:** section-header label renders; route color is passed to the
+  badge.
+- **`TripDetailsPane`:** "Live · vehicle {id}" heading appears when a vehicle is
+  present; timeline markers render for the three states.
+
+## Risks / Notes
+
+- Changing the scheduled color from blue to gray and the ETA from `19 mins` to
+  `19m` will break existing `ArrivalDeparture` test assertions; those tests are
+  updated as part of this work.
+- `StopPane` couples fetching, hero card, surveys, and alerts in one file. This
+  change adds only the route-color map and the section header; no broader
+  refactor is undertaken.

--- a/docs/superpowers/specs/2026-07-22-arrival-departure-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-22-arrival-departure-redesign-design.md
@@ -48,14 +48,18 @@ A rounded-square colored badge rendering a route short name.
   build time and would emit no rule, rendering the badge unstyled. Use the same
   pattern as `RouteItem.svelte:29-30`:
   ```svelte
-  let bg = $derived(color ? `#${color}` : '#374151');
-  let fg = $derived(textColor ? `#${textColor}` : '#ffffff');
-  <div class="flex h-14 w-16 items-center justify-center rounded-lg text-center font-bold leading-tight break-words"
-       style="background-color: {bg}; color: {fg};">{shortName}</div>
+  let bg = $derived(color ? `#${color}` : '#374151'); let fg = $derived(textColor ? `#${textColor}`
+  : '#ffffff');
+  <div
+  	class="flex h-14 w-16 items-center justify-center break-words rounded-lg text-center font-bold leading-tight"
+  	style="background-color: {bg}; color: {fg};"
+  >
+  	{shortName}
+  </div>
   ```
 - **Layout:** `rounded-lg`, fixed size (~`w-16 h-14`), centered, bold. `leading-tight`
-  + `break-words` so "C Line" stacks onto two lines and longer `shortName` values
-  degrade gracefully instead of overflowing the box.
+  - `break-words` so "C Line" stacks onto two lines and longer `shortName` values
+    degrade gracefully instead of overflowing the box.
 - **Dark mode:** the badge is a self-colored block with contrasting text, so it
   reads correctly in both light and dark mode without overrides. Raw route colors
   are used as-is (not dark-adjusted like `RouteItem`); rely on the API `textColor`

--- a/docs/superpowers/specs/2026-07-22-arrival-departure-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-22-arrival-departure-redesign-design.md
@@ -69,7 +69,7 @@ A rounded-square colored badge rendering a route short name.
 
 New full-width flex row (the accordion renders its chevron immediately after):
 
-```
+```text
 [RouteBadge] | headsign (bold) + "time · status" | big ETA + live/clock icon
 ```
 

--- a/docs/superpowers/specs/2026-07-22-arrival-departure-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-22-arrival-departure-redesign-design.md
@@ -43,10 +43,23 @@ A rounded-square colored badge rendering a route short name.
   (`#374151`). This yields the red RapidRide C Line and the dark numbered
   routes from the mockup.
 - **Text color:** `#{textColor}` when present, otherwise white.
-- **Layout:** `rounded-lg`, fixed size (~`w-16 h-14`), centered, bold, text
-  wraps so "C Line" stacks onto two lines like the mockup.
+- **Applied via inline `style`, NOT Tailwind arbitrary classes.** Dynamic runtime
+  hex values cannot go in `class="bg-[#{color}]"` — Tailwind generates classes at
+  build time and would emit no rule, rendering the badge unstyled. Use the same
+  pattern as `RouteItem.svelte:29-30`:
+  ```svelte
+  let bg = $derived(color ? `#${color}` : '#374151');
+  let fg = $derived(textColor ? `#${textColor}` : '#ffffff');
+  <div class="flex h-14 w-16 items-center justify-center rounded-lg text-center font-bold leading-tight break-words"
+       style="background-color: {bg}; color: {fg};">{shortName}</div>
+  ```
+- **Layout:** `rounded-lg`, fixed size (~`w-16 h-14`), centered, bold. `leading-tight`
+  + `break-words` so "C Line" stacks onto two lines and longer `shortName` values
+  degrade gracefully instead of overflowing the box.
 - **Dark mode:** the badge is a self-colored block with contrasting text, so it
-  reads correctly in both light and dark mode without overrides.
+  reads correctly in both light and dark mode without overrides. Raw route colors
+  are used as-is (not dark-adjusted like `RouteItem`); rely on the API `textColor`
+  for contrast, with the `#374151`/white fallback used only when `color` is absent.
 
 ### 2. `src/components/ArrivalDeparture.svelte` (redesign)
 
@@ -62,12 +75,19 @@ New full-width flex row (the accordion renders its chevron immediately after):
 - **Big ETA:** compact `{n}m` format (e.g. `19m`) — replaces today's `19 mins`.
   `text-3xl font-bold`, in the status color.
 - **Superscript icon** beside the ETA: `faTowerBroadcast` for real-time
-  (predicted) arrivals; `faClock` for schedule-only arrivals.
+  (predicted) arrivals; `faClock` for schedule-only arrivals. Both imported from
+  `@fortawesome/free-solid-svg-icons` — `faTowerBroadcast` exists **only** in
+  free-solid, so import both from solid for a consistent stroke weight:
+  `import { faTowerBroadcast, faClock } from '@fortawesome/free-solid-svg-icons';`
 
 **Status color rule (`computeColor`):**
 
-- Not predicted (scheduled) → **gray** (`text-gray-400`/`text-gray-500`),
+- Not predicted (scheduled) → **gray**, `text-gray-500 dark:text-gray-400`,
   changed from today's blue, so scheduled rows read fully muted per the mockup.
+  (Must NOT use `text-gray-400` in light mode — ~2.9:1 on white fails WCAG AA;
+  `gray-500` ≈ 4.8:1 passes, and `gray-400` passes on the dark `gray-800`
+  surface, mirroring the existing 600/400 pairing documented at
+  `ArrivalDeparture.svelte:18-21`.)
 - Predicted, late (`delay > 0`) → violet (`text-violet-600 dark:text-violet-400`).
 - Predicted, early (`delay < -1`) → red (`text-red-600 dark:text-red-400`).
 - Predicted, on time → green (`text-green-600 dark:text-green-400`).
@@ -76,24 +96,31 @@ All existing logic — `computeStatusLabel`, frequency handling, canceled trips,
 arrival-vs-departure selection, i18n strings — is preserved. Only presentation,
 the scheduled color, and the compact ETA change.
 
-**Compact ETA format:** a new label form producing `{n}m`. Negative/`now`/`1m`
-edge cases handled the same way as today's minute logic, just abbreviated.
+**Compact ETA format:** a new label form producing `{n}m`. The `m` unit must be
+localizable — add an i18n key (e.g. `time.min_compact: "{n}m"`) and interpolate,
+rather than string-concatenating a literal `m`. Keep the `now` / `1m` / negative
+branches routing through i18n as today (`time.now`, etc.).
 
 ### 3. `src/components/stops/StopPane.svelte`
 
 - Build a `routeId → route` lookup from
-  `arrivalsAndDeparturesResponse.data.references.routes` and pass the matched
-  route's `color` and `textColor` into each `ArrivalDeparture` (the arrival
-  object itself carries no color).
+  `arrivalsAndDeparturesResponse.data.references.routes` as a **`$derived`** value
+  (`let routeById = $derived(new Map(...))`), NOT written into `$state` from an
+  `$effect` — that Svelte 5 anti-pattern would go stale against the 30s poll.
+  Pass the matched route's `color` and `textColor` into each `ArrivalDeparture`
+  (the arrival object itself carries no color).
 - Add an **"ARRIVALS & DEPARTURES"** section header above the accordion:
-  uppercase, letter-spaced, semibold, muted gray. Use an existing/appropriate
-  i18n key. No "Past · N" counter (deferred).
+  uppercase, letter-spaced, semibold, muted gray. Reuse the existing
+  `arrivals_and_departures` i18n key (`en.json:127`) and apply
+  `uppercase tracking-wide` in markup — do not duplicate an all-caps string. No
+  "Past · N" counter (deferred).
 
 ### 4. `src/components/oba/TripDetailsPane.svelte`
 
-- Heading becomes **"Live · vehicle {vehicleId}"** with a broadcast icon when a
-  real-time vehicle is present (`tripDetails.status.vehicleId`); otherwise a
-  schedule-oriented fallback heading.
+- Heading becomes **"Live · vehicle {vehicleId}"** with a `faTowerBroadcast` icon
+  when a real-time vehicle is present (`tripDetails.status.vehicleId`); otherwise
+  a schedule-oriented fallback heading. Add a new interpolated i18n key under the
+  existing `vehicle.*` namespace (`en.json:148-154`) — do not hardcode the string.
 - Timeline markers restyled to the mockup:
   - intermediate stop → empty ring circle,
   - vehicle current position → filled dark rounded-square with bus icon,
@@ -119,11 +146,21 @@ arrival by `routeId`. No API or fetch changes.
 - **`TripDetailsPane`:** "Live · vehicle {id}" heading appears when a vehicle is
   present; timeline markers render for the three states.
 
+## i18n keys
+
+- **Reuse:** `arrivals_and_departures` (`en.json:127`) for the section header.
+- **Add:** `time.min_compact` = `"{n}m"` for the compact ETA.
+- **Add:** a new interpolated key under `vehicle.*` for "Live · vehicle {id}".
+- New keys go into `src/locales/en.json` (the synchronous fallback locale);
+  other locales fall back to English until translated.
+
 ## Risks / Notes
 
 - Changing the scheduled color from blue to gray and the ETA from `19 mins` to
   `19m` will break existing `ArrivalDeparture` test assertions; those tests are
   updated as part of this work.
+- Contrast: scheduled gray uses `text-gray-500 dark:text-gray-400` (WCAG AA
+  safe); `text-gray-400` must not be used in light mode.
 - `StopPane` couples fetching, hero card, surveys, and alerts in one file. This
   change adds only the route-color map and the section header; no broader
   refactor is undertaken.

--- a/src/components/ArrivalDeparture.svelte
+++ b/src/components/ArrivalDeparture.svelte
@@ -19,9 +19,11 @@
 	let stopSequence = $derived(arrivalDeparture.stopSequence || 1); // Default to 1 if not provided
 
 	function computeColor(scheduledMins, predictedMins, isPredicted) {
-		// Each branch returns the 600 shade for light mode (passes WCAG AA on
-		// white) paired with 400 shade in dark mode (passes on gray-800)
-		// The 500 shade fails 4.5:1 in both modes for normal size status text
+		// Each colored branch returns the 600 shade for light mode (passes WCAG AA
+		// on white) paired with the 400 shade in dark mode (passes on gray-800).
+		// The colored 500 shades fail 4.5:1 in both modes for normal-size status
+		// text — the neutral gray-500/400 below is the exception (gray-500 ≈ 4.8:1
+		// on white, gray-400 passes on gray-800), so it's safe here.
 		if (!isPredicted) {
 			// Scheduled (no real-time) arrivals read fully muted, per the mockup.
 			// gray-500 passes WCAG AA on white; gray-400 passes on the dark gray-800 surface.

--- a/src/components/ArrivalDeparture.svelte
+++ b/src/components/ArrivalDeparture.svelte
@@ -4,7 +4,12 @@
 	import RouteBadge from '$components/RouteBadge.svelte';
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 	import { faTowerBroadcast, faClock } from '@fortawesome/free-solid-svg-icons';
-	let { arrivalDeparture, includeArrivalDepartureInStatusLabel = true, route = null } = $props();
+	let {
+		arrivalDeparture,
+		includeArrivalDepartureInStatusLabel = true,
+		route = null,
+		expanded = false
+	} = $props();
 
 	const MS_IN_MINS = 60000;
 
@@ -231,11 +236,25 @@
 		</p>
 	</div>
 
-	<div class="flex shrink-0 items-start gap-0.5">
-		<span class="text-xl font-bold leading-none {arrivalInfo.color}">{arrivalInfo.timeText}</span>
-		<FontAwesomeIcon
-			icon={arrivalInfo.isPredicted ? faTowerBroadcast : faClock}
-			class="text-xs {arrivalInfo.color}"
-		/>
+	<div class="flex shrink-0 flex-col items-center gap-1">
+		<div class="flex items-start gap-0.5">
+			<span class="text-xl font-bold leading-none {arrivalInfo.color}">{arrivalInfo.timeText}</span>
+			<FontAwesomeIcon
+				icon={arrivalInfo.isPredicted ? faTowerBroadcast : faClock}
+				class="text-xs {arrivalInfo.color}"
+			/>
+		</div>
+		<!-- Expand/collapse chevron, stacked under the ETA (AccordionItem's own
+		     chevron is hidden via hideChevron). -->
+		<svg
+			class="h-5 w-5 text-gray-500 transition-transform dark:text-gray-400"
+			class:rotate-180={expanded}
+			fill="none"
+			stroke="currentColor"
+			viewBox="0 0 24 24"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+		</svg>
 	</div>
 </div>

--- a/src/components/ArrivalDeparture.svelte
+++ b/src/components/ArrivalDeparture.svelte
@@ -220,7 +220,7 @@
 	<RouteBadge shortName={routeShortName} color={route?.color} textColor={route?.textColor} />
 
 	<div class="min-w-0 flex-1">
-		<p class="truncate text-lg font-semibold text-gray-900 dark:text-white">
+		<p class="line-clamp-2 text-lg font-semibold text-gray-900 dark:text-white">
 			{tripHeadsign}
 		</p>
 		<p class="truncate text-sm">
@@ -232,7 +232,7 @@
 	</div>
 
 	<div class="flex shrink-0 items-start gap-0.5">
-		<span class="text-3xl font-bold leading-none {arrivalInfo.color}">{arrivalInfo.timeText}</span>
+		<span class="text-xl font-bold leading-none {arrivalInfo.color}">{arrivalInfo.timeText}</span>
 		<FontAwesomeIcon
 			icon={arrivalInfo.isPredicted ? faTowerBroadcast : faClock}
 			class="text-xs {arrivalInfo.color}"

--- a/src/components/ArrivalDeparture.svelte
+++ b/src/components/ArrivalDeparture.svelte
@@ -225,9 +225,8 @@
 		</p>
 		<p class="truncate text-sm">
 			<span class="text-gray-500 dark:text-gray-400"
-				>{msToLocalArrivalDepartureTimeString(arrivalInfo.displayTime)}</span
+				>{msToLocalArrivalDepartureTimeString(arrivalInfo.displayTime)} ·</span
 			>
-			<span class="text-gray-500 dark:text-gray-400"> · </span>
 			<span class={arrivalInfo.color}>{arrivalInfo.statusText}</span>
 		</p>
 	</div>

--- a/src/components/ArrivalDeparture.svelte
+++ b/src/components/ArrivalDeparture.svelte
@@ -216,7 +216,7 @@
 	let arrivalInfo = $derived(computeArrivalInfo(currentTime));
 </script>
 
-<div class="flex items-center gap-3">
+<div class="flex w-full min-w-0 items-center gap-3 pr-1">
 	<RouteBadge shortName={routeShortName} color={route?.color} textColor={route?.textColor} />
 
 	<div class="min-w-0 flex-1">

--- a/src/components/ArrivalDeparture.svelte
+++ b/src/components/ArrivalDeparture.svelte
@@ -1,7 +1,10 @@
 <script>
 	import { t } from 'svelte-i18n';
 	import { msToLocalArrivalDepartureTimeString } from '$lib/dateTimeFormat';
-	let { arrivalDeparture, includeArrivalDepartureInStatusLabel = true } = $props();
+	import RouteBadge from '$components/RouteBadge.svelte';
+	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
+	import { faTowerBroadcast, faClock } from '@fortawesome/free-solid-svg-icons';
+	let { arrivalDeparture, includeArrivalDepartureInStatusLabel = true, route = null } = $props();
 
 	const MS_IN_MINS = 60000;
 
@@ -20,7 +23,9 @@
 		// white) paired with 400 shade in dark mode (passes on gray-800)
 		// The 500 shade fails 4.5:1 in both modes for normal size status text
 		if (!isPredicted) {
-			return 'text-blue-600 dark:text-blue-400';
+			// Scheduled (no real-time) arrivals read fully muted, per the mockup.
+			// gray-500 passes WCAG AA on white; gray-400 passes on the dark gray-800 surface.
+			return 'text-gray-500 dark:text-gray-400';
 		}
 
 		const delay = predictedMins - scheduledMins;
@@ -189,15 +194,11 @@
 	}
 
 	function computeTimeLabel(eta) {
-		if (eta < 0) {
-			return `${eta} ${$t('time.min')}`;
-		} else if (eta === 0) {
+		if (eta === 0) {
 			return $t('time.now');
-		} else if (eta === 1) {
-			return `1 ${$t('time.min')}`;
-		} else {
-			return `${eta} ${$t('time.mins')}`;
 		}
+		// Compact minute form (e.g. "19m", "1m", "-3m"). Unit is localizable.
+		return $t('time.min_compact', { values: { n: eta } });
 	}
 
 	let currentTime = $state(Date.now());
@@ -213,19 +214,27 @@
 	let arrivalInfo = $derived(computeArrivalInfo(currentTime));
 </script>
 
-<div class="flex flex-col gap-1">
-	<p class="text-left text-xl font-semibold text-black dark:text-white">
-		{routeShortName} - {tripHeadsign}
-	</p>
-	<p class="text-left font-semibold text-black dark:text-white">
-		<span class="text-md">{msToLocalArrivalDepartureTimeString(arrivalInfo.displayTime)}</span> -
-		<span class={arrivalInfo.color}>
-			{arrivalInfo.statusText}
-		</span>
-	</p>
-</div>
-<div>
-	<p class="text-lg font-semibold {arrivalInfo.color}">
-		{arrivalInfo.timeText}
-	</p>
+<div class="flex items-center gap-3">
+	<RouteBadge shortName={routeShortName} color={route?.color} textColor={route?.textColor} />
+
+	<div class="min-w-0 flex-1">
+		<p class="truncate text-lg font-semibold text-gray-900 dark:text-white">
+			{tripHeadsign}
+		</p>
+		<p class="truncate text-sm">
+			<span class="text-gray-500 dark:text-gray-400"
+				>{msToLocalArrivalDepartureTimeString(arrivalInfo.displayTime)}</span
+			>
+			<span class="text-gray-500 dark:text-gray-400"> · </span>
+			<span class={arrivalInfo.color}>{arrivalInfo.statusText}</span>
+		</p>
+	</div>
+
+	<div class="flex shrink-0 items-start gap-0.5">
+		<span class="text-3xl font-bold leading-none {arrivalInfo.color}">{arrivalInfo.timeText}</span>
+		<FontAwesomeIcon
+			icon={arrivalInfo.isPredicted ? faTowerBroadcast : faClock}
+			class="text-xs {arrivalInfo.color}"
+		/>
+	</div>
 </div>

--- a/src/components/RouteBadge.svelte
+++ b/src/components/RouteBadge.svelte
@@ -1,0 +1,21 @@
+<script>
+	/**
+	 * @typedef {Object} Props
+	 * @property {string} shortName - Route short name (e.g. "C Line", "21")
+	 * @property {string} [color] - Route color as a hex string without "#" (from references.routes)
+	 * @property {string} [textColor] - Route text color as a hex string without "#"
+	 */
+
+	/** @type {Props} */
+	let { shortName, color = null, textColor = null } = $props();
+
+	let bg = $derived(color ? `#${color}` : '#374151');
+	let fg = $derived(textColor ? `#${textColor}` : '#ffffff');
+</script>
+
+<div
+	class="flex h-14 w-16 shrink-0 items-center justify-center break-words rounded-lg px-1 text-center text-sm font-bold leading-tight"
+	style="background-color: {bg}; color: {fg};"
+>
+	{shortName}
+</div>

--- a/src/components/RouteBadge.svelte
+++ b/src/components/RouteBadge.svelte
@@ -11,11 +11,21 @@
 
 	let bg = $derived(color ? `#${color}` : '#374151');
 	let fg = $derived(textColor ? `#${textColor}` : '#ffffff');
+
+	// Auto-shrink the label so long names (e.g. "Waterfront Shuttle") fit the
+	// fixed badge box. The text wraps on spaces, so the constraint is the longest
+	// word; short codes ("10", "C Line") stay at the base 14px size.
+	let longestWord = $derived(
+		String(shortName ?? '')
+			.split(/\s+/)
+			.reduce((max, word) => Math.max(max, word.length), 1)
+	);
+	let fontSize = $derived(Math.max(8, Math.min(14, Math.round(90 / longestWord))));
 </script>
 
 <div
-	class="flex h-14 w-16 shrink-0 items-center justify-center break-words rounded-lg px-1 text-center text-sm font-bold leading-tight"
-	style="background-color: {bg}; color: {fg};"
+	class="flex h-14 w-16 shrink-0 items-center justify-center break-words rounded-lg px-1 text-center font-bold leading-tight"
+	style="background-color: {bg}; color: {fg}; font-size: {fontSize}px;"
 >
 	{shortName}
 </div>

--- a/src/components/__tests__/ArrivalDeparture.test.js
+++ b/src/components/__tests__/ArrivalDeparture.test.js
@@ -96,4 +96,21 @@ describe('ArrivalDeparture', () => {
 		expect(eta.className).toContain('text-xl');
 		expect(eta.className).not.toContain('text-3xl');
 	});
+
+	test('renders its own chevron that rotates only when expanded', async () => {
+		// the chevron is the plain svg with `transition-transform` (not a FontAwesome icon)
+		const chevronOf = (container) =>
+			[...container.querySelectorAll('svg')].find((s) =>
+				s.getAttribute('class')?.includes('transition-transform')
+			);
+
+		const { container, rerender } = render(ArrivalDeparture, {
+			props: { arrivalDeparture: baseArrival(), expanded: false }
+		});
+		expect(chevronOf(container)).toBeTruthy();
+		expect(chevronOf(container).getAttribute('class')).not.toContain('rotate-180');
+
+		await rerender({ arrivalDeparture: baseArrival(), expanded: true });
+		expect(chevronOf(container).getAttribute('class')).toContain('rotate-180');
+	});
 });

--- a/src/components/__tests__/ArrivalDeparture.test.js
+++ b/src/components/__tests__/ArrivalDeparture.test.js
@@ -72,20 +72,28 @@ describe('ArrivalDeparture', () => {
 		expect(eta.className).toContain('text-gray-500');
 	});
 
-	// Regression guard for the overflow bug: a long headsign must truncate rather
-	// than push the ETA off the container. The row must fill its flex parent
-	// (w-full) and be shrinkable (min-w-0) so the truncation actually engages.
-	test('fills width and truncates a long headsign so content cannot overflow', () => {
+	// Regression guard for the overflow bug: a long headsign must wrap to a
+	// second line (and clamp/shrink after) rather than push the ETA off the
+	// container. The row must fill its flex parent (w-full) and be shrinkable
+	// (min-w-0) so the layout can't overflow.
+	test('fills width and clamps a long headsign so content cannot overflow', () => {
 		render(ArrivalDeparture, {
 			props: { arrivalDeparture: baseArrival({ tripHeadsign: 'Aurora Village Transit Center' }) }
 		});
 		const headsign = screen.getByText('Aurora Village Transit Center');
-		// headsign itself truncates, and its column can shrink below content width
-		expect(headsign.className).toContain('truncate');
+		// headsign wraps to a second line then clamps, and its column can shrink
+		expect(headsign.className).toContain('line-clamp-2');
 		expect(headsign.parentElement.className).toContain('min-w-0');
 		// the card row fills the available width and is itself shrinkable
 		const row = headsign.closest('div.flex');
 		expect(row.className).toContain('w-full');
 		expect(row.className).toContain('min-w-0');
+	});
+
+	test('renders the ETA at text-xl (not the oversized text-3xl)', () => {
+		render(ArrivalDeparture, { props: { arrivalDeparture: baseArrival() } });
+		const eta = screen.getByText('10m');
+		expect(eta.className).toContain('text-xl');
+		expect(eta.className).not.toContain('text-3xl');
 	});
 });

--- a/src/components/__tests__/ArrivalDeparture.test.js
+++ b/src/components/__tests__/ArrivalDeparture.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/svelte';
-import { expect, test, describe, vi } from 'vitest';
+import { expect, test, describe, vi, beforeEach, afterEach } from 'vitest';
 
 // Local i18n mock that interpolates {name} values (the global setup mock returns keys).
 // A small dictionary stands in for en.json's format strings so interpolated keys
@@ -48,6 +48,18 @@ function baseArrival(overrides = {}) {
 }
 
 describe('ArrivalDeparture', () => {
+	// Freeze the clock so baseArrival() and the component derive their ETA from
+	// the same "now" -- otherwise a minute rollover between the two Date.now()
+	// calls could flip an exact assertion (e.g. "10m" -> "9m"). Only Date is
+	// faked; real timers are left alone so async rendering still works.
+	beforeEach(() => {
+		vi.useFakeTimers({ toFake: ['Date'] });
+		vi.setSystemTime(new Date('2026-07-22T12:00:00Z'));
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	test('renders the headsign and a route badge with the short name', () => {
 		render(ArrivalDeparture, {
 			props: { arrivalDeparture: baseArrival(), route: { color: 'FF0000', textColor: 'FFFFFF' } }

--- a/src/components/__tests__/ArrivalDeparture.test.js
+++ b/src/components/__tests__/ArrivalDeparture.test.js
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/svelte';
+import { expect, test, describe, vi } from 'vitest';
+
+// Local i18n mock that interpolates {name} values (the global setup mock returns keys).
+// A small dictionary stands in for en.json's format strings so interpolated keys
+// (like time.min_compact -> "{n}m") render real text instead of the raw key.
+vi.mock('svelte-i18n', () => {
+	const messages = {
+		'time.now': 'now',
+		'time.min_compact': '{n}m'
+	};
+	return {
+		t: {
+			subscribe: (fn) => {
+				fn((key, options) => {
+					let str = messages[key] ?? key;
+					if (options?.values) {
+						for (const [name, value] of Object.entries(options.values)) {
+							str = str.replace(`{${name}}`, value);
+						}
+					}
+					return str;
+				});
+				return () => {};
+			}
+		}
+	};
+});
+
+import ArrivalDeparture from '../ArrivalDeparture.svelte';
+
+const MIN = 60000;
+
+function baseArrival(overrides = {}) {
+	return {
+		routeShortName: '10',
+		tripHeadsign: 'Downtown Seattle',
+		stopSequence: 1,
+		predicted: true,
+		scheduledArrivalTime: Date.now() + 10 * MIN,
+		predictedArrivalTime: Date.now() + 10 * MIN,
+		scheduledDepartureTime: Date.now() + 10 * MIN,
+		predictedDepartureTime: Date.now() + 10 * MIN,
+		tripStatus: null,
+		frequency: null,
+		...overrides
+	};
+}
+
+describe('ArrivalDeparture', () => {
+	test('renders the headsign and a route badge with the short name', () => {
+		render(ArrivalDeparture, {
+			props: { arrivalDeparture: baseArrival(), route: { color: 'FF0000', textColor: 'FFFFFF' } }
+		});
+		expect(screen.getByText('Downtown Seattle')).toBeInTheDocument();
+		const badge = screen.getByText('10');
+		expect(badge).toHaveStyle('background-color: #FF0000');
+	});
+
+	test('renders a compact ETA like "10m"', () => {
+		render(ArrivalDeparture, { props: { arrivalDeparture: baseArrival() } });
+		expect(screen.getByText('10m')).toBeInTheDocument();
+	});
+
+	test('uses gray for scheduled (not predicted) arrivals', () => {
+		render(ArrivalDeparture, {
+			props: {
+				arrivalDeparture: baseArrival({ predicted: false, predictedArrivalTime: null })
+			}
+		});
+		const eta = screen.getByText('10m');
+		expect(eta.className).toContain('text-gray-500');
+	});
+});

--- a/src/components/__tests__/ArrivalDeparture.test.js
+++ b/src/components/__tests__/ArrivalDeparture.test.js
@@ -71,4 +71,21 @@ describe('ArrivalDeparture', () => {
 		const eta = screen.getByText('10m');
 		expect(eta.className).toContain('text-gray-500');
 	});
+
+	// Regression guard for the overflow bug: a long headsign must truncate rather
+	// than push the ETA off the container. The row must fill its flex parent
+	// (w-full) and be shrinkable (min-w-0) so the truncation actually engages.
+	test('fills width and truncates a long headsign so content cannot overflow', () => {
+		render(ArrivalDeparture, {
+			props: { arrivalDeparture: baseArrival({ tripHeadsign: 'Aurora Village Transit Center' }) }
+		});
+		const headsign = screen.getByText('Aurora Village Transit Center');
+		// headsign itself truncates, and its column can shrink below content width
+		expect(headsign.className).toContain('truncate');
+		expect(headsign.parentElement.className).toContain('min-w-0');
+		// the card row fills the available width and is itself shrinkable
+		const row = headsign.closest('div.flex');
+		expect(row.className).toContain('w-full');
+		expect(row.className).toContain('min-w-0');
+	});
 });

--- a/src/components/__tests__/RouteBadge.test.js
+++ b/src/components/__tests__/RouteBadge.test.js
@@ -21,4 +21,18 @@ describe('RouteBadge', () => {
 		expect(badge).toHaveStyle('background-color: #374151');
 		expect(badge).toHaveStyle('color: #ffffff');
 	});
+
+	test('keeps short codes at the base 14px size', () => {
+		render(RouteBadge, { props: { shortName: '10' } });
+		expect(screen.getByText('10')).toHaveStyle('font-size: 14px');
+	});
+
+	test('shrinks the font so a long name like "Waterfront Shuttle" fits the box', () => {
+		render(RouteBadge, { props: { shortName: 'Waterfront Shuttle' } });
+		const badge = screen.getByText('Waterfront Shuttle');
+		// longest word "Waterfront" (10 chars) -> round(96/10) = 10px, well below 14
+		const fontSize = parseInt(badge.style.fontSize, 10);
+		expect(fontSize).toBeLessThan(14);
+		expect(fontSize).toBeGreaterThanOrEqual(9);
+	});
 });

--- a/src/components/__tests__/RouteBadge.test.js
+++ b/src/components/__tests__/RouteBadge.test.js
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/svelte';
+import { expect, test, describe } from 'vitest';
+import RouteBadge from '../RouteBadge.svelte';
+
+describe('RouteBadge', () => {
+	test('renders the route short name', () => {
+		render(RouteBadge, { props: { shortName: 'C Line' } });
+		expect(screen.getByText('C Line')).toBeInTheDocument();
+	});
+
+	test('uses the route color as background and text color when provided', () => {
+		render(RouteBadge, { props: { shortName: '10', color: 'FF0000', textColor: '00FF00' } });
+		const badge = screen.getByText('10');
+		expect(badge).toHaveStyle('background-color: #FF0000');
+		expect(badge).toHaveStyle('color: #00FF00');
+	});
+
+	test('falls back to dark slate background and white text when color is absent', () => {
+		render(RouteBadge, { props: { shortName: '21' } });
+		const badge = screen.getByText('21');
+		expect(badge).toHaveStyle('background-color: #374151');
+		expect(badge).toHaveStyle('color: #ffffff');
+	});
+});

--- a/src/components/containers/AccordionItem.svelte
+++ b/src/components/containers/AccordionItem.svelte
@@ -10,10 +10,13 @@
 	 * @property {boolean} [fullBleed] - Extend the header row to the container's
 	 *   edges (negative horizontal margin) while keeping its content padded, so
 	 *   the row background/dividers span full width. Off by default.
+	 * @property {boolean} [hideChevron] - Suppress the built-in expand chevron so
+	 *   the header snippet can render its own (it receives the active state). Off
+	 *   by default.
 	 */
 
 	/** @type {Props} */
-	let { data = null, header, children, fullBleed = false } = $props();
+	let { data = null, header, children, fullBleed = false, hideChevron = false } = $props();
 
 	const id = crypto.randomUUID();
 	const { registerItem } = getContext('accordion');
@@ -33,17 +36,24 @@
 			onclick={toggle}
 			aria-expanded={$isActive}
 		>
-			{@render header?.()}
-			<svg
-				class="h-6 w-6 shrink-0 transition-transform"
-				class:rotate-180={$isActive}
-				fill="none"
-				stroke="currentColor"
-				viewBox="0 0 24 24"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-			</svg>
+			{@render header?.($isActive)}
+			{#if !hideChevron}
+				<svg
+					class="h-6 w-6 shrink-0 transition-transform"
+					class:rotate-180={$isActive}
+					fill="none"
+					stroke="currentColor"
+					viewBox="0 0 24 24"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M19 9l-7 7-7-7"
+					/>
+				</svg>
+			{/if}
 		</button>
 	</div>
 

--- a/src/components/containers/AccordionItem.svelte
+++ b/src/components/containers/AccordionItem.svelte
@@ -7,10 +7,13 @@
 	 * @property {any} [data]
 	 * @property {import('svelte').Snippet} [header]
 	 * @property {import('svelte').Snippet} [children]
+	 * @property {boolean} [fullBleed] - Extend the header row to the container's
+	 *   edges (negative horizontal margin) while keeping its content padded, so
+	 *   the row background/dividers span full width. Off by default.
 	 */
 
 	/** @type {Props} */
-	let { data = null, header, children } = $props();
+	let { data = null, header, children, fullBleed = false } = $props();
 
 	const id = crypto.randomUUID();
 	const { registerItem } = getContext('accordion');
@@ -21,7 +24,7 @@
 </script>
 
 <div class="relative">
-	<div class="sticky -top-[17px] z-10 bg-white px-4 dark:bg-gray-800">
+	<div class="sticky -top-[17px] z-10 bg-white px-4 dark:bg-gray-800 {fullBleed ? '-mx-4' : ''}">
 		<button
 			type="button"
 			class="flex w-full items-center justify-between py-3 text-left text-base font-medium text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"

--- a/src/components/oba/TripDetailsPane.svelte
+++ b/src/components/oba/TripDetailsPane.svelte
@@ -120,10 +120,12 @@
 
 				{#each tripDetails.schedule.stopTimes as tripStop, index}
 					<div class="mb-4 flex items-center">
-						{#if index === busPosition}
-							<div
-								class="relative flex size-8 items-center justify-center rounded-md bg-neutral-800 dark:bg-neutral-200"
-							>
+						<div
+							class="relative flex size-8 items-center justify-center {index === busPosition
+								? 'rounded-md bg-neutral-800 dark:bg-neutral-200'
+								: ''}"
+						>
+							{#if index === busPosition}
 								<FontAwesomeIcon icon={faBus} class="text-sm text-white dark:text-neutral-900" />
 								{#if tripStop.stopId === stop.id}
 									<FontAwesomeIcon
@@ -131,23 +133,19 @@
 										class="absolute -right-1 -top-1 rounded-full border border-white bg-brand p-1 text-xs text-white"
 									/>
 								{/if}
-							</div>
-						{:else if tripStop.stopId === stop.id}
-							<div class="flex size-8 items-center justify-center">
+							{:else if tripStop.stopId === stop.id}
 								<FontAwesomeIcon icon={faLocationDot} class="text-xl text-brand-accent" />
-							</div>
-						{:else}
-							<div class="flex size-8 items-center justify-center">
+							{:else}
 								<div
 									class="size-4 rounded-full border-2 border-neutral-400 bg-white dark:bg-neutral-800"
 								></div>
-							</div>
-						{/if}
+							{/if}
+						</div>
 						<div class="ml-4 flex w-full items-center justify-between space-x-1">
 							<div
-								class="text-md dark:text-white"
-								class:font-bold={tripStop.stopId === stop.id}
-								class:font-semibold={tripStop.stopId !== stop.id}
+								class="text-md dark:text-white {tripStop.stopId === stop.id
+									? 'font-bold'
+									: 'font-semibold'}"
 							>
 								{stopInfo[tripStop.stopId] ? stopInfo[tripStop.stopId].name : tripStop.stopId}
 							</div>

--- a/src/components/oba/TripDetailsPane.svelte
+++ b/src/components/oba/TripDetailsPane.svelte
@@ -1,7 +1,12 @@
 <script>
 	import { _ } from 'svelte-i18n';
 	import { onMount, onDestroy } from 'svelte';
-	import { faBus, faLocationDot, faCheck } from '@fortawesome/free-solid-svg-icons';
+	import {
+		faBus,
+		faLocationDot,
+		faCheck,
+		faTowerBroadcast
+	} from '@fortawesome/free-solid-svg-icons';
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 	import { formatSecondsFromMidnight } from '$lib/dateTimeFormat';
 	import { resolveVehicleStopIndex } from '$lib/tripDetailsUtils';
@@ -98,7 +103,12 @@
 	{#if error}
 		<p>{error}</p>
 	{:else if tripDetails}
-		{#if routeInfo}
+		{#if tripDetails.status?.vehicleId}
+			<h2 class="h2 flex items-center gap-2">
+				<FontAwesomeIcon icon={faTowerBroadcast} class="text-brand" />
+				{$_('trip_details.live_vehicle', { values: { vehicleId: tripDetails.status.vehicleId } })}
+			</h2>
+		{:else if routeInfo}
 			<h2 class="h2">
 				{$_('trip_details.route')}
 				{routeInfo.shortName}
@@ -110,30 +120,35 @@
 
 				{#each tripDetails.schedule.stopTimes as tripStop, index}
 					<div class="mb-4 flex items-center">
-						<div
-							class="relative flex size-8 items-center justify-center rounded-md border border-neutral-400 bg-white dark:bg-neutral-800"
-						>
-							{#if index === busPosition && tripStop.stopId === stop.id}
-								<FontAwesomeIcon
-									icon={faBus}
-									class="absolute bg-white text-xl text-brand dark:bg-black"
-								/>
-								<!-- Green checkmark to show "bus has arrived to the stop" -->
-								<FontAwesomeIcon
-									icon={faCheck}
-									class="absolute -right-1 -top-1 rounded-full border border-white bg-brand p-1 text-xs text-white"
-								/>
-							{:else if index === busPosition}
-								<FontAwesomeIcon
-									icon={faBus}
-									class="absolute bg-white text-xl text-brand dark:bg-black"
-								/>
-							{:else if tripStop.stopId === stop.id}
-								<FontAwesomeIcon icon={faLocationDot} class="text-md text-brand-accent" />
-							{/if}
-						</div>
+						{#if index === busPosition}
+							<div
+								class="relative flex size-8 items-center justify-center rounded-md bg-neutral-800 dark:bg-neutral-200"
+							>
+								<FontAwesomeIcon icon={faBus} class="text-sm text-white dark:text-neutral-900" />
+								{#if tripStop.stopId === stop.id}
+									<FontAwesomeIcon
+										icon={faCheck}
+										class="absolute -right-1 -top-1 rounded-full border border-white bg-brand p-1 text-xs text-white"
+									/>
+								{/if}
+							</div>
+						{:else if tripStop.stopId === stop.id}
+							<div class="flex size-8 items-center justify-center">
+								<FontAwesomeIcon icon={faLocationDot} class="text-xl text-brand-accent" />
+							</div>
+						{:else}
+							<div class="flex size-8 items-center justify-center">
+								<div
+									class="size-4 rounded-full border-2 border-neutral-400 bg-white dark:bg-neutral-800"
+								></div>
+							</div>
+						{/if}
 						<div class="ml-4 flex w-full items-center justify-between space-x-1">
-							<div class="text-md font-semibold dark:text-white">
+							<div
+								class="text-md dark:text-white"
+								class:font-bold={tripStop.stopId === stop.id}
+								class:font-semibold={tripStop.stopId !== stop.id}
+							>
 								{stopInfo[tripStop.stopId] ? stopInfo[tripStop.stopId].name : tripStop.stopId}
 							</div>
 							<div class="whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">

--- a/src/components/oba/TripDetailsPane.svelte
+++ b/src/components/oba/TripDetailsPane.svelte
@@ -9,7 +9,7 @@
 	} from '@fortawesome/free-solid-svg-icons';
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 	import { formatSecondsFromMidnight } from '$lib/dateTimeFormat';
-	import { resolveVehicleStopIndex } from '$lib/tripDetailsUtils';
+	import { resolveVehicleStopIndex, computeVisibleStopRange } from '$lib/tripDetailsUtils';
 
 	/**
 	 * @typedef {Object} Props
@@ -28,6 +28,13 @@
 	let interval;
 	let busPosition = $state(-1);
 	let abortController = null;
+
+	// Only show the segment from the vehicle's current position through the
+	// rider's selected stop: stops already passed and stops beyond the rider's
+	// stop are hidden.
+	let visibleRange = $derived(
+		computeVisibleStopRange(tripDetails?.schedule?.stopTimes, busPosition, stop.id)
+	);
 
 	// Locate the vehicle along the trip using the stop IDs the server reports for
 	// exactly this purpose. `closestStop` is the stop nearest the vehicle's
@@ -104,12 +111,12 @@
 		<p>{error}</p>
 	{:else if tripDetails}
 		{#if tripDetails.status?.vehicleId}
-			<h2 class="h2 flex items-center gap-2">
+			<h2 class="flex items-center gap-2 text-sm font-semibold">
 				<FontAwesomeIcon icon={faTowerBroadcast} class="text-brand" />
 				{$_('trip_details.live_vehicle', { values: { vehicleId: tripDetails.status.vehicleId } })}
 			</h2>
 		{:else if routeInfo}
-			<h2 class="h2">
+			<h2 class="text-sm font-semibold">
 				{$_('trip_details.route')}
 				{routeInfo.shortName}
 			</h2>
@@ -119,41 +126,43 @@
 				<div class="absolute bottom-0 left-3.5 top-0 w-[1px] bg-neutral-400"></div>
 
 				{#each tripDetails.schedule.stopTimes as tripStop, index}
-					<div class="mb-4 flex items-center">
-						<div
-							class="relative flex size-8 items-center justify-center {index === busPosition
-								? 'rounded-md bg-neutral-800 dark:bg-neutral-200'
-								: ''}"
-						>
-							{#if index === busPosition}
-								<FontAwesomeIcon icon={faBus} class="text-sm text-white dark:text-neutral-900" />
-								{#if tripStop.stopId === stop.id}
-									<FontAwesomeIcon
-										icon={faCheck}
-										class="absolute -right-1 -top-1 rounded-full border border-white bg-brand p-1 text-xs text-white"
-									/>
-								{/if}
-							{:else if tripStop.stopId === stop.id}
-								<FontAwesomeIcon icon={faLocationDot} class="text-xl text-brand-accent" />
-							{:else}
-								<div
-									class="size-4 rounded-full border-2 border-neutral-400 bg-white dark:bg-neutral-800"
-								></div>
-							{/if}
-						</div>
-						<div class="ml-4 flex w-full items-center justify-between space-x-1">
+					{#if index >= visibleRange.start && index <= visibleRange.end}
+						<div class="mb-4 flex items-center">
 							<div
-								class="text-md dark:text-white {tripStop.stopId === stop.id
-									? 'font-bold'
-									: 'font-semibold'}"
+								class="relative flex size-8 items-center justify-center {index === busPosition
+									? 'rounded-md bg-neutral-800 dark:bg-neutral-200'
+									: ''}"
 							>
-								{stopInfo[tripStop.stopId] ? stopInfo[tripStop.stopId].name : tripStop.stopId}
+								{#if index === busPosition}
+									<FontAwesomeIcon icon={faBus} class="text-sm text-white dark:text-neutral-900" />
+									{#if tripStop.stopId === stop.id}
+										<FontAwesomeIcon
+											icon={faCheck}
+											class="absolute -right-1 -top-1 rounded-full border border-white bg-brand p-1 text-xs text-white"
+										/>
+									{/if}
+								{:else if tripStop.stopId === stop.id}
+									<FontAwesomeIcon icon={faLocationDot} class="text-xl text-brand-accent" />
+								{:else}
+									<div
+										class="size-4 rounded-full border-2 border-neutral-400 bg-white dark:bg-neutral-800"
+									></div>
+								{/if}
 							</div>
-							<div class="whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
-								{formatSecondsFromMidnight(tripStop.arrivalTime)}
+							<div class="ml-4 flex w-full items-center justify-between space-x-1">
+								<div
+									class="text-md dark:text-white {tripStop.stopId === stop.id
+										? 'font-bold'
+										: 'font-semibold'}"
+								>
+									{stopInfo[tripStop.stopId] ? stopInfo[tripStop.stopId].name : tripStop.stopId}
+								</div>
+								<div class="whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+									{formatSecondsFromMidnight(tripStop.arrivalTime)}
+								</div>
 							</div>
 						</div>
-					</div>
+					{/if}
 				{/each}
 			</div>
 		{:else}

--- a/src/components/oba/__tests__/TripDetailsPane.test.js
+++ b/src/components/oba/__tests__/TripDetailsPane.test.js
@@ -1,0 +1,75 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { expect, test, describe, vi, beforeEach, afterEach } from 'vitest';
+
+// Local i18n mock that interpolates {vehicleId}.
+//
+// Note: this appends each interpolated value to the key rather than
+// substituting it into the key string. The key itself (e.g.
+// "trip_details.live_vehicle") never contains a literal "{vehicleId}"
+// placeholder to replace -- only a real translation message would -- so a
+// mock that tries `key.replace('{vehicleId}', value)` is a no-op and the
+// resulting assertion would pass even if the component never passed the
+// vehicle id through at all. Appending the value instead means the test can
+// only pass if the component actually forwards `values: { vehicleId }` to
+// `$_()`.
+vi.mock('svelte-i18n', () => ({
+	_: {
+		subscribe: (fn) => {
+			fn((key, options) => {
+				let str = key;
+				if (options?.values) {
+					for (const value of Object.values(options.values)) {
+						str = `${str} ${value}`;
+					}
+				}
+				return str;
+			});
+			return () => {};
+		}
+	}
+}));
+
+import TripDetailsPane from '../TripDetailsPane.svelte';
+
+const stop = { id: '1_75403', name: 'Fauntleroy Way SW & SW Myrtle St' };
+
+function mockTripResponse({ vehicleId }) {
+	return {
+		data: {
+			entry: {
+				routeId: '1_100479',
+				status: vehicleId ? { vehicleId, closestStop: '1_75403' } : null,
+				schedule: {
+					stopTimes: [{ stopId: '1_75403', arrivalTime: 41400 }]
+				}
+			},
+			references: {
+				routes: [{ id: '1_100479', shortName: 'C Line' }],
+				stops: [{ id: '1_75403', name: 'Fauntleroy Way SW & SW Myrtle St' }]
+			}
+		}
+	};
+}
+
+describe('TripDetailsPane', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	test('shows a "Live · vehicle {id}" heading when a vehicle is present', async () => {
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => mockTripResponse({ vehicleId: '1_8129001' })
+		});
+
+		render(TripDetailsPane, { props: { stop, tripId: '1_trip', serviceDate: 123 } });
+
+		await waitFor(() => {
+			expect(screen.getByText('trip_details.live_vehicle 1_8129001')).toBeInTheDocument();
+		});
+	});
+});

--- a/src/components/oba/__tests__/TripDetailsPane.test.js
+++ b/src/components/oba/__tests__/TripDetailsPane.test.js
@@ -58,13 +58,19 @@ describe('TripDetailsPane', () => {
 	afterEach(() => {
 		vi.useRealTimers();
 		vi.restoreAllMocks();
+		// vi.restoreAllMocks() does not revert a direct global assignment, so the
+		// fetch stub is registered via vi.stubGlobal and cleared here explicitly.
+		vi.unstubAllGlobals();
 	});
 
 	test('shows a "Live · vehicle {id}" heading when a vehicle is present', async () => {
-		global.fetch = vi.fn().mockResolvedValue({
-			ok: true,
-			json: async () => mockTripResponse({ vehicleId: '1_8129001' })
-		});
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => mockTripResponse({ vehicleId: '1_8129001' })
+			})
+		);
 
 		render(TripDetailsPane, { props: { stop, tripId: '1_trip', serviceDate: 123 } });
 

--- a/src/components/stops/StopPane.svelte
+++ b/src/components/stops/StopPane.svelte
@@ -328,14 +328,17 @@
 					{#key arrivalsAndDepartures.stopId}
 						<Accordion {handleAccordionSelectionChanged}>
 							{#each arrivalsAndDepartures.arrivalsAndDepartures as arrival}
-								<AccordionItem data={arrival} fullBleed>
-									{#snippet header()}
+								<AccordionItem data={arrival} fullBleed hideChevron>
+									{#snippet header(isActive)}
 										<!-- min-w-0 lets this flex child shrink below its content width so the
-										     card's headsign truncates instead of pushing the ETA/chevron off-screen -->
+										     card's headsign wraps/clamps instead of pushing the ETA off-screen.
+										     ArrivalDeparture renders the chevron itself (stacked under the ETA),
+										     so the built-in AccordionItem chevron is hidden. -->
 										<span class="block min-w-0 flex-1">
 											<ArrivalDeparture
 												arrivalDeparture={arrival}
 												route={routeById.get(arrival.routeId)}
+												expanded={isActive}
 											/>
 										</span>
 									{/snippet}

--- a/src/components/stops/StopPane.svelte
+++ b/src/components/stops/StopPane.svelte
@@ -330,7 +330,9 @@
 							{#each arrivalsAndDepartures.arrivalsAndDepartures as arrival}
 								<AccordionItem data={arrival}>
 									{#snippet header()}
-										<span class="block flex-1">
+										<!-- min-w-0 lets this flex child shrink below its content width so the
+										     card's headsign truncates instead of pushing the ETA/chevron off-screen -->
+										<span class="block min-w-0 flex-1">
 											<ArrivalDeparture
 												arrivalDeparture={arrival}
 												route={routeById.get(arrival.routeId)}

--- a/src/components/stops/StopPane.svelte
+++ b/src/components/stops/StopPane.svelte
@@ -328,7 +328,7 @@
 					{#key arrivalsAndDepartures.stopId}
 						<Accordion {handleAccordionSelectionChanged}>
 							{#each arrivalsAndDepartures.arrivalsAndDepartures as arrival}
-								<AccordionItem data={arrival}>
+								<AccordionItem data={arrival} fullBleed>
 									{#snippet header()}
 										<!-- min-w-0 lets this flex child shrink below its content width so the
 										     card's headsign truncates instead of pushing the ETA/chevron off-screen -->

--- a/src/components/stops/StopPane.svelte
+++ b/src/components/stops/StopPane.svelte
@@ -158,6 +158,12 @@
 
 	let routeShortNames = $derived(routeShortNamesForStop(arrivalsAndDeparturesResponse, stop));
 
+	// references.routes carries the per-route color/textColor; the arrival objects
+	// only carry routeId, so build a lookup to feed RouteBadge via ArrivalDeparture.
+	let routeById = $derived(
+		new Map((arrivalsAndDeparturesResponse?.data?.references?.routes ?? []).map((r) => [r.id, r]))
+	);
+
 	function handleAccordionSelectionChanged(event) {
 		const data = event.activeData; // this is the ArrivalDeparture object plumbed into the AccordionItem
 		const show = !!data;
@@ -314,13 +320,21 @@
 						{@render loadMoreButton(true)}
 					</div>
 				{:else}
+					<h2
+						class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+					>
+						{$isLoading ? '' : $t('arrivals_and_departures')}
+					</h2>
 					{#key arrivalsAndDepartures.stopId}
 						<Accordion {handleAccordionSelectionChanged}>
 							{#each arrivalsAndDepartures.arrivalsAndDepartures as arrival}
 								<AccordionItem data={arrival}>
 									{#snippet header()}
-										<span>
-											<ArrivalDeparture arrivalDeparture={arrival} />
+										<span class="block flex-1">
+											<ArrivalDeparture
+												arrivalDeparture={arrival}
+												route={routeById.get(arrival.routeId)}
+											/>
 										</span>
 									{/snippet}
 									<TripDetailsPane

--- a/src/components/stops/__tests__/StopBottomSheet.test.js
+++ b/src/components/stops/__tests__/StopBottomSheet.test.js
@@ -95,10 +95,18 @@ describe('StopBottomSheet', () => {
 	test('renders arrivals from the fetched data', async () => {
 		render(StopBottomSheet, { props: defaultProps });
 
+		// ArrivalDeparture now renders the route short name inside a separate
+		// RouteBadge and the headsign in its own element, so assert on each
+		// piece rather than the old concatenated "route - headsign" string.
 		await waitFor(() => {
 			expect(
 				screen.getByText(
-					`${mockArrivalsAndDeparturesResponse.data.entry.arrivalsAndDepartures[0].routeShortName} - ${mockArrivalsAndDeparturesResponse.data.entry.arrivalsAndDepartures[0].tripHeadsign}`
+					mockArrivalsAndDeparturesResponse.data.entry.arrivalsAndDepartures[0].tripHeadsign
+				)
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					mockArrivalsAndDeparturesResponse.data.entry.arrivalsAndDepartures[0].routeShortName
 				)
 			).toBeInTheDocument();
 		});

--- a/src/components/stops/__tests__/StopPane.test.js
+++ b/src/components/stops/__tests__/StopPane.test.js
@@ -115,6 +115,7 @@ vi.mock('svelte-i18n', () => ({
 				const translations = {
 					stop: 'Stop',
 					routes: 'Routes',
+					arrivals_and_departures: 'Arrivals and departures',
 					'schedule_for_stop.view_schedule': 'View Schedule',
 					load_more_arrivals: 'Load more arrivals',
 					no_arrivals_found_in_next_minutes: 'No arrivals found in the next {minutes} minutes'
@@ -267,6 +268,19 @@ describe('StopPane', () => {
 		await waitFor(() => {
 			expect(screen.getByText('Pine St & 3rd Ave')).toBeInTheDocument();
 			expect(screen.getByText('Stop #75403')).toBeInTheDocument();
+		});
+	});
+
+	test('renders the ARRIVALS & DEPARTURES section header when arrivals exist', async () => {
+		global.fetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => mockArrivalsAndDeparturesResponse
+		});
+
+		render(StopPane, { props: { stop: mockStopData } });
+		await waitFor(() => {
+			expect(screen.getByText('Arrivals and departures')).toBeInTheDocument();
 		});
 	});
 
@@ -501,9 +515,10 @@ describe('StopPane', () => {
 			expect(stopNameHeading).toHaveTextContent('Pine St & 3rd Ave');
 
 			const headings = screen.getAllByRole('heading', { level: 2 });
-			expect(headings).toHaveLength(2);
+			expect(headings).toHaveLength(3);
 			expect(headings[0]).toHaveTextContent('Stop #75403');
 			expect(headings[1]).toHaveTextContent('Routes: 10, 11');
+			expect(headings[2]).toHaveTextContent('Arrivals and departures');
 		});
 	});
 

--- a/src/lib/__tests__/tripDetailsUtils.test.js
+++ b/src/lib/__tests__/tripDetailsUtils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveVehicleStopIndex } from '$lib/tripDetailsUtils.js';
+import { resolveVehicleStopIndex, computeVisibleStopRange } from '$lib/tripDetailsUtils.js';
 
 describe('resolveVehicleStopIndex', () => {
 	const stopTimes = [{ stopId: 'a' }, { stopId: 'b' }, { stopId: 'c' }, { stopId: 'd' }];
@@ -44,5 +44,38 @@ describe('resolveVehicleStopIndex', () => {
 
 	it('returns -1 when status has neither closestStop nor nextStop', () => {
 		expect(resolveVehicleStopIndex({}, stopTimes)).toBe(-1);
+	});
+});
+
+describe('computeVisibleStopRange', () => {
+	const stopTimes = [
+		{ stopId: 'a' },
+		{ stopId: 'b' },
+		{ stopId: 'c' },
+		{ stopId: 'd' },
+		{ stopId: 'e' }
+	];
+
+	it('spans from the vehicle position through the rider stop', () => {
+		// bus at index 1 (b), rider stop d (index 3) => show b..d, hide a and e
+		expect(computeVisibleStopRange(stopTimes, 1, 'd')).toEqual({ start: 1, end: 3 });
+	});
+
+	it('starts at the first stop when the vehicle position is unknown', () => {
+		expect(computeVisibleStopRange(stopTimes, -1, 'c')).toEqual({ start: 0, end: 2 });
+	});
+
+	it('ends at the last stop when the rider stop is not in the list', () => {
+		expect(computeVisibleStopRange(stopTimes, 1, 'zzz')).toEqual({ start: 1, end: 4 });
+	});
+
+	it('clamps the start to the rider stop when the bus has already passed it', () => {
+		// bus at 3 (d) but rider stop is b (index 1) => show only the rider stop
+		expect(computeVisibleStopRange(stopTimes, 3, 'b')).toEqual({ start: 1, end: 1 });
+	});
+
+	it('returns an empty range for no stop times', () => {
+		expect(computeVisibleStopRange([], 0, 'a')).toEqual({ start: 0, end: -1 });
+		expect(computeVisibleStopRange(null, 0, 'a')).toEqual({ start: 0, end: -1 });
 	});
 });

--- a/src/lib/tripDetailsUtils.js
+++ b/src/lib/tripDetailsUtils.js
@@ -17,3 +17,31 @@ export function resolveVehicleStopIndex(status, stopTimes) {
 	const targetStopId = status.closestStop || status.nextStop;
 	return targetStopId ? stopTimes.findIndex((st) => st.stopId === targetStopId) : -1;
 }
+
+/**
+ * Restrict a trip's stop list to the segment the rider cares about: from the
+ * vehicle's current position through the rider's selected stop. Stops the bus
+ * has already passed (before its current position) and stops beyond the rider's
+ * stop are hidden.
+ *
+ * When the vehicle position is unknown (`busPosition < 0`, e.g. a scheduled
+ * trip), the range starts at the first stop — passed stops can't be inferred
+ * without a live position. The start is never allowed past the rider's stop.
+ *
+ * @param {Array<{ stopId: string }> | null | undefined} stopTimes
+ * @param {number} busPosition index of the vehicle's current stop, or -1
+ * @param {string} riderStopId the rider's selected stop id
+ * @returns {{ start: number, end: number }} inclusive index range to render
+ *   (`end < start` means nothing should be shown)
+ */
+export function computeVisibleStopRange(stopTimes, busPosition, riderStopId) {
+	if (!stopTimes || stopTimes.length === 0) return { start: 0, end: -1 };
+
+	const lastIndex = stopTimes.length - 1;
+	const riderIndex = stopTimes.findIndex((st) => st.stopId === riderStopId);
+	const end = riderIndex >= 0 ? riderIndex : lastIndex;
+	const rawStart = busPosition >= 0 ? busPosition : 0;
+	const start = Math.min(rawStart, end);
+
+	return { start, end };
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -143,7 +143,8 @@
 		"secs": "secs",
 		"min": "min",
 		"mins": "mins",
-		"minutes": "minutes"
+		"minutes": "minutes",
+		"min_compact": "{n}m"
 	},
 	"vehicle": {
 		"number": "Vehicle #",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -232,7 +232,8 @@
 	"trip_details": {
 		"route": "Route",
 		"no_stops": "No stop times available for this trip.",
-		"loading": "Loading trip details..."
+		"loading": "Loading trip details...",
+		"live_vehicle": "Live · vehicle {vehicleId}"
 	},
 	"skip_to_main_content": "Skip to main content"
 }


### PR DESCRIPTION
## Summary

Redesigns the stop pane's arrivals/departures UI to match the new mockup:

- **New `RouteBadge` component** — a colored rounded-square route badge. Uses the route's real `color`/`textColor` from the arrivals response (`references.routes`), so RapidRide lines keep their brand color; routes without a color fall back to a dark slate. Applied via inline `style` (dynamic hex can't go in Tailwind arbitrary classes).
- **`ArrivalDeparture` card redesign** — badge + bold headsign + a `time · status` sub-line (gray time, status-colored text) + a large compact ETA (`19m`) with a live/schedule icon (`faTowerBroadcast` for real-time, `faClock` for scheduled). Scheduled (no real-time) arrivals now render fully muted gray instead of blue. All existing status/frequency/canceled/arrival-vs-departure logic is preserved.
- **`StopPane` section header** — adds the "ARRIVALS & DEPARTURES" header and derives a `routeId → route` color map that feeds each card's badge.
- **`TripDetailsPane` timeline restyle** — heading becomes "Live · vehicle {id}" (with a broadcast icon) when a real-time vehicle is present; timeline markers restyled to the mockup (dark bus square at the vehicle, pin at your stop, empty rings elsewhere).

New i18n keys (`time.min_compact`, `trip_details.live_vehicle`) added to the English fallback locale. The mockup's "Past · N" counter is intentionally deferred to a follow-up.

Design spec and implementation plan are included under `docs/superpowers/`.

## Test plan

- [x] `npx vitest run` — full suite green (1432 tests), incl. new `RouteBadge`, `ArrivalDeparture`, and `TripDetailsPane` tests
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [x] Exercised live against Puget Sound stop #20170 (RapidRide C): red C Line badges, colored statuses (`on time`/`N min late`), compact ETAs incl. negative (`-2m`) edge case, and the expanded "Live · vehicle …" timeline all render correctly in the browser; only pre-existing analytics/favicon console errors, none from these components.

## Review notes (non-blocking)

A multi-agent review (whole-branch + simplify pass) flagged only Minor items, left as optional follow-ups:
- `TripDetailsPane` test covers the vehicle-present heading; the fallback heading, the three marker states, and the bold-stop-name class are not yet unit-tested (verified visually).
- The section-header `<h2>` has no `aria-labelledby` tying it to the arrivals list.
- Deliberately **not** dark-adjusting badge colors (unlike `RouteItem`): the badge is a filled tile that must preserve brand identity and relies on the API `textColor` for contrast.
- Considered but deferred: extracting the `#`-prefix/fallback color helper and the `routeId→route` map into `$lib` shared helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced reusable route badges on arrival/departure cards, with updated predicted vs. scheduled styling and compact localized ETA display.
  * Enhanced trip details with a “Live · vehicle {vehicleId}” heading and updated timeline rendering for the visible stop range.
  * Added an “Arrivals & Departures” section header in the stop pane.
* **Documentation**
  * Added design and implementation-plan docs for the arrival/departure UI redesign.
* **Tests**
  * Added and updated component tests for route badges, arrival cards, stop pane sections, and live vehicle heading.
* **Chores**
  * Updated formatting rules to skip the `.superpowers/` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->