### PR TITLE
fix: surface the upstream reason when an analytics event fails

### DIFF
--- a/src/lib/Insights/Insights.js
+++ b/src/lib/Insights/Insights.js
@@ -1,4 +1,5 @@
 import { env as dynamicEnv } from '$env/dynamic/public';
+import { upstreamError } from './upstreamError.js';
 
 /**
  * Provider-agnostic facade. Builds an AnalyticsEnvelope and POSTs it to /api/events.
@@ -75,8 +76,7 @@ export class Analytics {
 			});
 
 			if (!response.ok) {
-				const errorText = await response.text();
-				throw new Error(`Error sending event: ${response.statusText}. ${errorText}`);
+				throw await upstreamError(response);
 			}
 			return response.json();
 		} catch (error) {

--- a/src/lib/Insights/adapters/PlausibleAdapter.js
+++ b/src/lib/Insights/adapters/PlausibleAdapter.js
@@ -1,3 +1,5 @@
+import { upstreamError } from '../upstreamError.js';
+
 const UPSTREAM_TIMEOUT_MS = 5000;
 
 export class PlausibleAdapter {
@@ -56,9 +58,7 @@ export class PlausibleAdapter {
 			});
 
 			if (!res.ok) {
-				const err = new Error(`Error sending event: ${res.statusText}`);
-				err.upstreamStatus = res.status;
-				throw err;
+				throw await upstreamError(res);
 			}
 
 			const text = await res.text();

--- a/src/lib/Insights/adapters/UmamiAdapter.js
+++ b/src/lib/Insights/adapters/UmamiAdapter.js
@@ -1,3 +1,5 @@
+import { insightsError, upstreamError } from '../upstreamError.js';
+
 const UPSTREAM_TIMEOUT_MS = 5000;
 
 const MAX_DATA_VALUE_LENGTH = 256;
@@ -135,16 +137,12 @@ export class UmamiAdapter {
 			});
 
 			if (!res.ok) {
-				const err = new Error(`Error sending event: ${res.statusText}`);
-				err.upstreamStatus = res.status;
-				throw err;
+				throw await upstreamError(res);
 			}
 
 			const text = await res.text();
 			if (!isSuccessfulIngest(text)) {
-				const err = new Error('Umami dropped event as bot-like (isbot rejected the User-Agent)');
-				err.upstreamStatus = 502;
-				throw err;
+				throw insightsError('Umami dropped event as bot-like (isbot rejected the User-Agent)', 502);
 			}
 			try {
 				return JSON.parse(text);

--- a/src/lib/Insights/upstreamError.js
+++ b/src/lib/Insights/upstreamError.js
@@ -1,0 +1,50 @@
+const MAX_UPSTREAM_BODY_LENGTH = 300;
+
+/**
+ * Build an Error carrying the `upstreamStatus` that `/api/events` reads to pick its own
+ * HTTP status. Single home for that contract so every upstream-failure throw in this
+ * feature spells it the same way.
+ *
+ * @param {string} message
+ * @param {number} upstreamStatus
+ * @returns {Error}
+ */
+export function insightsError(message, upstreamStatus) {
+	const err = new Error(message);
+	err.upstreamStatus = upstreamStatus;
+	return err;
+}
+
+/**
+ * Build the Error for a non-OK response, folding the response body into the message. The
+ * actionable reason lives in the body — Umami answers a stale PUBLIC_ANALYTICS_WEBSITE_ID
+ * with `{"error":{"message":"Website not found."}}` — while statusText is only
+ * "Bad Request", so dropping the body makes misconfiguration undiagnosable.
+ *
+ * The body is consumed (callers must not read it again) and capped at
+ * MAX_UPSTREAM_BODY_LENGTH so a misconfigured proxy's HTML error page can't flood logs.
+ * The numeric status leads the message because HTTP/2 has no reason phrase: statusText is
+ * always '' there, which is the shape the browser sees when it calls this on /api/events.
+ *
+ * @param {{status?: number, statusText?: string, text?: () => Promise<string>}} res -
+ *   The non-OK response. Deliberately tolerant of Response-likes missing `text()`.
+ * @returns {Promise<Error>} Error carrying `upstreamStatus`.
+ */
+export async function upstreamError(res) {
+	let detail = '';
+	try {
+		detail = (await res.text()).trim();
+	} catch (bodyError) {
+		// An unreadable body must not mask the failure it was meant to explain — but an
+		// empty body and an unreadable one are different incidents, so say which happened.
+		detail = `<upstream body unreadable: ${bodyError?.name || 'Error'}>`;
+	}
+
+	if (detail.length > MAX_UPSTREAM_BODY_LENGTH) {
+		detail = `${detail.slice(0, MAX_UPSTREAM_BODY_LENGTH)}…`;
+	}
+
+	const status = [res.status, res.statusText].filter(Boolean).join(' ');
+
+	return insightsError(`Error sending event: ${status}${detail ? ` — ${detail}` : ''}`, res.status);
+}

--- a/src/routes/api/events/+server.js
+++ b/src/routes/api/events/+server.js
@@ -27,6 +27,10 @@ export async function POST({ request, getClientAddress }) {
 			headers: { 'Content-Type': 'application/json' }
 		});
 	} catch (error) {
+		// The upstream's reason (e.g. Umami's "Website not found." for a stale
+		// PUBLIC_ANALYTICS_WEBSITE_ID) is only actionable if it reaches the operator's logs —
+		// the browser console that also receives it belongs to whoever happened to trip it.
+		console.error('Events endpoint failure:', error);
 		// AbortError comes from the adapter's AbortController timeout (5s) — surface as 504.
 		const isTimeout = error?.name === 'AbortError';
 		return new Response(JSON.stringify({ error: error.message || 'Unknown error' }), {

--- a/src/tests/api/events.test.js
+++ b/src/tests/api/events.test.js
@@ -118,7 +118,24 @@ describe('POST /api/events', () => {
 		);
 	});
 
-	it('forwards upstream status code on upstream error', async () => {
+	// The whole point of folding the body in is that it survives to the wire, so assert it
+	// here and not only at the adapter level.
+	it('forwards upstream status code and the upstream reason on upstream error', async () => {
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 400,
+			statusText: 'Bad Request',
+			text: async () => '{"error":{"message":"Website not found."}}'
+		});
+		const response = await POST(buildEvent());
+		const data = await response.json();
+		expect(response.status).toBe(400);
+		expect(data.error).toBe(
+			'Error sending event: 400 Bad Request — {"error":{"message":"Website not found."}}'
+		);
+	});
+
+	it('still forwards the upstream status when the upstream body cannot be read', async () => {
 		global.fetch = vi.fn().mockResolvedValue({
 			ok: false,
 			status: 502,
@@ -127,7 +144,8 @@ describe('POST /api/events', () => {
 		const response = await POST(buildEvent());
 		const data = await response.json();
 		expect(response.status).toBe(502);
-		expect(data).toEqual({ error: 'Error sending event: Bad Gateway' });
+		expect(data.error).toContain('Error sending event: 502 Bad Gateway');
+		expect(data.error).toContain('upstream body unreadable');
 	});
 
 	it('returns 400 when request body is not valid JSON', async () => {

--- a/src/tests/lib/Insights/Insights.test.js
+++ b/src/tests/lib/Insights/Insights.test.js
@@ -120,6 +120,7 @@ describe('Analytics envelope construction', () => {
 	it('swallows and logs (does not throw) when /api/events responds non-OK', async () => {
 		global.fetch = vi.fn().mockResolvedValue({
 			ok: false,
+			status: 500,
 			statusText: 'Server Error',
 			text: async () => 'boom'
 		});
@@ -128,7 +129,7 @@ describe('Analytics envelope construction', () => {
 		expect(result).toBeUndefined();
 		expect(errorSpy).toHaveBeenCalledWith(
 			'Analytics error:',
-			expect.objectContaining({ message: 'Error sending event: Server Error. boom' })
+			expect.objectContaining({ message: 'Error sending event: 500 Server Error — boom' })
 		);
 	});
 

--- a/src/tests/lib/Insights/adapters/PlausibleAdapter.test.js
+++ b/src/tests/lib/Insights/adapters/PlausibleAdapter.test.js
@@ -154,18 +154,23 @@ describe('PlausibleAdapter.forwardEvent', () => {
 		expect(result).toEqual({ status: 'ok' });
 	});
 
-	it('throws Error with upstreamStatus on non-OK response', async () => {
+	// Asserts the adapter routes its non-OK branch through upstreamError, body included —
+	// this is the real Plausible response to an unregistered PUBLIC_ANALYTICS_DOMAIN.
+	it('throws Error with upstreamStatus and the upstream body on non-OK response', async () => {
 		global.fetch = vi.fn().mockResolvedValue({
 			ok: false,
-			status: 502,
-			statusText: 'Bad Gateway'
+			status: 400,
+			statusText: 'Bad Request',
+			text: async () => 'domain `example.com` is not registered'
 		});
 		try {
 			await new PlausibleAdapter(fullEnv).forwardEvent(envelope, ctx);
 			expect.unreachable('should have thrown');
 		} catch (error) {
-			expect(error.message).toBe('Error sending event: Bad Gateway');
-			expect(error.upstreamStatus).toBe(502);
+			expect(error.message).toBe(
+				'Error sending event: 400 Bad Request — domain `example.com` is not registered'
+			);
+			expect(error.upstreamStatus).toBe(400);
 		}
 	});
 

--- a/src/tests/lib/Insights/adapters/UmamiAdapter.test.js
+++ b/src/tests/lib/Insights/adapters/UmamiAdapter.test.js
@@ -224,18 +224,23 @@ describe('UmamiAdapter.forwardEvent (edge cases)', () => {
 		}
 	});
 
-	it('throws Error with upstreamStatus on non-OK response', async () => {
+	// Asserts the adapter routes its non-OK branch through upstreamError, body included —
+	// this is the real Umami response to a stale PUBLIC_ANALYTICS_WEBSITE_ID.
+	it('throws Error with upstreamStatus and the upstream body on non-OK response', async () => {
 		global.fetch = vi.fn().mockResolvedValue({
 			ok: false,
-			status: 502,
-			statusText: 'Bad Gateway'
+			status: 400,
+			statusText: 'Bad Request',
+			text: async () => '{"error":{"message":"Website not found.","code":"bad-request"}}'
 		});
 		try {
 			await new UmamiAdapter(fullEnv).forwardEvent(envelope, ctx);
 			expect.unreachable('should have thrown');
 		} catch (error) {
-			expect(error.message).toBe('Error sending event: Bad Gateway');
-			expect(error.upstreamStatus).toBe(502);
+			expect(error.message).toBe(
+				'Error sending event: 400 Bad Request — {"error":{"message":"Website not found.","code":"bad-request"}}'
+			);
+			expect(error.upstreamStatus).toBe(400);
 		}
 	});
 

--- a/src/tests/lib/Insights/upstreamError.test.js
+++ b/src/tests/lib/Insights/upstreamError.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { insightsError, upstreamError } from '$lib/Insights/upstreamError.js';
+
+const response = (overrides) => ({
+	status: 400,
+	statusText: 'Bad Request',
+	text: async () => '',
+	...overrides
+});
+
+describe('insightsError', () => {
+	it('carries the message and upstreamStatus', () => {
+		const error = insightsError('dropped as bot-like', 502);
+		expect(error).toBeInstanceOf(Error);
+		expect(error.message).toBe('dropped as bot-like');
+		expect(error.upstreamStatus).toBe(502);
+	});
+});
+
+describe('upstreamError', () => {
+	it('folds the response body into the message', async () => {
+		const error = await upstreamError(
+			response({
+				text: async () => '{"error":{"message":"Website not found.","code":"bad-request"}}'
+			})
+		);
+		expect(error.message).toBe(
+			'Error sending event: 400 Bad Request — {"error":{"message":"Website not found.","code":"bad-request"}}'
+		);
+	});
+
+	it('sets upstreamStatus from the response status', async () => {
+		const error = await upstreamError(response({ status: 503, statusText: 'Service Unavailable' }));
+		expect(error.upstreamStatus).toBe(503);
+	});
+
+	// HTTP/2 has no reason phrase, so statusText is '' for every h2 response — including the
+	// one the browser gets back from /api/events in production.
+	it('falls back to the numeric status when statusText is empty (HTTP/2)', async () => {
+		const error = await upstreamError(
+			response({ statusText: '', text: async () => 'Website not found.' })
+		);
+		expect(error.message).toBe('Error sending event: 400 — Website not found.');
+	});
+
+	it('omits the separator when the body is empty', async () => {
+		const error = await upstreamError(response({ text: async () => '' }));
+		expect(error.message).toBe('Error sending event: 400 Bad Request');
+	});
+
+	it('omits the separator when the body is only whitespace', async () => {
+		const error = await upstreamError(response({ text: async () => '  \n\t ' }));
+		expect(error.message).toBe('Error sending event: 400 Bad Request');
+	});
+
+	it('truncates an oversized body', async () => {
+		const error = await upstreamError(response({ text: async () => 'x'.repeat(500) }));
+		expect(error.message).toBe(`Error sending event: 400 Bad Request — ${'x'.repeat(300)}…`);
+	});
+
+	it('leaves a body at exactly the limit untruncated', async () => {
+		const error = await upstreamError(response({ text: async () => 'x'.repeat(300) }));
+		expect(error.message).toBe(`Error sending event: 400 Bad Request — ${'x'.repeat(300)}`);
+	});
+
+	// An unreadable body and an empty body are different incidents; the message must not
+	// conflate them, and neither may mask the upstream status.
+	it('reports an unreadable body without losing the status', async () => {
+		const error = await upstreamError(
+			response({
+				text: async () => {
+					throw new TypeError('stream already consumed');
+				}
+			})
+		);
+		expect(error.message).toBe(
+			'Error sending event: 400 Bad Request — <upstream body unreadable: TypeError>'
+		);
+		expect(error.upstreamStatus).toBe(400);
+	});
+
+	it('reports an unreadable body when the response exposes no text()', async () => {
+		const error = await upstreamError({ status: 400, statusText: 'Bad Request' });
+		expect(error.message).toBe(
+			'Error sending event: 400 Bad Request — <upstream body unreadable: TypeError>'
+		);
+		expect(error.upstreamStatus).toBe(400);
+	});
+});


### PR DESCRIPTION
## Summary

- A non-OK response from Umami/Plausible threw `Error sending event: ${res.statusText}` and dropped the response body. Umami answers a stale `PUBLIC_ANALYTICS_WEBSITE_ID` with HTTP 400 + `{"error":{"message":"Website not found."}}`, so the only thing an operator saw was `Bad Request` — the actionable reason was discarded.
- Adds `upstreamError(res)`, which folds the trimmed, 300-char-capped body into the message, and `insightsError(message, upstreamStatus)`, giving the status contract that `/api/events` reads a single home. Both server adapters and the browser-side `Analytics.postEvent` now use it.
- The message leads with the numeric status because HTTP/2 has no reason phrase — `statusText` is always `''` there, which is exactly the response the browser gets back from `/api/events` in production.
- An unreadable body is now reported as such rather than degrading silently to the same message an empty body produces.
- `/api/events` now logs its failures, matching every sibling route under `src/routes/api/`. This is the real payoff: the reason belongs in the operator's logs, not only in the console of whoever happened to trip it.

## Test plan

Exercised against a local mock upstream (not production analytics), driving the real SvelteKit route end-to-end for both providers:

- [x] Golden path — upstream 200 → `200` with the ingest JSON passed through; stop page `/stops/1_75403` loads with 0 console errors
- [x] Stale website ID — upstream 400 + Umami error body → `400`, message carries `Website not found.`
- [x] Empty error body → `400`, no orphaned `—` separator
- [x] Oversized body → truncated at exactly 300 chars + `…`, status preserved
- [x] Both `umami` and `plausible` providers via `PUBLIC_ANALYTICS_PROVIDER`
- [x] Browser leg verified in Playwright: `Analytics error: Error: Error sending event: 400 Bad Request — {"error":{"message":"Website not found."}}`
- [x] Server log verified: `Events endpoint failure: ...` reaches stdout
- [x] `npx vitest run` — 83 files, 1471 tests passing; prettier + eslint clean

## Review notes

Non-blocking findings raised during review, deliberately left out of scope:

- **Upstream body is echoed to unauthenticated clients.** `/api/events` has no auth, so anyone can drive a non-OK response and read back up to 300 chars of whatever the analytics host — or a proxy/WAF in front of it — returned. Umami/Plausible bodies are benign JSON, so this is a judgment call rather than a defect. Now that the route logs server-side, the hardening option is cheap if wanted: keep the detail in logs, return a generic message to the client.
- **Umami's "dropped as bot-like" branch asserts a cause it hasn't established.** `isSuccessfulIngest` returns false for several conditions (non-JSON body, HTML interstitial, `{}`), but only `{"beep":"boop"}` is an actual isbot rejection — and the body that would disprove the claim is discarded. Pre-existing behavior, unchanged here, but worth the same treatment this PR gave the non-OK branch.
- **Envelope-validation throws still become 500s.** `forwardEvent requires name and url` carries no `upstreamStatus`, so a malformed envelope surfaces as 500 rather than 400. One-line fix now that `insightsError` exists, but it changes response codes, so it seemed worth deciding separately.
- **`Insights.js` swallow is narrower than its comment claims.** `JSON.stringify(envelope)` and `navigator.sendBeacon` sit outside the try, so they can still produce the unhandled rejection the comment says can't happen.
- **Double truncation on the browser leg.** The server truncates to 300, JSON-escaping roughly doubles it, then the client truncates again. Harmless for real Umami bodies; moot if the client message is ever made generic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics error messages with upstream status codes and response details.
  * Preserved useful error information when upstream response bodies are unavailable or unreadable.
  * Standardized error reporting across supported analytics integrations.
  * Added server-side logging for event delivery failures.

* **Tests**
  * Expanded coverage for upstream failures, response formatting, truncated messages, and unreadable response bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->