### PR TITLE
perf: eliminate double map load on cold start; bundle Leaflet CSS

### DIFF
--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -7,6 +7,7 @@ import {
 	prioritizedRouteTypeForDisplay,
 	SHOW_ROUTE_LABELS_AT_ZOOM
 } from '$config/routeConfig';
+import 'leaflet/dist/leaflet.css';
 import './../../assets/styles/leaflet-map.css';
 import PolylineUtil from 'polyline-encoded';
 import { COLORS } from '$lib/colors';
@@ -64,17 +65,18 @@ export default class OpenStreetMapProvider {
 
 		this.L = leaflet.default;
 
-		// Leaflet CSS
-		const link = document.createElement('link');
-		link.rel = 'stylesheet';
-		link.href = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css';
-		document.head.appendChild(link);
+		// Leaflet's CSS is bundled via the top-of-file import 'leaflet/dist/leaflet.css'
+		// rather than injected from a CDN at runtime, so the map's core styles aren't a
+		// render-blocking third-party request or a single point of failure.
 
 		this.map = this.L.map(element, { zoomControl: false }).setView([options.lat, options.lng], 14);
 
 		this.L.control.zoom({ position: 'bottomright' }).addTo(this.map);
+		// Record the applied style URL so setTheme() can skip a redundant layer
+		// rebuild when the theme already matches the boot style (see setTheme).
+		this.currentStyleUrl = `https://tiles.openfreemap.org/styles/${this.maplibreLayer}`;
 		this.maplibreLayer = this.L.maplibreGL({
-			style: `https://tiles.openfreemap.org/styles/${this.maplibreLayer}`,
+			style: this.currentStyleUrl,
 			interactive: true,
 			dragRotate: false
 		}).addTo(this.map);
@@ -574,6 +576,13 @@ export default class OpenStreetMapProvider {
 		} else {
 			styleUrl = 'https://tiles.openfreemap.org/styles/positron';
 		}
+
+		// Rebuilding the MapLibre layer re-fetches the style, sprites, glyph fonts,
+		// and vector tiles. Skip it when the style is unchanged — otherwise the
+		// themeChange dispatched right after initMap tears down and rebuilds the
+		// layer with the identical style, doubling the map's cold-load network cost.
+		if (styleUrl === this.currentStyleUrl) return;
+		this.currentStyleUrl = styleUrl;
 
 		if (this.maplibreLayer) {
 			this.map.removeLayer(this.maplibreLayer);

--- a/src/tests/lib/OpenStreetMapProvider.test.js
+++ b/src/tests/lib/OpenStreetMapProvider.test.js
@@ -361,6 +361,63 @@ describe('addVehicleMarker — route color', () => {
 	});
 });
 
+describe('setTheme — avoids redundant layer rebuilds', () => {
+	let provider;
+	let removeLayer;
+
+	beforeEach(() => {
+		provider = new OpenStreetMapProvider(vi.fn());
+		removeLayer = vi.fn();
+		provider.map = { removeLayer };
+		provider.L = {
+			maplibreGL: vi.fn(() => ({ addTo: vi.fn().mockReturnThis() }))
+		};
+		// Simulate post-initMap state: the light (positron) style is applied.
+		provider.currentStyleUrl = 'https://tiles.openfreemap.org/styles/positron';
+		provider.maplibreLayer = { existing: true };
+	});
+
+	// Regression guard: onMount dispatches a themeChange right after initMap, so
+	// setTheme is called with the theme that already matches the boot style. If it
+	// rebuilds the layer, MapLibre re-fetches the style/sprites/fonts/tiles and the
+	// whole map loads over the network twice.
+	test('does not rebuild the layer when the style is unchanged', () => {
+		provider.setTheme('light');
+
+		expect(removeLayer).not.toHaveBeenCalled();
+		expect(provider.L.maplibreGL).not.toHaveBeenCalled();
+		expect(provider.currentStyleUrl).toBe('https://tiles.openfreemap.org/styles/positron');
+	});
+
+	test('rebuilds with the new style when the theme actually changes', () => {
+		provider.setTheme('dark');
+
+		expect(removeLayer).toHaveBeenCalledWith({ existing: true });
+		expect(provider.L.maplibreGL).toHaveBeenCalledWith({
+			style: 'https://tiles.openfreemap.org/styles/dark'
+		});
+		expect(provider.currentStyleUrl).toBe('https://tiles.openfreemap.org/styles/dark');
+	});
+
+	test('a repeated switch to the same theme is a no-op after the first change', () => {
+		provider.setTheme('dark');
+		provider.L.maplibreGL.mockClear();
+		removeLayer.mockClear();
+
+		provider.setTheme('dark');
+
+		expect(removeLayer).not.toHaveBeenCalled();
+		expect(provider.L.maplibreGL).not.toHaveBeenCalled();
+	});
+
+	test('bails out before the map is initialized', () => {
+		provider.map = null;
+		provider.setTheme('dark');
+
+		expect(provider.L.maplibreGL).not.toHaveBeenCalled();
+	});
+});
+
 describe('flyTo — vertical offset for the bottom sheet', () => {
 	let provider;
 


### PR DESCRIPTION
## Summary

Two low-cost, high-impact map performance fixes, prompted by a production Lighthouse audit of the Sound Transit instance (Performance 95 — the app is already fast; these trim real waste on the map's cold-load path).

### 1. Map no longer loads twice on cold start
The OSM map was fetching its **entire style JSON, sprites, glyph fonts, and vector tiles twice** on every cold load — confirmed in the Lighthouse network trace, where every `tiles.openfreemap.org` request (including `/styles/positron` → 200) appeared exactly twice (~437 KB of duplicate transfer, plus a redundant MapLibre GL setup feeding into TTI).

**Cause:** `onMount` dispatches a `themeChange` event immediately after `initMap()`, and `setTheme()` unconditionally removed and rebuilt the MapLibre layer — with the *same* style it just booted with.

**Fix:** `setTheme()` now early-returns when the style URL is unchanged, tracked via `this.currentStyleUrl` (recorded in both `initMap` and `setTheme`).

### 2. Leaflet CSS is bundled instead of loaded from unpkg
`initMap()` injected `<link href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">` at runtime — a render-blocking third-party request and CDN single point of failure for the map's core styles. Replaced with a bundled `import 'leaflet/dist/leaflet.css'` (the `leaflet` package is already a direct dependency), so the version stays pinned to `package.json`.

## Tests
Adds 4 `setTheme` tests: unchanged-style no-op, real theme change rebuilds, repeated-same-theme no-op, bail before map init. Full suite green: **1460 passing**, lint/format clean.

## Notes
Separately, the audit surfaced a failing `/api/events` analytics call (`fetch failed` → 500) on the Sound Transit deployment. That's an **environment/config issue** — the configured `PUBLIC_ANALYTICS_API_HOST` (umami) is unreachable from the server — not an app bug, so it's out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant map layer rebuilds when switching to a theme that is already active.
  * Improved theme changes so switching styles updates the map correctly without unnecessary reloads.
  * Prevented theme updates from triggering map operations before the map is initialized.

* **Tests**
  * Added coverage for unchanged themes, theme switching, and uninitialized maps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->