### PR TITLE
iOS-style stop UI polish: collapsed stop list, refresh spinner, route badges

### DIFF
--- a/docs/superpowers/specs/2026-07-22-collapsed-stop-list-design.md
+++ b/docs/superpowers/specs/2026-07-22-collapsed-stop-list-design.md
@@ -87,7 +87,7 @@ straight rail reads as flowing into and out of the zig-zag.
 New key `trip_details.collapsed_stops` in `src/locales/en.json`, pluralized via
 svelte-i18n's ICU MessageFormat:
 
-```
+```json
 "collapsed_stops": "{count, plural, one {# stop} other {# stops}}"
 ```
 

--- a/docs/superpowers/specs/2026-07-22-collapsed-stop-list-design.md
+++ b/docs/superpowers/specs/2026-07-22-collapsed-stop-list-design.md
@@ -1,0 +1,108 @@
+# iOS-style collapsed stop list in TripDetailsPane
+
+Date: 2026-07-22
+
+## Problem
+
+When a vehicle is several stops away from the rider's selected stop, the trip
+details pane (`src/components/oba/TripDetailsPane.svelte`) renders every stop
+between the vehicle and the rider stop as a uniform vertical list of circles on
+a straight rail. Long lists dominate the pane and bury the information the rider
+actually cares about: where the bus is now, and the last stops before theirs.
+
+The iOS app solves this by collapsing the middle of the list into a single
+zig-zag connector labelled "N stops", showing only the vehicle's current stop,
+the last few stops before the rider's stop, and the rider's stop itself.
+
+## Goal
+
+Replicate the iOS experience in Wayfinder:
+
+- Vehicle's current stop at top, with the bus icon (unchanged).
+- A **static** zig-zag segment collapsing the hidden middle stops, with an
+  **"N stops"** legend (N = number of collapsed stops).
+- The last **3** stops before the rider's stop, each a normal circle.
+- The rider's stop, bold, with the filled location marker (unchanged).
+
+Static, not interactive — matches iOS.
+
+## Design
+
+### Collapse logic (pure, unit-tested)
+
+New function in `src/lib/tripDetailsUtils.js`:
+
+```js
+buildStopSegments(stopTimes, busPosition, riderStopId, (tailCount = 3));
+```
+
+Returns an ordered array of render items, built on top of the existing
+`computeVisibleStopRange` so the "hide already-passed / hide beyond-rider"
+logic stays in one place:
+
+```js
+[
+  { type: 'stop', index },        // render as a normal stop row
+  { type: 'collapsed', count },   // render as a zig-zag with an "N stops" legend
+  ...
+]
+```
+
+Rules, given `range = computeVisibleStopRange(...)` with inclusive
+`{ start, end }`:
+
+- `end < start` (empty range) → `[]`.
+- `intermediate = end - start - 1` (stops strictly between head and rider).
+- If `intermediate <= tailCount`: no collapse — every index `start..end` is a
+  `stop` item (identical to today's output for short trips).
+- If `intermediate > tailCount`: emit
+  - head: `{ type: 'stop', index: start }`
+  - `{ type: 'collapsed', count: intermediate - tailCount }`
+  - tail: indices `end - tailCount .. end` as `stop` items (the last
+    `tailCount` intermediate stops plus the rider stop).
+
+Threshold: the zig-zag appears only when the vehicle is more than
+`tailCount + 1` indices from the rider stop (for `tailCount = 3`, ≥ 5 indices).
+
+Edge cases covered by tests: empty/short ranges, `start === end` (single stop),
+unknown vehicle position (`busPosition < 0`, scheduled trip — no bus icon, but
+long lists still collapse), and the rider stop missing from `stopTimes`.
+
+### Template
+
+`TripDetailsPane.svelte` iterates over the segment list instead of filtering
+`stopTimes` by an index range. `stop` items reuse the existing row markup (bus
+icon / rider marker / circle, keyed off `index === busPosition` and
+`stopId === stop.id`, plus the arrival time — Wayfinder shows times, iOS does
+not). `collapsed` items render a self-contained SVG zig-zag in the left rail
+plus the legend.
+
+The continuous rail line and its masking pattern are unchanged: the existing
+circle dots already mask the absolute rail line with `bg-white
+dark:bg-neutral-800`; the zig-zag cell uses the same opaque background so the
+straight rail reads as flowing into and out of the zig-zag.
+
+### i18n
+
+New key `trip_details.collapsed_stops` in `src/locales/en.json`, pluralized via
+svelte-i18n's ICU MessageFormat:
+
+```
+"collapsed_stops": "{count, plural, one {# stop} other {# stops}}"
+```
+
+English is the synchronous fallback; other locales inherit it until translated.
+
+## Testing
+
+- `tripDetailsUtils.test.js`: unit tests for `buildStopSegments` — collapse
+  counts, the no-collapse threshold, single-stop and empty ranges, unknown
+  vehicle position.
+- `TripDetailsPane.test.js`: assert the zig-zag legend appears with the correct
+  count for a long trip and is absent for a short one.
+
+## Out of scope
+
+- Tap-to-expand interaction (iOS is static; deferred).
+- Changing which stops count as "passed" / vehicle-position resolution
+  (`resolveVehicleStopIndex` / `computeVisibleStopRange` are unchanged).

--- a/src/components/RouteBadge.svelte
+++ b/src/components/RouteBadge.svelte
@@ -12,20 +12,48 @@
 	let bg = $derived(color ? `#${color}` : '#374151');
 	let fg = $derived(textColor ? `#${textColor}` : '#ffffff');
 
-	// Auto-shrink the label so long names (e.g. "Waterfront Shuttle") fit the
-	// fixed badge box. The text wraps on spaces, so the constraint is the longest
-	// word; short codes ("10", "C Line") stay at the base 14px size.
-	let longestWord = $derived(
+	// Auto-size the label to fill the fixed badge box. Two constraints compete,
+	// and the smaller wins:
+	//   width  — the text wraps on spaces, so the longest unbreakable word caps
+	//            the type size (e.g. "First Hill Streetcar" is held to 10px by
+	//            "Streetcar").
+	//   height — each word roughly costs a line, so multi-word names shrink to
+	//            avoid overflowing vertically (e.g. two-line "C Line" -> 21px).
+	// Short codes ("60", "8") hit neither limit and grow to the 24px ceiling.
+	let words = $derived(
 		String(shortName ?? '')
+			.trim()
 			.split(/\s+/)
-			.reduce((max, word) => Math.max(max, word.length), 1)
+			.filter(Boolean)
 	);
-	let fontSize = $derived(Math.max(8, Math.min(14, Math.round(90 / longestWord))));
+	let longestWord = $derived(words.reduce((max, word) => Math.max(max, word.length), 1));
+	let lineCount = $derived(Math.max(1, words.length));
+	let fontSize = $derived(
+		Math.max(8, Math.min(24, Math.round(90 / longestWord), Math.round(42 / lineCount)))
+	);
 </script>
 
+<!-- The iOS-style gloss (top highlight -> transparent -> faint shade) and the
+	inset edge shadows are the same for every route, so they live in CSS; only the
+	route color and the fitted font size vary per badge. -->
 <div
-	class="flex h-14 w-16 shrink-0 items-center justify-center break-words rounded-lg px-1 text-center font-bold leading-tight"
-	style="background-color: {bg}; background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.28) 0%, rgba(255, 255, 255, 0.08) 42%, rgba(255, 255, 255, 0) 55%, rgba(0, 0, 0, 0.12) 100%); box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3), inset 0 -1px 1px rgba(0, 0, 0, 0.12); color: {fg}; font-size: {fontSize}px;"
+	class="route-badge flex h-14 w-16 shrink-0 items-center justify-center break-words rounded-lg px-1 text-center font-bold leading-tight"
+	style="background-color: {bg}; color: {fg}; font-size: {fontSize}px;"
 >
 	{shortName}
 </div>
+
+<style>
+	.route-badge {
+		background-image: linear-gradient(
+			to bottom,
+			rgba(255, 255, 255, 0.28) 0%,
+			rgba(255, 255, 255, 0.08) 42%,
+			rgba(255, 255, 255, 0) 55%,
+			rgba(0, 0, 0, 0.12) 100%
+		);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.3),
+			inset 0 -1px 1px rgba(0, 0, 0, 0.12);
+	}
+</style>

--- a/src/components/RouteBadge.svelte
+++ b/src/components/RouteBadge.svelte
@@ -25,7 +25,7 @@
 
 <div
 	class="flex h-14 w-16 shrink-0 items-center justify-center break-words rounded-lg px-1 text-center font-bold leading-tight"
-	style="background-color: {bg}; color: {fg}; font-size: {fontSize}px;"
+	style="background-color: {bg}; background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.28) 0%, rgba(255, 255, 255, 0.08) 42%, rgba(255, 255, 255, 0) 55%, rgba(0, 0, 0, 0.12) 100%); box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3), inset 0 -1px 1px rgba(0, 0, 0, 0.12); color: {fg}; font-size: {fontSize}px;"
 >
 	{shortName}
 </div>

--- a/src/components/__tests__/RouteBadge.test.js
+++ b/src/components/__tests__/RouteBadge.test.js
@@ -22,17 +22,45 @@ describe('RouteBadge', () => {
 		expect(badge).toHaveStyle('color: #ffffff');
 	});
 
-	test('keeps short codes at the base 14px size', () => {
+	test('grows short codes to the 24px ceiling to fill the box', () => {
 		render(RouteBadge, { props: { shortName: '10' } });
-		expect(screen.getByText('10')).toHaveStyle('font-size: 14px');
+		expect(screen.getByText('10')).toHaveStyle('font-size: 24px');
 	});
 
-	test('shrinks the font so a long name like "Waterfront Shuttle" fits the box', () => {
+	test('sizes a long single word by its width: "Waterfront Shuttle" fits the box', () => {
 		render(RouteBadge, { props: { shortName: 'Waterfront Shuttle' } });
-		const badge = screen.getByText('Waterfront Shuttle');
-		// longest word "Waterfront" (10 chars) -> round(96/10) = 10px, well below 14
-		const fontSize = parseInt(badge.style.fontSize, 10);
-		expect(fontSize).toBeLessThan(14);
-		expect(fontSize).toBeGreaterThanOrEqual(9);
+		// longest word "Waterfront" (10 chars) -> round(90/10) = 9px (width-bound)
+		expect(screen.getByText('Waterfront Shuttle')).toHaveStyle('font-size: 9px');
+	});
+
+	test('constrains multi-word labels by line count, not just longest word', () => {
+		// "Link Light Rail": width term round(90/5)=18, height term round(42/3)=14.
+		// The height term wins, so removing it would wrongly render 18px.
+		render(RouteBadge, { props: { shortName: 'Link Light Rail' } });
+		expect(screen.getByText('Link Light Rail')).toHaveStyle('font-size: 14px');
+	});
+
+	test('keeps a two-word line name below the ceiling its longest word would allow', () => {
+		// "C Line": longest word "Line" alone permits ~23px, but two lines cap it
+		// at height term round(42/2)=21px.
+		render(RouteBadge, { props: { shortName: 'C Line' } });
+		expect(screen.getByText('C Line')).toHaveStyle('font-size: 21px');
+	});
+
+	test('clamps very long unbreakable words to the 8px floor', () => {
+		// "Transportation" (14 chars) -> round(90/14)=6, raised to the 8px floor.
+		render(RouteBadge, { props: { shortName: 'Transportation' } });
+		expect(screen.getByText('Transportation')).toHaveStyle('font-size: 8px');
+	});
+
+	test.each([
+		['empty', ''],
+		['whitespace-only', '   '],
+		['missing', undefined]
+	])('resolves %s shortName to a finite size via the trim/filter/?? guards', (_label, value) => {
+		// Without the guards these inputs would make lineCount/longestWord produce
+		// NaN; all three should instead fall through to the 24px ceiling.
+		const { container } = render(RouteBadge, { props: { shortName: value } });
+		expect(container.firstChild).toHaveStyle('font-size: 24px');
 	});
 });

--- a/src/components/navigation/BottomSheet.svelte
+++ b/src/components/navigation/BottomSheet.svelte
@@ -117,8 +117,11 @@
 			{@render header?.()}
 		</div>
 
+		<!-- px-4 (not px-3) so full-bleed accordion rows, which reach the edge with
+		     `-mx-4` (1rem), line up exactly with this padding instead of spilling 4px
+		     past it. overflow-x-hidden guards against any other incidental overflow. -->
 		<div
-			class="flex-1 overflow-y-auto overscroll-contain px-3"
+			class="flex-1 overflow-y-auto overflow-x-hidden overscroll-contain px-4"
 			style:padding-bottom="calc(1rem + env(safe-area-inset-bottom))"
 		>
 			{@render children?.()}

--- a/src/components/oba/TripDetailsPane.svelte
+++ b/src/components/oba/TripDetailsPane.svelte
@@ -123,61 +123,79 @@
 			</h2>
 		{/if}
 		{#if tripDetails.schedule?.stopTimes.length > 0}
-			<div class="relative">
-				<div class="absolute bottom-0 left-3.5 top-0 w-[1px] bg-neutral-400"></div>
-
-				{#each stopSegments as segment (segment.type === 'stop' ? `stop-${segment.index}` : 'collapsed')}
+			<div>
+				{#each stopSegments as segment, i (segment.type === 'stop' ? `stop-${segment.index}` : 'collapsed')}
+					{@const isFirst = i === 0}
+					{@const isLast = i === stopSegments.length - 1}
 					{#if segment.type === 'collapsed'}
-						<div class="mb-4 flex items-center">
-							<div class="relative flex size-8 items-center justify-center">
-								<!-- Zig-zag connector standing in for the collapsed stops; the opaque
-								     background masks the straight rail line behind it. -->
+						<div class="flex items-stretch">
+							<div class="relative flex w-8 shrink-0 justify-center">
+								<!-- Zig-zag connector standing in for the collapsed stops. It IS this
+								     row's rail segment, so it joins the straight rail above and below
+								     without needing an opaque mask. -->
 								<svg
-									class="bg-white text-neutral-400 dark:bg-neutral-800"
+									class="text-neutral-400"
 									width="16"
-									height="36"
-									viewBox="0 0 16 36"
+									height="56"
+									viewBox="0 0 16 56"
 									fill="none"
 									aria-hidden="true"
 								>
 									<path
-										d="M8 0 L2 6 L14 12 L2 18 L14 24 L2 30 L8 36"
+										d="M8 0 L8 8 L12 16 L4 24 L12 32 L4 40 L8 48 L8 56"
 										stroke="currentColor"
-										stroke-width="2"
+										stroke-width="1.5"
 										stroke-linejoin="round"
 									/>
 								</svg>
 							</div>
-							<div class="ml-4 text-sm text-gray-500 dark:text-gray-400">
+							<div class="ml-4 flex items-center text-sm text-gray-500 dark:text-gray-400">
 								{$_('trip_details.collapsed_stops', { values: { count: segment.count } })}
 							</div>
 						</div>
 					{:else}
 						{@const index = segment.index}
 						{@const tripStop = tripDetails.schedule.stopTimes[index]}
-						<div class="mb-4 flex items-center">
-							<div
-								class="relative flex size-8 items-center justify-center {index === busPosition
-									? 'rounded-md bg-neutral-800 dark:bg-neutral-200'
-									: ''}"
-							>
-								{#if index === busPosition}
-									<FontAwesomeIcon icon={faBus} class="text-sm text-white dark:text-neutral-900" />
-									{#if tripStop.stopId === stop.id}
-										<FontAwesomeIcon
-											icon={faCheck}
-											class="absolute -right-1 -top-1 rounded-full border border-white bg-brand p-1 text-xs text-white"
-										/>
-									{/if}
-								{:else if tripStop.stopId === stop.id}
-									<FontAwesomeIcon icon={faLocationDot} class="text-xl text-brand-accent" />
-								{:else}
+						<div class="flex items-stretch">
+							<div class="relative flex w-8 shrink-0 justify-center">
+								<!-- Per-row rail line, centered on the marker. Trimmed to a half at
+								     the first and last rows so it never overshoots the endpoints. -->
+								{#if !(isFirst && isLast)}
 									<div
-										class="size-4 rounded-full border-2 border-neutral-400 bg-white dark:bg-neutral-800"
+										class="absolute w-px bg-neutral-400 {isFirst
+											? 'bottom-0 top-1/2'
+											: isLast
+												? 'top-0 h-1/2'
+												: 'inset-y-0'}"
 									></div>
 								{/if}
+								<div
+									class="relative my-2 flex size-8 items-center justify-center {index ===
+									busPosition
+										? 'rounded-md bg-neutral-800 dark:bg-neutral-200'
+										: ''}"
+								>
+									{#if index === busPosition}
+										<FontAwesomeIcon
+											icon={faBus}
+											class="text-sm text-white dark:text-neutral-900"
+										/>
+										{#if tripStop.stopId === stop.id}
+											<FontAwesomeIcon
+												icon={faCheck}
+												class="absolute -right-1 -top-1 rounded-full border border-white bg-brand p-1 text-xs text-white"
+											/>
+										{/if}
+									{:else if tripStop.stopId === stop.id}
+										<FontAwesomeIcon icon={faLocationDot} class="text-xl text-brand-accent" />
+									{:else}
+										<div
+											class="size-4 rounded-full border-2 border-neutral-400 bg-white dark:bg-neutral-800"
+										></div>
+									{/if}
+								</div>
 							</div>
-							<div class="ml-4 flex w-full items-center justify-between space-x-1">
+							<div class="ml-4 flex flex-1 items-center justify-between space-x-1">
 								<div
 									class="text-md dark:text-white {tripStop.stopId === stop.id
 										? 'font-bold'

--- a/src/components/oba/TripDetailsPane.svelte
+++ b/src/components/oba/TripDetailsPane.svelte
@@ -9,7 +9,7 @@
 	} from '@fortawesome/free-solid-svg-icons';
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 	import { formatSecondsFromMidnight } from '$lib/dateTimeFormat';
-	import { resolveVehicleStopIndex, computeVisibleStopRange } from '$lib/tripDetailsUtils';
+	import { resolveVehicleStopIndex, buildStopSegments } from '$lib/tripDetailsUtils';
 
 	/**
 	 * @typedef {Object} Props
@@ -29,11 +29,12 @@
 	let busPosition = $state(-1);
 	let abortController = null;
 
-	// Only show the segment from the vehicle's current position through the
-	// rider's selected stop: stops already passed and stops beyond the rider's
-	// stop are hidden.
-	let visibleRange = $derived(
-		computeVisibleStopRange(tripDetails?.schedule?.stopTimes, busPosition, stop.id)
+	// Rows to render for the segment from the vehicle's current position through
+	// the rider's selected stop: stops already passed and stops beyond the rider's
+	// stop are hidden, and a long run of stops in the middle is collapsed into a
+	// single "N stops" marker (mirroring the iOS trip view).
+	let stopSegments = $derived(
+		buildStopSegments(tripDetails?.schedule?.stopTimes, busPosition, stop.id)
 	);
 
 	// Locate the vehicle along the trip using the stop IDs the server reports for
@@ -125,8 +126,35 @@
 			<div class="relative">
 				<div class="absolute bottom-0 left-3.5 top-0 w-[1px] bg-neutral-400"></div>
 
-				{#each tripDetails.schedule.stopTimes as tripStop, index}
-					{#if index >= visibleRange.start && index <= visibleRange.end}
+				{#each stopSegments as segment (segment.type === 'stop' ? `stop-${segment.index}` : 'collapsed')}
+					{#if segment.type === 'collapsed'}
+						<div class="mb-4 flex items-center">
+							<div class="relative flex size-8 items-center justify-center">
+								<!-- Zig-zag connector standing in for the collapsed stops; the opaque
+								     background masks the straight rail line behind it. -->
+								<svg
+									class="bg-white text-neutral-400 dark:bg-neutral-800"
+									width="16"
+									height="36"
+									viewBox="0 0 16 36"
+									fill="none"
+									aria-hidden="true"
+								>
+									<path
+										d="M8 0 L2 6 L14 12 L2 18 L14 24 L2 30 L8 36"
+										stroke="currentColor"
+										stroke-width="2"
+										stroke-linejoin="round"
+									/>
+								</svg>
+							</div>
+							<div class="ml-4 text-sm text-gray-500 dark:text-gray-400">
+								{$_('trip_details.collapsed_stops', { values: { count: segment.count } })}
+							</div>
+						</div>
+					{:else}
+						{@const index = segment.index}
+						{@const tripStop = tripDetails.schedule.stopTimes[index]}
 						<div class="mb-4 flex items-center">
 							<div
 								class="relative flex size-8 items-center justify-center {index === busPosition

--- a/src/components/oba/__tests__/TripDetailsPane.test.js
+++ b/src/components/oba/__tests__/TripDetailsPane.test.js
@@ -121,7 +121,8 @@ describe('TripDetailsPane', () => {
 	});
 
 	test('does not collapse when only a few stops remain to the rider stop', async () => {
-		// 4 stops (3 intermediate == tail count) => no collapsed marker.
+		// 4 stops: vehicle at index 0, rider at the last index, so only 2
+		// intermediate stops -- fewer than the tail count of 3, so no marker.
 		vi.stubGlobal(
 			'fetch',
 			vi.fn().mockResolvedValue({

--- a/src/components/oba/__tests__/TripDetailsPane.test.js
+++ b/src/components/oba/__tests__/TripDetailsPane.test.js
@@ -51,6 +51,30 @@ function mockTripResponse({ vehicleId }) {
 	};
 }
 
+// Builds a trip of `stopCount` stops where the vehicle sits at the first stop
+// and the rider's stop (`stop.id`) is the last one, so the whole run from the
+// vehicle to the rider is visible.
+function mockLongTripResponse(stopCount) {
+	const stopTimes = Array.from({ length: stopCount }, (_, i) => ({
+		stopId: i === stopCount - 1 ? stop.id : `1_stop${i}`,
+		arrivalTime: 41400 + i * 60
+	}));
+
+	return {
+		data: {
+			entry: {
+				routeId: '1_100479',
+				status: { vehicleId: '1_8129001', closestStop: stopTimes[0].stopId },
+				schedule: { stopTimes }
+			},
+			references: {
+				routes: [{ id: '1_100479', shortName: 'C Line' }],
+				stops: [{ id: stop.id, name: stop.name }]
+			}
+		}
+	};
+}
+
 describe('TripDetailsPane', () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
@@ -77,5 +101,40 @@ describe('TripDetailsPane', () => {
 		await waitFor(() => {
 			expect(screen.getByText('trip_details.live_vehicle 1_8129001')).toBeInTheDocument();
 		});
+	});
+
+	test('collapses the middle stops into an "N stops" marker on a long trip', async () => {
+		// 10 stops, vehicle at index 0, rider at index 9: keep the last 3, collapse 5.
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => mockLongTripResponse(10)
+			})
+		);
+
+		render(TripDetailsPane, { props: { stop, tripId: '1_trip' } });
+
+		await waitFor(() => {
+			expect(screen.getByText('trip_details.collapsed_stops 5')).toBeInTheDocument();
+		});
+	});
+
+	test('does not collapse when only a few stops remain to the rider stop', async () => {
+		// 4 stops (3 intermediate == tail count) => no collapsed marker.
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => mockLongTripResponse(4)
+			})
+		);
+
+		render(TripDetailsPane, { props: { stop, tripId: '1_trip' } });
+
+		await waitFor(() => {
+			expect(screen.getByText(stop.name)).toBeInTheDocument();
+		});
+		expect(screen.queryByText(/trip_details\.collapsed_stops/)).not.toBeInTheDocument();
 	});
 });

--- a/src/components/stops/StopBottomSheet.svelte
+++ b/src/components/stops/StopBottomSheet.svelte
@@ -62,10 +62,11 @@
 				<button
 					type="button"
 					onclick={() => stopPane?.refresh()}
+					disabled={stopPaneLoading}
 					title={$isLoading ? '' : $t('refresh')}
 					aria-label={$isLoading ? '' : $t('refresh')}
 					aria-busy={stopPaneLoading}
-					class="flex h-8 w-8 items-center justify-center rounded-full bg-brand-accent text-sm text-white hover:bg-brand-accent-dark"
+					class="flex h-8 w-8 items-center justify-center rounded-full bg-brand-accent text-sm text-white hover:bg-brand-accent-dark disabled:cursor-not-allowed disabled:opacity-60"
 				>
 					<span class="flex" class:animate-spin={stopPaneLoading}>
 						<FontAwesomeIcon icon={faArrowsRotate} />

--- a/src/components/stops/StopBottomSheet.svelte
+++ b/src/components/stops/StopBottomSheet.svelte
@@ -16,7 +16,12 @@
 	import BottomSheet from '$components/navigation/BottomSheet.svelte';
 	import StopPane from '$components/stops/StopPane.svelte';
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
-	import { faCircleInfo, faCalendarDays, faX } from '@fortawesome/free-solid-svg-icons';
+	import {
+		faCircleInfo,
+		faCalendarDays,
+		faX,
+		faArrowsRotate
+	} from '@fortawesome/free-solid-svg-icons';
 	import { keybinding } from '$lib/keybinding';
 	import '$lib/i18n.js';
 	import { isLoading, t } from 'svelte-i18n';
@@ -25,6 +30,10 @@
 	let { stop, closePane, tripSelected, handleUpdateRouteMap, snap = $bindable('half') } = $props();
 
 	let arrivalsAndDeparturesResponse = $state(null);
+	// Bound from StopPane so the toolbar refresh button can spin while any fetch
+	// (initial, manual, or the 30s poll) is in flight, and trigger a manual one.
+	let stopPane = $state(null);
+	let stopPaneLoading = $state(false);
 
 	let actions = $derived([
 		{ href: `/stops/${stop.id}`, icon: faCircleInfo, labelKey: 'stop_details.view_details' },
@@ -50,6 +59,18 @@
 				<p class="truncate text-xs text-gray-600 dark:text-gray-400">{subtitle}</p>
 			</div>
 			<div class="flex flex-none gap-1.5">
+				<button
+					type="button"
+					onclick={() => stopPane?.refresh()}
+					title={$isLoading ? '' : $t('refresh')}
+					aria-label={$isLoading ? '' : $t('refresh')}
+					aria-busy={stopPaneLoading}
+					class="flex h-8 w-8 items-center justify-center rounded-full bg-brand-accent text-sm text-white hover:bg-brand-accent-dark"
+				>
+					<span class="flex" class:animate-spin={stopPaneLoading}>
+						<FontAwesomeIcon icon={faArrowsRotate} />
+					</span>
+				</button>
 				{#each actions as action (action.href)}
 					<a
 						href={action.href}
@@ -74,10 +95,12 @@
 	{/snippet}
 
 	<StopPane
+		bind:this={stopPane}
 		{tripSelected}
 		{handleUpdateRouteMap}
 		{stop}
 		showHeroCard={false}
 		bind:arrivalsAndDeparturesResponse
+		bind:loading={stopPaneLoading}
 	/>
 </BottomSheet>

--- a/src/components/stops/StopPane.svelte
+++ b/src/components/stops/StopPane.svelte
@@ -1,7 +1,6 @@
 <script>
 	import ArrivalDeparture from '$components/ArrivalDeparture.svelte';
 	import TripDetailsPane from '$components/oba/TripDetailsPane.svelte';
-	import LoadingSpinner from '$components/LoadingSpinner.svelte';
 	import Accordion from '$components/containers/SingleSelectAccordion.svelte';
 	import AccordionItem from '$components/containers/AccordionItem.svelte';
 	import SurveyModal from '$components/surveys/SurveyModal.svelte';
@@ -32,7 +31,10 @@
 		handleUpdateRouteMap = null,
 		tripSelected = null,
 		showHeroCard = true,
-		arrivalsAndDeparturesResponse = $bindable(null)
+		arrivalsAndDeparturesResponse = $bindable(null),
+		// Exposed so a parent (e.g. the bottom-sheet toolbar refresh button) can
+		// reflect whether a fetch — initial, manual, or the 30s poll — is in flight.
+		loading = $bindable(false)
 	} = $props();
 
 	// Time window (in minutes) for upcoming arrivals. Defaults to the OBA
@@ -41,8 +43,9 @@
 	const DEFAULT_MINUTES_AFTER = 35;
 	const MINUTES_AFTER_INCREMENT = 30;
 
-	let arrivalsAndDepartures = $state();
-	let loading = $state(false);
+	// Seed from any server-rendered response so the standalone page shows arrivals
+	// immediately instead of flashing the first-load skeleton.
+	let arrivalsAndDepartures = $state(arrivalsAndDeparturesResponse?.data?.entry);
 	let error = $state();
 	let serviceAlerts = $state([]);
 	let minutesAfter = $state(DEFAULT_MINUTES_AFTER);
@@ -114,6 +117,11 @@
 		}, 30000);
 
 		return promise;
+	}
+
+	// Manual refresh for the toolbar button: fetch now and restart the poll timer.
+	export function refresh() {
+		if (stop?.id) resetDataFetchInterval(stop.id);
 	}
 
 	// Widen the arrivals window and refetch. If the count doesn't grow, surface a
@@ -229,14 +237,27 @@
 	});
 </script>
 
+{#snippet skeletonList()}
+	<!-- First-load placeholder. Once real data arrives, `arrivalsAndDepartures`
+	     stays set, so background refreshes never bring this back. -->
+	<div class="space-y-4" role="status" aria-busy="true" aria-label="Loading">
+		{#each Array.from({ length: 4 }, (_, i) => i) as i (i)}
+			<div class="flex items-center gap-3 px-1">
+				<div class="h-14 w-14 shrink-0 animate-pulse rounded-lg bg-gray-200 dark:bg-gray-700"></div>
+				<div class="flex-1 space-y-2">
+					<div class="h-4 w-3/4 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+					<div class="h-3 w-1/2 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+				</div>
+				<div class="h-5 w-10 shrink-0 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+			</div>
+		{/each}
+	</div>
+{/snippet}
+
 {#if $isLoading}
-	<p>Loading...</p>
+	{@render skeletonList()}
 {:else}
 	<div>
-		{#if loading && isLoading && tripSelected}
-			<LoadingSpinner />
-		{/if}
-
 		{#if error}
 			<p>{error}</p>
 		{/if}
@@ -356,6 +377,8 @@
 					</div>
 				{/if}
 			</div>
+		{:else if !error}
+			{@render skeletonList()}
 		{/if}
 	</div>
 {/if}

--- a/src/components/stops/StopPane.svelte
+++ b/src/components/stops/StopPane.svelte
@@ -47,7 +47,11 @@
 	// immediately instead of flashing the first-load skeleton.
 	let arrivalsAndDepartures = $state(arrivalsAndDeparturesResponse?.data?.entry);
 	let error = $state();
-	let serviceAlerts = $state([]);
+	// Seed alerts from the same server-rendered response so they show on first
+	// render instead of waiting for the initial client fetch to complete.
+	let serviceAlerts = $state(
+		filterActiveAlerts(arrivalsAndDeparturesResponse?.data?.references?.situations ?? [])
+	);
 	let minutesAfter = $state(DEFAULT_MINUTES_AFTER);
 	let loadingMore = $state(false);
 	let noMoreArrivals = $state(false);
@@ -240,7 +244,7 @@
 {#snippet skeletonList()}
 	<!-- First-load placeholder. Once real data arrives, `arrivalsAndDepartures`
 	     stays set, so background refreshes never bring this back. -->
-	<div class="space-y-4" role="status" aria-busy="true" aria-label="Loading">
+	<div class="space-y-4" role="status" aria-busy="true" aria-label={$t('loading')}>
 		{#each Array.from({ length: 4 }, (_, i) => i) as i (i)}
 			<div class="flex items-center gap-3 px-1">
 				<div class="h-14 w-14 shrink-0 animate-pulse rounded-lg bg-gray-200 dark:bg-gray-700"></div>

--- a/src/lib/__tests__/tripDetailsUtils.test.js
+++ b/src/lib/__tests__/tripDetailsUtils.test.js
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { resolveVehicleStopIndex, computeVisibleStopRange } from '$lib/tripDetailsUtils.js';
+import {
+	resolveVehicleStopIndex,
+	computeVisibleStopRange,
+	buildStopSegments
+} from '$lib/tripDetailsUtils.js';
 
 describe('resolveVehicleStopIndex', () => {
 	const stopTimes = [{ stopId: 'a' }, { stopId: 'b' }, { stopId: 'c' }, { stopId: 'd' }];
@@ -77,5 +81,85 @@ describe('computeVisibleStopRange', () => {
 	it('returns an empty range for no stop times', () => {
 		expect(computeVisibleStopRange([], 0, 'a')).toEqual({ start: 0, end: -1 });
 		expect(computeVisibleStopRange(null, 0, 'a')).toEqual({ start: 0, end: -1 });
+	});
+});
+
+describe('buildStopSegments', () => {
+	// 10 stops: a..j
+	const stopTimes = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'].map((stopId) => ({
+		stopId
+	}));
+
+	it('collapses the middle stops when the vehicle is far from the rider stop', () => {
+		// bus at index 0 (a), rider stop j (index 9): 8 intermediate stops,
+		// keep the last 3 (g, h, i), collapse the other 5.
+		expect(buildStopSegments(stopTimes, 0, 'j')).toEqual([
+			{ type: 'stop', index: 0 },
+			{ type: 'collapsed', count: 5 },
+			{ type: 'stop', index: 6 },
+			{ type: 'stop', index: 7 },
+			{ type: 'stop', index: 8 },
+			{ type: 'stop', index: 9 }
+		]);
+	});
+
+	it('collapses exactly one stop when the vehicle is tailCount + 2 stops away', () => {
+		// bus at 0, rider at index 5: 4 intermediate stops, collapse 1, keep 3.
+		expect(buildStopSegments(stopTimes, 0, 'f')).toEqual([
+			{ type: 'stop', index: 0 },
+			{ type: 'collapsed', count: 1 },
+			{ type: 'stop', index: 2 },
+			{ type: 'stop', index: 3 },
+			{ type: 'stop', index: 4 },
+			{ type: 'stop', index: 5 }
+		]);
+	});
+
+	it('does not collapse when intermediate stops equal the tail count', () => {
+		// bus at 0, rider at index 4: 3 intermediate stops == tailCount, show all.
+		expect(buildStopSegments(stopTimes, 0, 'e')).toEqual([
+			{ type: 'stop', index: 0 },
+			{ type: 'stop', index: 1 },
+			{ type: 'stop', index: 2 },
+			{ type: 'stop', index: 3 },
+			{ type: 'stop', index: 4 }
+		]);
+	});
+
+	it('respects a custom tailCount', () => {
+		// bus at 0, rider at index 9, tailCount 2: keep last 2 (h, i), collapse 6.
+		expect(buildStopSegments(stopTimes, 0, 'j', 2)).toEqual([
+			{ type: 'stop', index: 0 },
+			{ type: 'collapsed', count: 6 },
+			{ type: 'stop', index: 7 },
+			{ type: 'stop', index: 8 },
+			{ type: 'stop', index: 9 }
+		]);
+	});
+
+	it('collapses long scheduled trips even without a known vehicle position', () => {
+		// busPosition -1 => range starts at 0; rider at index 9 => collapse 5.
+		expect(buildStopSegments(stopTimes, -1, 'j')).toEqual([
+			{ type: 'stop', index: 0 },
+			{ type: 'collapsed', count: 5 },
+			{ type: 'stop', index: 6 },
+			{ type: 'stop', index: 7 },
+			{ type: 'stop', index: 8 },
+			{ type: 'stop', index: 9 }
+		]);
+	});
+
+	it('returns a single stop when the vehicle sits at the rider stop', () => {
+		expect(buildStopSegments(stopTimes, 3, 'd')).toEqual([{ type: 'stop', index: 3 }]);
+	});
+
+	it('returns an empty list when the bus has already passed the rider stop', () => {
+		// bus at 5, rider at index 3 => computeVisibleStopRange clamps to 3..3.
+		expect(buildStopSegments(stopTimes, 5, 'd')).toEqual([{ type: 'stop', index: 3 }]);
+	});
+
+	it('returns an empty list when there are no stop times', () => {
+		expect(buildStopSegments([], 0, 'a')).toEqual([]);
+		expect(buildStopSegments(null, 0, 'a')).toEqual([]);
 	});
 });

--- a/src/lib/tripDetailsUtils.js
+++ b/src/lib/tripDetailsUtils.js
@@ -45,3 +45,43 @@ export function computeVisibleStopRange(stopTimes, busPosition, riderStopId) {
 
 	return { start, end };
 }
+
+/**
+ * Build the ordered list of rows to render for the trip's visible stop segment,
+ * collapsing the middle stops into a single "N stops" marker when the vehicle is
+ * far from the rider's stop — mirroring the iOS trip view.
+ *
+ * Within the visible range (vehicle position → rider stop) the head stop and the
+ * last `tailCount` stops before the rider's stop (plus the rider's stop itself)
+ * are always shown; anything in between is collapsed. When `tailCount` or fewer
+ * intermediate stops exist, nothing is collapsed and every stop is rendered.
+ *
+ * @param {Array<{ stopId: string }> | null | undefined} stopTimes
+ * @param {number} busPosition index of the vehicle's current stop, or -1
+ * @param {string} riderStopId the rider's selected stop id
+ * @param {number} [tailCount] stops to keep before the rider's stop (default 3)
+ * @returns {Array<{ type: 'stop', index: number } | { type: 'collapsed', count: number }>}
+ *   ordered render items; empty when there is nothing to show
+ */
+export function buildStopSegments(stopTimes, busPosition, riderStopId, tailCount = 3) {
+	const { start, end } = computeVisibleStopRange(stopTimes, busPosition, riderStopId);
+	if (end < start) return [];
+
+	const intermediate = end - start - 1;
+	if (intermediate <= tailCount) {
+		const segments = [];
+		for (let index = start; index <= end; index++) {
+			segments.push({ type: 'stop', index });
+		}
+		return segments;
+	}
+
+	const segments = [
+		{ type: 'stop', index: start },
+		{ type: 'collapsed', count: intermediate - tailCount }
+	];
+	for (let index = end - tailCount; index <= end; index++) {
+		segments.push({ type: 'stop', index });
+	}
+	return segments;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -128,6 +128,7 @@
 	"show_more": "Show more",
 	"show_less": "Show less",
 	"load_more_arrivals": "Load more arrivals",
+	"refresh": "Refresh",
 	"no_arrivals_found_in_next_minutes": "No arrivals found in the next {minutes} minutes",
 	"stop": "Stop",
 	"routes": "Routes",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -233,7 +233,8 @@
 		"route": "Route",
 		"no_stops": "No stop times available for this trip.",
 		"loading": "Loading trip details...",
-		"live_vehicle": "Live · vehicle {vehicleId}"
+		"live_vehicle": "Live · vehicle {vehicleId}",
+		"collapsed_stops": "{count, plural, one {# stop} other {# stops}}"
 	},
 	"skip_to_main_content": "Skip to main content"
 }


### PR DESCRIPTION
## Summary

A set of iOS-inspired polish passes on the stop / trip detail UI. Three independent threads, all on this branch:

- **Collapsed stop list** — distant intermediate stops in `TripDetailsPane` collapse into an iOS-style zig-zag connector (with supporting `tripDetailsUtils` helpers), plus bottom-sheet overflow fixes for full-bleed accordion rows.
- **Refresh affordance** — replaced the stop-pane refresh dimming with a toolbar spinner + skeleton.
- **Route badges** — gave `RouteBadge` a subtle iOS-style gradient/gloss (static styling lives in scoped CSS), and replaced the flat 14px font cap with auto-sizing: short codes (e.g. `60`) grow to a 24px ceiling, while multi-word names (e.g. `First Hill Streetcar`) stay bounded by a longest-word width constraint and a line-count height constraint.

## Test plan

- [x] `npx vitest run` on the affected suites (`RouteBadge`, `TripDetailsPane`, `tripDetailsUtils`) — green (RouteBadge now 11 tests).
- [x] Exercised the route badges in the running dev app (Broadway & Marion stop): confirmed `43` renders large with the gloss, `First Hill Streetcar` stays small and fits, gradient/shadow render correctly after the scoped-CSS refactor.
- [ ] Reviewer spot-check of the zig-zag collapse and refresh spinner in-app (those commits predate this session's manual pass).

## Notes

- This PR bundles three thematically-related but independent features; they can be reviewed commit-by-commit.
- Badge font sizing uses two competing constraints (`90 / longestWord` for width, `42 / lineCount` for height), min of the two, clamped to `[8, 24]`. New tests pin the height path, the 8px floor, and empty/whitespace/missing-input guards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Trip details now collapse long sequences of intermediate stops into a compact “N stops” marker.
  - Stop details include a refresh button with loading feedback.
  - Stop arrival lists now display skeleton placeholders while loading.
- **UI Improvements**
  - Route badges use improved font sizing for short, long, and multi-word names.
  - Bottom sheets provide better horizontal spacing and overflow protection.
- **Localization**
  - Added labels for refreshing data and collapsed stop counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->