### PR TITLE
Re-compose the map around the selected stop

### DIFF
--- a/docs/superpowers/plans/2026-07-23-map-stop-selection.md
+++ b/docs/superpowers/plans/2026-07-23-map-stop-selection.md
@@ -1373,11 +1373,7 @@ Replace the markup block (currently lines 71-103) with:
 	<!-- The button keeps its 32px box in every tier. Collapsing the *icon* to a
 	     dot is the whole point, but collapsing the hit target with it would put
 	     the control under the WCAG 2.5.8 minimum and make it unusable on touch. -->
-	<button
-		class="marker-hit-area"
-		onclick={onClick}
-		aria-label={stop.name}
-	>
+	<button class="marker-hit-area" onclick={onClick} aria-label={stop.name}>
 		{#if isFullPin}
 			<span class="custom-marker dark:border-[#5a2c2c] {isHighlighted ? 'highlight' : ''}">
 				<span class="bus-icon dark:text-white">

--- a/docs/superpowers/plans/2026-07-23-map-stop-selection.md
+++ b/docs/superpowers/plans/2026-07-23-map-stop-selection.md
@@ -359,6 +359,13 @@ Then replace the framing effect's `else` branch (currently lines 173-186):
     // from an open stop sheet, handleRouteSelected has already set
     // currentModal = Modal.ROUTE and added the route's vehicles before this
     // teardown flushes. A normal stop close leaves currentModal null.
+    // Everything in this block is scoped to a *plain* stop close. When a route is
+    // selected from an open stop sheet, handleRouteSelected has already pushed
+    // '/' and set currentModal = Modal.ROUTE, selectedRoute, and isRouteSelected
+    // in the same synchronous handler — Svelte coalesces that into one flush, so
+    // this branch runs with the route already live. Resetting any of it here
+    // would stomp the selection the rider just made (and RouteModal would keep
+    // rendering against a null route).
     if (currentModal !== Modal.ROUTE) {
         provider.clearVehicleMarkers();
         // clearVehicleMarkers only detaches the markers from the map. The module
@@ -366,17 +373,20 @@ Then replace the framing effect's `else` branch (currently lines 173-186):
         // find stale entries via .has() and update detached markers that never
         // render. RouteMap's onDestroy already pairs these two calls.
         clearVehicleMarkersMap();
+
+        // closePane() short-circuits for the stop case (pushState + return), and
+        // the accordion never fires its collapse callback because StopPane is
+        // destroyed rather than collapsed. So if the rider had a row expanded,
+        // these three are still truthy — which pins mapMode at ROUTE forever and
+        // permanently stops markers from loading.
+        showRouteMap = false;
+        isRouteSelected = false;
+        selectedRoute = null;
     }
+    // Correct on both paths: a route selection should still drop the previously
+    // expanded trip and the previous stop's arrivals.
     selectedTrip = null;
     stopArrivals = null;
-    // closePane() short-circuits for the stop case (pushState + return), and the
-    // accordion never fires its collapse callback because StopPane is destroyed
-    // rather than collapsed. So if the rider had a row expanded, these three are
-    // still truthy — which pins mapMode at ROUTE forever and permanently stops
-    // markers from loading. Reset them here, where every close path converges.
-    showRouteMap = false;
-    isRouteSelected = false;
-    selectedRoute = null;
 }
 ```
 

--- a/docs/superpowers/plans/2026-07-23-map-stop-selection.md
+++ b/docs/superpowers/plans/2026-07-23-map-stop-selection.md
@@ -1,0 +1,3421 @@
+# Map Stop Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a rider selects a stop, de-emphasize every other stop into dots and draw the routes from that stop's arrivals list plus their live vehicles, each colored consistently across line, vehicle, legend, and arrival badge.
+
+**Architecture:** Route colors resolve once in `MapExperience` (a pure module, `$lib/activeRoutes.js`) and flow down two paths — into the map layer and into the arrivals sheet — so badge and line can never disagree. Stop markers stay mounted for the lifetime of a selection and get their tier via a reactive `marker.props.emphasis` mutation, the same channel the providers already use for `showRoutesLabel`. A new `StopRoutesLayer.svelte` owns shape fetching and vehicle polling; a reworked `vehicleUtils.js` polls N routes on one interval with a failure-aware, route-scoped marker sweep.
+
+**Tech Stack:** SvelteKit 5 (runes), Leaflet + MapLibre GL (OSM provider), Google Maps JS API (Google provider), Tailwind, Vitest + @testing-library/svelte.
+
+**Spec:** `docs/superpowers/specs/2026-07-23-map-stop-selection-design.md`
+
+## Global Constraints
+
+- **Run tests with `npx vitest run`**, never `npm run test` — it hangs in a non-TTY shell.
+- **Settings are module constants, not env vars:** `STOP_TREATMENT = 'dots'`, `SHOW_VEHICLES = true`, `DIM_BASEMAP = true`. There is no `animateFlow` constant and no flow-dash overlay.
+- **Both map providers must stay at parity** for every new method. `PUBLIC_OBA_MAP_PROVIDER` selects between them at runtime; a method on one must exist on the other.
+- **Coverage:** `vite.config.js` sets `all: true` with a global 70% threshold and no `include`, so every new file counts toward coverage whether or not it has a test.
+- **`RouteBadge` takes hex WITHOUT a leading `#`** (`RouteBadge.svelte:12` does `` `#${color}` ``). Map-facing colors carry the `#`. `assignRouteColors` returns both forms; do not convert anywhere else.
+- **OBA sends `predictedArrivalTime: 0`, not `null`,** when there is no prediction. Always test `a.predicted && a.predictedArrivalTime > 0` — never `??`.
+- **Formatting:** run `npx prettier --write <files>` before each commit; `npm run prepush` runs `prettier --check` and will fail CI otherwise.
+- **Every `StopMarker` tier keeps its 32px (`h-8 w-8`) button** for WCAG 2.5.8 target size. Dots are inner `<span>`s.
+
+## File Structure
+
+**Create:**
+
+| Path                                                           | Responsibility                                                                                                           |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `src/lib/activeRoutes.js`                                      | Pure: derive distinct active routes from an arrivals response; assign de-collided colors. No DOM, no fetch.              |
+| `src/lib/__tests__/activeRoutes.test.js`                       | Tests for the above.                                                                                                     |
+| `src/lib/mapPanes.js`                                          | Provider-neutral route stacking-layer names + their Leaflet z-indexes, so consumers never import a provider to get them. |
+| `src/components/map/__tests__/support/layerBindings.svelte.js` | Test-only `$state` harness for reading `$bindable` writes back from a `.test.js`.                                        |
+| `src/components/map/StopRoutesLayer.svelte`                    | Effectful: fetch per-route shapes, draw polylines, drive vehicle polling, own teardown.                                  |
+| `src/components/map/__tests__/StopRoutesLayer.test.js`         | Smoke + teardown coverage.                                                                                               |
+| `src/components/map/RouteLegend.svelte`                        | Presentational: swatch + short name + live count per drawn route.                                                        |
+| `src/components/map/__tests__/RouteLegend.test.js`             | Rendering tests.                                                                                                         |
+| `src/components/map/__tests__/StopMarker.test.js`              | Tier rendering + a11y invariants (no test exists today).                                                                 |
+| `src/components/__tests__/MapView.test.js`                     | Regression: markers survive trip expansion.                                                                              |
+
+**Modify:**
+
+| Path                                               | Change                                                                                                             |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `src/lib/colors.js`                                | Add `ROUTE_FALLBACK_PALETTE`.                                                                                      |
+| `src/lib/vehicleUtils.js`                          | `fetchVehicles` returns `null` on failure; add `fetchAndUpdateVehiclesForRoutes`; per-marker `routeId` ownership.  |
+| `src/lib/__tests__/vehicleUtils.test.js`           | Update for the new `fetchVehicles` contract; add multi-route tests.                                                |
+| `src/components/map/StopMarker.svelte`             | Add `emphasis` + `dotColor`; branch the template.                                                                  |
+| `src/components/map/MapView.svelte`                | Gate `mapMode` on `stop`; seed emphasis in `addMarker`; mount `StopRoutesLayer` + `RouteLegend`; guard `RouteMap`. |
+| `src/components/MapExperience.svelte`              | Bind `stopArrivals`; derive colors; complete the teardown.                                                         |
+| `src/components/stops/StopBottomSheet.svelte`      | Promote `arrivalsAndDeparturesResponse` to `$bindable`; forward `routeColors`.                                     |
+| `src/components/stops/StopPane.svelte`             | Forward `routeColors` to `ArrivalDeparture`.                                                                       |
+| `src/components/ArrivalDeparture.svelte`           | Accept `routeColors`; pass to `RouteBadge`.                                                                        |
+| `src/lib/Provider/OpenStreetMapProvider.svelte.js` | Panes, casing, `revealPolylines`, `setStopEmphasis`, `setBasemapDimmed`, emphasis in `addMarker`.                  |
+| `src/lib/Provider/GoogleMapProvider.svelte.js`     | Same surface; `_applyStyles` for dim+theme composition.                                                            |
+| `src/tests/lib/OpenStreetMapProvider.test.js`      | Tests for the new methods.                                                                                         |
+| `src/tests/lib/GoogleMapProvider.test.js`          | Tests for the new methods.                                                                                         |
+| `src/components/__tests__/MapExperience.test.js`   | Regression: teardown clears stranded route flags.                                                                  |
+| `src/locales/en.json`                              | Add `map.routes_shown`.                                                                                            |
+| `src/assets/styles/leaflet-map.css`                | `.oba-dim-basemap .leaflet-tile-pane` filter.                                                                      |
+
+---
+
+## Task 1: Keep stop markers mounted during trip expansion (P1)
+
+**Files:**
+
+- Modify: `src/components/map/MapView.svelte:56-75`
+- Test: `src/components/__tests__/MapView.test.js` (create)
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: the invariant every later task depends on — while `stop` is truthy, `mapMode` stays `Modes.NORMAL` and `markersMap` is never emptied.
+
+**Why:** `MapView.svelte:77-84` calls `clearAllMarkers()` whenever `mapMode !== NORMAL`. Expanding an arrival row sets `isRouteSelected`, `selectedRoute`, `selectedTrip`, and `showRouteMap` in `MapExperience`, which `MapView.svelte:60` turns into `Modes.ROUTE` — destroying every marker at exactly the moment the feature needs them.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/__tests__/MapView.test.js`:
+
+```js
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/svelte';
+import MapView from '$components/map/MapView.svelte';
+
+vi.mock('$components/map/RouteMap.svelte', () => ({ default: () => null }));
+vi.mock('$components/map/StopRoutesLayer.svelte', () => ({ default: () => null }));
+vi.mock('$components/map/RouteLegend.svelte', () => ({ default: () => null }));
+vi.mock('$lib/LocationButton/LocationButton.svelte', () => ({ default: () => null }));
+
+function makeProvider() {
+	return {
+		initMap: vi.fn().mockResolvedValue(undefined),
+		eventListeners: vi.fn(),
+		enableContextMenu: vi.fn(),
+		getBoundingBox: vi.fn(() => ({ north: 1, south: 0, east: 1, west: 0 })),
+		getCenter: vi.fn(() => ({ lat: 0, lng: 0 })),
+		map: { getZoom: () => 15 },
+		hasMarker: vi.fn(() => false),
+		addMarker: vi.fn(),
+		clearAllStopMarkers: vi.fn(),
+		setStopEmphasis: vi.fn(),
+		resetStopEmphasis: vi.fn(),
+		setBasemapDimmed: vi.fn(),
+		setTheme: vi.fn()
+	};
+}
+
+describe('MapView map mode', () => {
+	beforeEach(() => {
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ data: { list: [], references: { routes: [] } } })
+		});
+	});
+
+	test('does not clear stop markers when a trip is expanded inside a stop selection', async () => {
+		const mapProvider = makeProvider();
+		render(MapView, {
+			props: {
+				handleStopMarkerSelect: vi.fn(),
+				mapProvider,
+				stop: { id: 'stop_1', lat: 47.6, lon: -122.3 },
+				selectedTrip: { tripId: 'trip_1' },
+				isRouteSelected: true,
+				showRouteMap: true
+			}
+		});
+		await vi.waitFor(() => expect(mapProvider.initMap).toHaveBeenCalled());
+		expect(mapProvider.clearAllStopMarkers).not.toHaveBeenCalled();
+	});
+
+	test('still clears stop markers for a route selection with no stop', async () => {
+		const mapProvider = makeProvider();
+		render(MapView, {
+			props: {
+				handleStopMarkerSelect: vi.fn(),
+				mapProvider,
+				stop: null,
+				selectedRoute: { id: 'route_1' },
+				isRouteSelected: true
+			}
+		});
+		await vi.waitFor(() => expect(mapProvider.clearAllStopMarkers).toHaveBeenCalled());
+	});
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/components/__tests__/MapView.test.js`
+Expected: the first test FAILS — `clearAllStopMarkers` was called.
+
+- [ ] **Step 3: Gate the ROUTE branch on `stop`**
+
+In `src/components/map/MapView.svelte`, change the mode effect (currently lines 56-75). Only the `else if` condition changes:
+
+```js
+$effect(() => {
+	let newMode;
+	if (isTripPlanModeActive) {
+		newMode = Modes.TRIP_PLAN;
+		// A selected stop owns the map: expanding one of its arrival rows sets
+		// selectedTrip/isRouteSelected/showRouteMap, and without this guard that
+		// would flip us to ROUTE — whose effect clears every stop marker, exactly
+		// when the stop-selection layer needs them tiered and on screen.
+	} else if (!stop && (selectedRoute || isRouteSelected || showRouteMap || selectedTrip)) {
+		newMode = Modes.ROUTE;
+	} else {
+		newMode = Modes.NORMAL;
+	}
+	if (modeChangeTimeout) {
+		clearTimeout(modeChangeTimeout);
+	}
+	if (mapMode === Modes.ROUTE && newMode === Modes.NORMAL) {
+		modeChangeTimeout = setTimeout(() => {
+			mapMode = newMode;
+		}, 100);
+	} else if (mapMode !== newMode) {
+		mapMode = newMode;
+	}
+});
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/components/__tests__/MapView.test.js`
+Expected: both tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+npx prettier --write src/components/map/MapView.svelte src/components/__tests__/MapView.test.js
+git add src/components/map/MapView.svelte src/components/__tests__/MapView.test.js
+git commit -m "fix: keep stop markers mounted while a stop selection is active
+
+Expanding an arrival row set isRouteSelected/showRouteMap, flipping mapMode
+to ROUTE, whose effect clears every stop marker. Gate ROUTE on there being
+no selected stop."
+```
+
+---
+
+## Task 2: Complete the stop teardown (P2 + P3)
+
+**Files:**
+
+- Modify: `src/components/MapExperience.svelte:173-186`
+- Test: `src/components/__tests__/MapExperience.test.js`
+
+**Interfaces:**
+
+- Consumes: Task 1's invariant.
+- Produces: closing a stop sheet always returns the app to a clean NORMAL map — `showRouteMap`, `isRouteSelected`, `selectedRoute`, `selectedTrip` all falsy, and `vehicleMarkersMap` emptied.
+
+**Why:** `closePane()` short-circuits for the stop case (`:211-214`) and never resets the route flags; the framing effect's `else` branch clears only `selectedTrip`. After expand-then-close, `mapMode` sticks at `ROUTE` forever and no stop markers ever return. Separately, `clearVehicleMarkers()` empties the map but not the module-level `vehicleMarkersMap`, so the next selection finds detached markers and its vehicles never appear.
+
+- [ ] **Step 1: Make the page store reactive in the test file**
+
+`src/components/__tests__/MapExperience.test.js` currently mocks `$app/stores` with a one-shot subscribe over a module-level `pageValue`, so a test can set the page **before** render but can never simulate a navigation **after** it. Closing a stop sheet is exactly that, so swap in a real store. Replace the existing mock block:
+
+```js
+// Per-test controllable page store (overrides the global vitest-setup mock).
+// A real writable, not a one-shot subscribe, so a test can simulate navigating
+// away from a stop after render — which is how the teardown path is reached.
+import { writable } from 'svelte/store';
+
+let pageValue;
+const pageStore = writable(undefined);
+vi.mock('$app/stores', () => ({
+	page: { subscribe: (fn) => pageStore.subscribe(fn) }
+}));
+
+function setPage(next) {
+	pageValue = next;
+	pageStore.set(next);
+}
+```
+
+Then change the three existing tests from `pageValue = {…}` to `setPage({…})`. Behavior is identical for them — the store is seeded before `render` exactly as before.
+
+Also capture the sheet's props so a test can drive expansion and close, by extending the existing `StopBottomSheet` mock:
+
+```js
+let capturedSheetProps = null;
+vi.mock('$components/stops/StopBottomSheet.svelte', () => ({
+	default: function StopBottomSheet(anchor, props) {
+		capturedSheetProps = props;
+		const el = document.createElement('div');
+		el.setAttribute('data-testid', 'stop-bottom-sheet');
+		anchor.before(el);
+		return {};
+	}
+}));
+
+vi.mock('$lib/vehicleUtils.js', () => ({ clearVehicleMarkersMap: vi.fn() }));
+import { clearVehicleMarkersMap } from '$lib/vehicleUtils.js';
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `src/components/__tests__/MapExperience.test.js`:
+
+```js
+function pageWithStop() {
+	return {
+		url: new URL('https://example.com/map/stops/1_75403'),
+		params: {},
+		route: { id: '/(map)' },
+		state: { stopData: STOP },
+		data: {}
+	};
+}
+
+function pageWithoutStop() {
+	return {
+		url: new URL('https://example.com/'),
+		params: {},
+		route: { id: '/(map)' },
+		state: {},
+		data: {}
+	};
+}
+
+test('clearing the selection resets the route flags an expanded row left behind', async () => {
+	setPage(pageWithStop());
+	render(MapExperience);
+
+	// Expanding an arrival row: StopPane calls both of these.
+	capturedSheetProps.tripSelected({
+		detail: { tripId: 'trip_1', routeId: 'route_1', routeShortName: 'C' }
+	});
+	capturedSheetProps.handleUpdateRouteMap({ detail: { show: true } });
+	await vi.waitFor(() => expect(capturedMapContainerProps.showRouteMap).toBe(true));
+
+	// closePane pushes '/' — mocked, so drive the resulting page change ourselves.
+	capturedSheetProps.closePane();
+	setPage(pageWithoutStop());
+
+	await vi.waitFor(() => {
+		expect(capturedMapContainerProps.showRouteMap).toBe(false);
+		expect(capturedMapContainerProps.isRouteSelected).toBe(false);
+		expect(capturedMapContainerProps.selectedRoute).toBeNull();
+		expect(capturedMapContainerProps.selectedTrip).toBeNull();
+	});
+});
+
+test('clearing the selection empties the module-level vehicle marker map', async () => {
+	setPage(pageWithStop());
+	render(MapExperience);
+
+	// The framing effect needs a provider before it will run its teardown.
+	capturedMapContainerProps.mapProvider = {
+		flyTo: vi.fn(),
+		highlightMarker: vi.fn(),
+		unHighlightMarker: vi.fn(),
+		resetStopEmphasis: vi.fn(),
+		setBasemapDimmed: vi.fn(),
+		cleanupInfoWindow: vi.fn(),
+		clearVehicleMarkers: vi.fn()
+	};
+
+	setPage(pageWithoutStop());
+
+	await vi.waitFor(() => expect(clearVehicleMarkersMap).toHaveBeenCalled());
+});
+```
+
+If binding `mapProvider` through the captured props proves impractical against the mocked `MapContainer`, change the `MapContainer` mock to assign a stub provider into its `mapProvider` binding on mount instead — the assertion is unchanged either way.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `npx vitest run src/components/__tests__/MapExperience.test.js`
+Expected: the three pre-existing tests still PASS; the two new ones FAIL — `showRouteMap` is still `true`, and `clearVehicleMarkersMap` was not called.
+
+- [ ] **Step 4: Complete the teardown**
+
+In `src/components/MapExperience.svelte`, add the import:
+
+```js
+import { clearVehicleMarkersMap } from '$lib/vehicleUtils';
+```
+
+Then replace the framing effect's `else` branch (currently lines 173-186):
+
+```js
+} else {
+    // Closed (back button or close): tear down the stop overlay.
+    if (currentHighlightedStopId !== null) {
+        provider.unHighlightMarker(currentHighlightedStopId);
+        currentHighlightedStopId = null;
+    }
+    provider.resetStopEmphasis();
+    provider.setBasemapDimmed(false);
+    provider.cleanupInfoWindow();
+    // Don't wipe vehicle markers a route is drawing: when a route is selected
+    // from an open stop sheet, handleRouteSelected has already set
+    // currentModal = Modal.ROUTE and added the route's vehicles before this
+    // teardown flushes. A normal stop close leaves currentModal null.
+    if (currentModal !== Modal.ROUTE) {
+        provider.clearVehicleMarkers();
+        // clearVehicleMarkers only detaches the markers from the map. The module
+        // -level vehicleMarkersMap still holds them, so the next selection would
+        // find stale entries via .has() and update detached markers that never
+        // render. RouteMap's onDestroy already pairs these two calls.
+        clearVehicleMarkersMap();
+    }
+    selectedTrip = null;
+    stopArrivals = null;
+    // closePane() short-circuits for the stop case (pushState + return), and the
+    // accordion never fires its collapse callback because StopPane is destroyed
+    // rather than collapsed. So if the rider had a row expanded, these three are
+    // still truthy — which pins mapMode at ROUTE forever and permanently stops
+    // markers from loading. Reset them here, where every close path converges.
+    showRouteMap = false;
+    isRouteSelected = false;
+    selectedRoute = null;
+}
+```
+
+Note `stopArrivals` is declared in Task 8; if this task runs first, declare `let stopArrivals = $state(null);` alongside the other state declarations now and leave it otherwise unused. `resetStopEmphasis` and `setBasemapDimmed` arrive in Tasks 6 and 7 — add them to the test's provider stub now, and if the real providers do not yet have them, guard with `provider.resetStopEmphasis?.()` and `provider.setBasemapDimmed?.(false)` and drop the `?.` in Task 7.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run src/components/__tests__/MapExperience.test.js`
+Expected: all five PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+npx prettier --write src/components/MapExperience.svelte src/components/__tests__/MapExperience.test.js
+git add src/components/MapExperience.svelte src/components/__tests__/MapExperience.test.js
+git commit -m "fix: fully tear down stop state on close
+
+closePane short-circuits for stops and never reset showRouteMap /
+isRouteSelected / selectedRoute, so closing a sheet with an arrival row
+expanded pinned mapMode at ROUTE and stop markers never returned. Also pair
+clearVehicleMarkers with clearVehicleMarkersMap so the module-level map does
+not leak detached markers into the next selection."
+```
+
+---
+
+## Task 3: Camera-free polyline reveal (P4)
+
+**Files:**
+
+- Modify: `src/lib/Provider/OpenStreetMapProvider.svelte.js:778-873`
+- Modify: `src/lib/Provider/GoogleMapProvider.svelte.js` (add a no-op `revealPolylines`)
+- Test: `src/tests/lib/OpenStreetMapProvider.test.js`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `revealPolylines({ only = [], duration = 1.2 })` on both providers. `only` is an array of polyline objects; empty means all tracked polylines. OSM animates `stroke-dashoffset` on each polyline and its `_casing`; Google is a no-op returning `undefined`.
+
+**Why:** `_revealPolylinesWithDraw` is OSM-only and reachable only from inside `fitToPolylines`, which hides everything and flies the camera to the route bounds. Stop selection keeps its own `flyTo` framing, so there is no path today that reveals without refitting. It also iterates all polylines, so calling it per-route would re-animate already-drawn routes.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/tests/lib/OpenStreetMapProvider.test.js`:
+
+```js
+describe('revealPolylines', () => {
+	function fakePolyline() {
+		const path = {
+			style: {},
+			getTotalLength: () => 100,
+			getBoundingClientRect: () => ({})
+		};
+		return { _path: path, addTo: vi.fn(), remove: vi.fn() };
+	}
+
+	test('animates only the polylines passed in `only`', () => {
+		const provider = new OpenStreetMapProvider(vi.fn());
+		const a = fakePolyline();
+		const b = fakePolyline();
+		provider.map = { hasLayer: () => true, removeLayer: vi.fn() };
+		provider.polylines = [a, b];
+
+		provider.revealPolylines({ only: [a] });
+
+		expect(a._path.style.strokeDashoffset).toBe('0');
+		expect(b._path.style.strokeDashoffset).toBeUndefined();
+	});
+
+	test('animates a polyline casing alongside its polyline', () => {
+		const provider = new OpenStreetMapProvider(vi.fn());
+		const line = fakePolyline();
+		line._casing = fakePolyline();
+		provider.map = { hasLayer: () => true, removeLayer: vi.fn() };
+		provider.polylines = [line];
+
+		provider.revealPolylines({ only: [line] });
+
+		expect(line._casing._path.style.strokeDashoffset).toBe('0');
+	});
+
+	test('does not move the camera', () => {
+		const provider = new OpenStreetMapProvider(vi.fn());
+		const line = fakePolyline();
+		const flyToBounds = vi.fn();
+		provider.map = { hasLayer: () => true, removeLayer: vi.fn(), flyToBounds };
+		provider.polylines = [line];
+
+		provider.revealPolylines({ only: [line] });
+
+		expect(flyToBounds).not.toHaveBeenCalled();
+	});
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/tests/lib/OpenStreetMapProvider.test.js -t revealPolylines`
+Expected: FAIL — `provider.revealPolylines is not a function`.
+
+- [ ] **Step 3: Extract the public reveal on the OSM provider**
+
+In `src/lib/Provider/OpenStreetMapProvider.svelte.js`, replace `_revealPolylinesWithDraw` with a public method that takes an explicit target list, and have `fitToPolylines` delegate to it.
+
+```js
+/**
+ * Reveals polylines with a "draw from start to end" animation using the SVG
+ * stroke-dashoffset technique, without touching the camera. The direction-arrow
+ * decorators are added once the line has finished drawing.
+ *
+ * @param {{ only?: Array, duration?: number }} [options] `only` limits the
+ *   animation to specific polylines — used by the stop-selection layer, whose
+ *   routes resolve one at a time and must not re-animate their neighbors.
+ *   Omit it to reveal every tracked polyline.
+ */
+revealPolylines({ only = [], duration = 1.2 } = {}) {
+    const targets = only.length ? only : this.polylines;
+
+    targets.forEach((polyline) => {
+        if (!polyline) return;
+        // The casing is a second, wider stroke drawn underneath. It is deliberately
+        // absent from this.polylines (like arrowDecorator) so it can't double-count
+        // in fitToPolylines/_getRoutePaths, so reveal it explicitly here.
+        [polyline._casing, polyline].forEach((layer) => {
+            if (!layer) return;
+            if (!this.map.hasLayer(layer)) layer.addTo(this.map);
+        });
+
+        const path = polyline._path;
+        const addDecorator = () => {
+            if (polyline.arrowDecorator && !this.map.hasLayer(polyline.arrowDecorator)) {
+                polyline.arrowDecorator.addTo(this.map);
+            }
+        };
+
+        // SVG renderer only: fall back to an instant reveal otherwise.
+        if (!path || typeof path.getTotalLength !== 'function') {
+            addDecorator();
+            return;
+        }
+
+        [polyline._casing, polyline].forEach((layer) => {
+            const layerPath = layer?._path;
+            if (!layerPath || typeof layerPath.getTotalLength !== 'function') return;
+            const length = layerPath.getTotalLength();
+            layerPath.style.transition = 'none';
+            layerPath.style.strokeDasharray = `${length} ${length}`;
+            layerPath.style.strokeDashoffset = `${length}`;
+            // Force a reflow so the starting offset is applied before transitioning.
+            layerPath.getBoundingClientRect();
+            layerPath.style.transition = `stroke-dashoffset ${duration}s ease-in-out`;
+            layerPath.style.strokeDashoffset = '0';
+        });
+
+        polyline._drawTimeoutId = setTimeout(() => {
+            polyline._drawTimeoutId = null;
+            // Bail if the polyline was cleared mid-draw (e.g. rapid route switch).
+            if (!this.map.hasLayer(polyline)) return;
+            // Clear the inline styles so the original stroke (e.g. the dashed
+            // pattern used for walking legs) is restored once drawing is done.
+            [polyline._casing, polyline].forEach((layer) => {
+                const layerPath = layer?._path;
+                if (!layerPath) return;
+                layerPath.style.transition = '';
+                layerPath.style.strokeDasharray = '';
+                layerPath.style.strokeDashoffset = '';
+            });
+            addDecorator();
+        }, duration * 1000);
+    });
+}
+```
+
+In `fitToPolylines`, replace the `this._revealPolylinesWithDraw(options.drawDuration ?? 1.2);` call with:
+
+```js
+this.revealPolylines({ duration: options.drawDuration ?? 1.2 });
+```
+
+Also extend `_setPolylinesVisible` to carry the casing:
+
+```js
+_setPolylinesVisible(visible) {
+    this.polylines.forEach((polyline) => {
+        [polyline, polyline._casing, polyline.arrowDecorator].forEach((layer) => {
+            if (!layer) return;
+            if (visible) {
+                if (!this.map.hasLayer(layer)) layer.addTo(this.map);
+            } else if (this.map.hasLayer(layer)) {
+                this.map.removeLayer(layer);
+            }
+        });
+    });
+}
+```
+
+- [ ] **Step 4: Add the Google no-op**
+
+In `src/lib/Provider/GoogleMapProvider.svelte.js`, next to `fitToPolylines`:
+
+```js
+/**
+ * Provider-parity no-op. Google's Polyline has no SVG path, so the
+ * stroke-dashoffset draw-in used by the OSM provider has no analogue; Google
+ * routes appear immediately. Kept so callers don't have to branch on provider.
+ */
+revealPolylines() {}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run src/tests/lib/OpenStreetMapProvider.test.js src/tests/lib/GoogleMapProvider.test.js`
+Expected: PASS, including the pre-existing `fitToPolylines` tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+npx prettier --write src/lib/Provider/OpenStreetMapProvider.svelte.js src/lib/Provider/GoogleMapProvider.svelte.js src/tests/lib/OpenStreetMapProvider.test.js
+git add src/lib/Provider src/tests/lib/OpenStreetMapProvider.test.js
+git commit -m "feat: add camera-free revealPolylines to the map providers
+
+The draw-in reveal was private to the OSM provider and reachable only from
+fitToPolylines, which hides every line and flies the camera. Expose it as
+revealPolylines({only}) so a caller can animate specific routes as they
+resolve, without moving the map or re-animating their neighbors."
+```
+
+---
+
+## Task 4: Derive active routes from an arrivals response
+
+**Files:**
+
+- Create: `src/lib/activeRoutes.js`
+- Test: `src/lib/__tests__/activeRoutes.test.js` (create)
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces:
+
+```js
+/**
+ * @typedef {Object} ActiveRoute
+ * @property {string} id          - OBA route id
+ * @property {string} shortName
+ * @property {number} type        - GTFS route type, for the vehicle glyph
+ * @property {string} tripId      - the soonest arrival's trip, used for the shape
+ * @property {string|null} gtfsColor - raw hex from references.routes, no '#'
+ */
+export function activeRoutesFromArrivals(response): ActiveRoute[]
+```
+
+Sorted soonest-arrival first. Route order matters: it drives legend order, the graduated stroke weights, and the ring-dot color when a stop is served by more than one route.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/lib/__tests__/activeRoutes.test.js`:
+
+```js
+import { describe, test, expect } from 'vitest';
+import { activeRoutesFromArrivals } from '$lib/activeRoutes.js';
+
+function makeResponse(arrivals, routes = []) {
+	return {
+		data: {
+			entry: { stopId: 'stop_1', arrivalsAndDepartures: arrivals },
+			references: { routes }
+		}
+	};
+}
+
+describe('activeRoutesFromArrivals', () => {
+	test('returns one entry per distinct route, soonest first', () => {
+		const result = activeRoutesFromArrivals(
+			makeResponse(
+				[
+					{
+						routeId: 'r_22',
+						tripId: 't_b',
+						predicted: true,
+						predictedArrivalTime: 2000,
+						scheduledArrivalTime: 2000
+					},
+					{
+						routeId: 'r_c',
+						tripId: 't_a',
+						predicted: true,
+						predictedArrivalTime: 1000,
+						scheduledArrivalTime: 1000
+					}
+				],
+				[
+					{ id: 'r_c', shortName: 'C Line', type: 3, color: 'b02a37' },
+					{ id: 'r_22', shortName: '22', type: 3, color: 'e0a021' }
+				]
+			)
+		);
+		expect(result.map((r) => r.id)).toEqual(['r_c', 'r_22']);
+		expect(result[0]).toEqual({
+			id: 'r_c',
+			shortName: 'C Line',
+			type: 3,
+			tripId: 't_a',
+			gtfsColor: 'b02a37'
+		});
+	});
+
+	test('keeps the soonest trip when a route has several arrivals', () => {
+		const result = activeRoutesFromArrivals(
+			makeResponse(
+				[
+					{
+						routeId: 'r_c',
+						tripId: 't_late',
+						predicted: true,
+						predictedArrivalTime: 5000,
+						scheduledArrivalTime: 5000
+					},
+					{
+						routeId: 'r_c',
+						tripId: 't_soon',
+						predicted: true,
+						predictedArrivalTime: 1000,
+						scheduledArrivalTime: 1000
+					}
+				],
+				[{ id: 'r_c', shortName: 'C Line', type: 3, color: 'b02a37' }]
+			)
+		);
+		expect(result).toHaveLength(1);
+		expect(result[0].tripId).toBe('t_soon');
+	});
+
+	// OBA sends predictedArrivalTime: 0 (not null) when there is no real-time
+	// prediction. A naive `predictedArrivalTime ?? scheduledArrivalTime` reads
+	// that as "arriving at epoch" and sorts it first. This test is the point.
+	test('treats predictedArrivalTime 0 as absent rather than as time zero', () => {
+		const result = activeRoutesFromArrivals(
+			makeResponse(
+				[
+					{
+						routeId: 'r_c',
+						tripId: 't_unpredicted',
+						predicted: false,
+						predictedArrivalTime: 0,
+						scheduledArrivalTime: 9000
+					},
+					{
+						routeId: 'r_22',
+						tripId: 't_predicted',
+						predicted: true,
+						predictedArrivalTime: 3000,
+						scheduledArrivalTime: 3200
+					}
+				],
+				[
+					{ id: 'r_c', shortName: 'C Line', type: 3, color: 'b02a37' },
+					{ id: 'r_22', shortName: '22', type: 3, color: 'e0a021' }
+				]
+			)
+		);
+		expect(result.map((r) => r.id)).toEqual(['r_22', 'r_c']);
+	});
+
+	test('picks the soonest trip by scheduled time when nothing is predicted', () => {
+		const result = activeRoutesFromArrivals(
+			makeResponse(
+				[
+					{
+						routeId: 'r_c',
+						tripId: 't_late',
+						predicted: false,
+						predictedArrivalTime: 0,
+						scheduledArrivalTime: 9000
+					},
+					{
+						routeId: 'r_c',
+						tripId: 't_soon',
+						predicted: false,
+						predictedArrivalTime: 0,
+						scheduledArrivalTime: 4000
+					}
+				],
+				[{ id: 'r_c', shortName: 'C Line', type: 3, color: 'b02a37' }]
+			)
+		);
+		expect(result[0].tripId).toBe('t_soon');
+	});
+
+	test('falls back to the arrival routeShortName when the route reference is missing', () => {
+		const result = activeRoutesFromArrivals(
+			makeResponse(
+				[
+					{
+						routeId: 'r_x',
+						tripId: 't_x',
+						routeShortName: '773',
+						predicted: true,
+						predictedArrivalTime: 1000,
+						scheduledArrivalTime: 1000
+					}
+				],
+				[]
+			)
+		);
+		expect(result[0].shortName).toBe('773');
+		expect(result[0].gtfsColor).toBeNull();
+	});
+
+	test.each([
+		['null', null],
+		['undefined', undefined],
+		['an empty object', {}],
+		['a response with no entry', { data: { references: { routes: [] } } }],
+		['a response with no arrivals array', { data: { entry: {}, references: { routes: [] } } }]
+	])('returns an empty array for %s', (_label, input) => {
+		expect(activeRoutesFromArrivals(input)).toEqual([]);
+	});
+
+	test('skips arrivals with no routeId', () => {
+		const result = activeRoutesFromArrivals(
+			makeResponse([{ tripId: 't_a', predicted: true, predictedArrivalTime: 1000 }], [])
+		);
+		expect(result).toEqual([]);
+	});
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/lib/__tests__/activeRoutes.test.js`
+Expected: FAIL — cannot resolve `$lib/activeRoutes.js`.
+
+- [ ] **Step 3: Implement**
+
+Create `src/lib/activeRoutes.js`:
+
+```js
+/**
+ * Derives the set of routes a rider can actually board from a stop, from that
+ * stop's arrivals-and-departures response.
+ *
+ * This is deliberately narrower than "routes the stop is signed for": a stop
+ * signed "128, 22, 773, C Line" whose 773 has no arrival in the current window
+ * yields three routes, not four. A line on the map then means "a bus you can
+ * catch from here is running this route now."
+ */
+
+/**
+ * @typedef {Object} ActiveRoute
+ * @property {string} id
+ * @property {string} shortName
+ * @property {number} type
+ * @property {string} tripId
+ * @property {string|null} gtfsColor
+ */
+
+/**
+ * Effective arrival time for ordering.
+ *
+ * OBA sends `predictedArrivalTime: 0` — not null — when there is no real-time
+ * prediction, so `predictedArrivalTime ?? scheduledArrivalTime` would read every
+ * unpredicted arrival as "arriving at the epoch" and sort it to the front. This
+ * mirrors the guard ArrivalDeparture.svelte already uses to pick its display time.
+ * @param {Object} arrival
+ * @returns {number}
+ */
+function effectiveArrivalTime(arrival) {
+	return arrival.predicted && arrival.predictedArrivalTime > 0
+		? arrival.predictedArrivalTime
+		: arrival.scheduledArrivalTime;
+}
+
+/**
+ * @param {Object} response - an /arrivals-and-departures-for-stop response
+ * @returns {ActiveRoute[]} distinct routes, soonest arrival first
+ */
+export function activeRoutesFromArrivals(response) {
+	const arrivals = response?.data?.entry?.arrivalsAndDepartures;
+	if (!Array.isArray(arrivals)) return [];
+
+	const routeRefs = new Map(
+		(response?.data?.references?.routes ?? []).map((route) => [route.id, route])
+	);
+
+	/** @type {Map<string, {arrival: Object, time: number}>} */
+	const soonestByRoute = new Map();
+
+	for (const arrival of arrivals) {
+		const routeId = arrival?.routeId;
+		if (!routeId) continue;
+
+		const time = effectiveArrivalTime(arrival);
+		const existing = soonestByRoute.get(routeId);
+		if (!existing || time < existing.time) {
+			soonestByRoute.set(routeId, { arrival, time });
+		}
+	}
+
+	return [...soonestByRoute.entries()]
+		.sort((a, b) => a[1].time - b[1].time)
+		.map(([routeId, { arrival }]) => {
+			const ref = routeRefs.get(routeId);
+			return {
+				id: routeId,
+				shortName: ref?.shortName ?? arrival.routeShortName ?? '',
+				type: ref?.type ?? 3,
+				tripId: arrival.tripId,
+				gtfsColor: ref?.color || null
+			};
+		});
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/lib/__tests__/activeRoutes.test.js`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+npx prettier --write src/lib/activeRoutes.js src/lib/__tests__/activeRoutes.test.js
+git add src/lib/activeRoutes.js src/lib/__tests__/activeRoutes.test.js
+git commit -m "feat: derive the active route set from a stop's arrivals"
+```
+
+---
+
+## Task 5: De-collided route colors
+
+**Files:**
+
+- Modify: `src/lib/colors.js`
+- Modify: `src/lib/activeRoutes.js`
+- Test: `src/lib/__tests__/activeRoutes.test.js`
+
+**Interfaces:**
+
+- Consumes: `ActiveRoute[]` from Task 4; `mapContrastColor` and `getBrightness` from `$lib/colorUtils`.
+- Produces:
+
+```js
+/**
+ * @typedef {Object} RouteColors
+ * @property {string} line     - '#rrggbb', for polylines and vehicle markers
+ * @property {string} badgeBg  - 'rrggbb' (no '#'), for RouteBadge `color`
+ * @property {string} badgeFg  - 'rrggbb' (no '#'), for RouteBadge `textColor`
+ */
+export function assignRouteColors(routes, { dark }): Map<string, RouteColors>
+export const ROUTE_FALLBACK_PALETTE // in $lib/colors.js
+```
+
+`badgeBg` is always `line` without the `#`, so badge and line can never diverge.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/lib/__tests__/activeRoutes.test.js`:
+
+```js
+import { assignRouteColors } from '$lib/activeRoutes.js';
+import { ROUTE_FALLBACK_PALETTE } from '$lib/colors.js';
+
+const route = (id, gtfsColor) => ({ id, shortName: id, type: 3, tripId: `t_${id}`, gtfsColor });
+
+function contrast(hexA, hexB) {
+	const lum = (hex) => {
+		const channels = [1, 3, 5]
+			.map((i) => parseInt(hex.slice(i, i + 2), 16) / 255)
+			.map((v) => (v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4));
+		return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+	};
+	const [hi, lo] = [lum(hexA), lum(hexB)].sort((a, b) => b - a);
+	return (hi + 0.05) / (lo + 0.05);
+}
+
+describe('assignRouteColors', () => {
+	test('keeps a unique GTFS color, contrast-adjusted for the basemap', () => {
+		const colors = assignRouteColors([route('r_c', 'b02a37')], { dark: false });
+		expect(colors.get('r_c').line).toBe('#b02a37');
+		expect(colors.get('r_c').badgeBg).toBe('b02a37');
+	});
+
+	test('badgeBg is always the line color without the hash', () => {
+		const colors = assignRouteColors([route('r_c', 'b02a37'), route('r_22', 'e0a021')], {
+			dark: true
+		});
+		for (const value of colors.values()) {
+			expect(value.badgeBg).toBe(value.line.slice(1));
+		}
+	});
+
+	test('gives colliding routes distinct colors', () => {
+		const colors = assignRouteColors([route('r_22', '4a4a4a'), route('r_128', '4a4a4a')], {
+			dark: false
+		});
+		expect(colors.get('r_22').line).not.toBe(colors.get('r_128').line);
+	});
+
+	test('assigns a palette color when the GTFS color is missing or invalid', () => {
+		const palette = ROUTE_FALLBACK_PALETTE.map((entry) => entry.light);
+		const colors = assignRouteColors([route('r_a', null), route('r_b', 'nonsense')], {
+			dark: false
+		});
+		expect(palette).toContain(colors.get('r_a').line);
+		expect(palette).toContain(colors.get('r_b').line);
+		expect(colors.get('r_a').line).not.toBe(colors.get('r_b').line);
+	});
+
+	test('is stable when the input order changes', () => {
+		const routes = [route('r_a', null), route('r_b', null), route('r_c', null)];
+		const forward = assignRouteColors(routes, { dark: false });
+		const reversed = assignRouteColors([...routes].reverse(), { dark: false });
+		for (const { id } of routes) {
+			expect(reversed.get(id).line).toBe(forward.get(id).line);
+		}
+	});
+
+	test('uses the dark palette variant in dark mode', () => {
+		const light = assignRouteColors([route('r_a', null)], { dark: false });
+		const dark = assignRouteColors([route('r_a', null)], { dark: true });
+		expect(dark.get('r_a').line).not.toBe(light.get('r_a').line);
+		expect(ROUTE_FALLBACK_PALETTE.map((e) => e.dark)).toContain(dark.get('r_a').line);
+	});
+
+	test('picks a readable badge foreground for light backgrounds', () => {
+		// #DCE775 (the Olive dark variant) is far too light for white text.
+		const colors = assignRouteColors([route('r_a', 'DCE775')], { dark: true });
+		const { badgeBg, badgeFg } = colors.get('r_a');
+		expect(contrast(`#${badgeBg}`, `#${badgeFg}`)).toBeGreaterThanOrEqual(4.5);
+	});
+
+	test('returns an empty map for an empty route list', () => {
+		expect(assignRouteColors([], { dark: false }).size).toBe(0);
+	});
+});
+
+describe('ROUTE_FALLBACK_PALETTE', () => {
+	// These guarantees are asserted in the design spec; enforce them here so a
+	// future palette edit can't quietly break legibility.
+	test('every entry clears 3:1 against its basemap and 4.5:1 against its text', () => {
+		for (const { light, dark } of ROUTE_FALLBACK_PALETTE) {
+			expect(contrast(light, '#F2F2F0')).toBeGreaterThanOrEqual(3);
+			expect(contrast(dark, '#1B1B1B')).toBeGreaterThanOrEqual(3);
+			expect(
+				Math.max(contrast(light, '#FFFFFF'), contrast(light, '#000000'))
+			).toBeGreaterThanOrEqual(4.5);
+			expect(Math.max(contrast(dark, '#FFFFFF'), contrast(dark, '#000000'))).toBeGreaterThanOrEqual(
+				4.5
+			);
+		}
+	});
+
+	test('entries stay visually distinct within each mode', () => {
+		const distance = (a, b) => {
+			const parse = (hex) => [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16));
+			const [x, y] = [parse(a), parse(b)];
+			return Math.hypot(x[0] - y[0], x[1] - y[1], x[2] - y[2]);
+		};
+		for (const key of ['light', 'dark']) {
+			const values = ROUTE_FALLBACK_PALETTE.map((entry) => entry[key]);
+			for (let i = 0; i < values.length; i++) {
+				for (let j = i + 1; j < values.length; j++) {
+					expect(distance(values[i], values[j])).toBeGreaterThan(60);
+				}
+			}
+		}
+	});
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/lib/__tests__/activeRoutes.test.js`
+Expected: FAIL — `assignRouteColors` and `ROUTE_FALLBACK_PALETTE` are not exported.
+
+- [ ] **Step 3: Add the palette**
+
+Append to `src/lib/colors.js`:
+
+```js
+/**
+ * Fallback colors for routes whose GTFS color is missing, invalid, or collides
+ * with another route drawn at the same time (real agencies routinely give
+ * several routes one generic color, which makes two lines in a shared corridor
+ * indistinguishable).
+ *
+ * Each entry is a light/dark pair because no single hex can clear both a light
+ * and a dark basemap — the same reason mapContrastColor adjusts GTFS colors per
+ * theme. These values were chosen by computation, not by eye; every one clears
+ * 3:1 against its basemap and 4.5:1 against its computed text color, and the
+ * closest pair within a mode is 65 units apart in RGB. See the palette tests in
+ * src/lib/__tests__/activeRoutes.test.js, which enforce all of that.
+ */
+export const ROUTE_FALLBACK_PALETTE = [
+	{ light: '#C2185B', dark: '#F06292' }, // crimson
+	{ light: '#1565C0', dark: '#64B5F6' }, // blue
+	{ light: '#2E7D32', dark: '#81C784' }, // green
+	{ light: '#E65100', dark: '#FFB74D' }, // orange
+	{ light: '#6A1B9A', dark: '#BA68C8' }, // purple
+	{ light: '#00695C', dark: '#4DB6AC' }, // teal
+	{ light: '#5D4037', dark: '#BCAAA4' }, // brown
+	{ light: '#827717', dark: '#DCE775' } // olive
+];
+```
+
+- [ ] **Step 4: Implement `assignRouteColors`**
+
+Append to `src/lib/activeRoutes.js`:
+
+```js
+import { mapContrastColor, getBrightness, hexToRgb } from '$lib/colorUtils.js';
+import { ROUTE_FALLBACK_PALETTE } from '$lib/colors.js';
+
+/**
+ * @typedef {Object} RouteColors
+ * @property {string} line    - '#rrggbb', for polylines and vehicle markers
+ * @property {string} badgeBg - 'rrggbb' (no '#'), for RouteBadge `color`
+ * @property {string} badgeFg - 'rrggbb' (no '#'), for RouteBadge `textColor`
+ */
+
+// Stable index into the fallback palette. Keyed on the route id rather than the
+// route's position in the list so a 30s refresh that reorders arrivals doesn't
+// change any route's color.
+function paletteIndexFor(routeId) {
+	let hash = 0;
+	for (let i = 0; i < routeId.length; i++) {
+		hash = (hash * 31 + routeId.charCodeAt(i)) | 0;
+	}
+	return Math.abs(hash) % ROUTE_FALLBACK_PALETTE.length;
+}
+
+// Badge text: the background is no longer the agency's own color, so the
+// agency's textColor (chosen for that original hex) may be unreadable against
+// it. Pick from the resolved background instead. 140 is the midpoint of
+// colorUtils' own brightness scale.
+function badgeForeground(hex) {
+	return getBrightness(hexToRgb(hex)) > 140 ? '000000' : 'ffffff';
+}
+
+/**
+ * Resolves one color per route, used identically by the polyline, the vehicle
+ * markers, the legend, and the arrival badge.
+ *
+ * @param {ActiveRoute[]} routes - in draw order (soonest arrival first)
+ * @param {{ dark?: boolean }} options
+ * @returns {Map<string, RouteColors>}
+ */
+export function assignRouteColors(routes, { dark = false } = {}) {
+	/** @type {Map<string, RouteColors>} */
+	const colors = new Map();
+	const taken = new Set();
+
+	const finish = (routeId, line) => {
+		taken.add(line.toLowerCase());
+		const badgeBg = line.slice(1);
+		colors.set(routeId, { line, badgeBg, badgeFg: badgeForeground(line) });
+	};
+
+	// Two passes so palette assignment is order-independent: every route that can
+	// keep its own GTFS color claims it first, and only then do the leftovers pick
+	// from the palette. A single pass would let an early colorless route grab a
+	// palette slot that a later route's GTFS color also maps to.
+	const needsFallback = [];
+	for (const route of routes) {
+		const resolved = mapContrastColor(route.gtfsColor, { dark });
+		if (resolved && !taken.has(resolved.toLowerCase())) {
+			finish(route.id, resolved);
+		} else {
+			needsFallback.push(route);
+		}
+	}
+
+	for (const route of needsFallback) {
+		const start = paletteIndexFor(route.id);
+		let line = null;
+		// Linear-probe from the hashed slot to the next unused palette entry.
+		for (let offset = 0; offset < ROUTE_FALLBACK_PALETTE.length; offset++) {
+			const entry = ROUTE_FALLBACK_PALETTE[(start + offset) % ROUTE_FALLBACK_PALETTE.length];
+			const candidate = dark ? entry.dark : entry.light;
+			if (!taken.has(candidate.toLowerCase())) {
+				line = candidate;
+				break;
+			}
+		}
+		// More routes than palette entries: accept a repeat rather than no color.
+		if (!line) {
+			const entry = ROUTE_FALLBACK_PALETTE[start];
+			line = dark ? entry.dark : entry.light;
+		}
+		finish(route.id, line);
+	}
+
+	return colors;
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run src/lib/__tests__/activeRoutes.test.js`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+npx prettier --write src/lib/activeRoutes.js src/lib/colors.js src/lib/__tests__/activeRoutes.test.js
+git add src/lib/activeRoutes.js src/lib/colors.js src/lib/__tests__/activeRoutes.test.js
+git commit -m "feat: resolve one de-collided color per active route
+
+Agencies routinely give several routes one generic color, which makes two
+lines in a shared corridor indistinguishable. Fall back to a computed
+light/dark palette, keyed on route id so colors are stable across refreshes."
+```
+
+---
+
+## Task 6: Stop marker emphasis tiers
+
+**Files:**
+
+- Modify: `src/components/map/StopMarker.svelte`
+- Test: `src/components/map/__tests__/StopMarker.test.js` (create)
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `StopMarker` accepts `emphasis: 'full' | 'routeDot' | 'muted' | 'hidden'` (default `'full'`) and `dotColor: string | null`. `isHighlighted` is unchanged and **wins over `emphasis`** — a highlighted marker always renders the full pin.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/components/map/__tests__/StopMarker.test.js`:
+
+```js
+import { render, screen } from '@testing-library/svelte';
+import { describe, test, expect, vi } from 'vitest';
+import { faBus } from '@fortawesome/free-solid-svg-icons';
+import StopMarker from '../StopMarker.svelte';
+
+const stop = {
+	id: 'stop_1',
+	name: 'California Ave SW & Fauntleroy Way SW',
+	direction: 'N',
+	routes: []
+};
+
+function renderMarker(props = {}) {
+	return render(StopMarker, {
+		props: { stop, icon: faBus, onClick: vi.fn(), ...props }
+	});
+}
+
+describe('StopMarker emphasis', () => {
+	test('renders the full pin by default', () => {
+		const { container } = renderMarker();
+		expect(container.querySelector('.custom-marker')).toBeInTheDocument();
+		expect(container.querySelector('.emphasis-dot')).not.toBeInTheDocument();
+	});
+
+	test('renders a route-colored ring dot for routeDot', () => {
+		const { container } = renderMarker({ emphasis: 'routeDot', dotColor: '#b02a37' });
+		const dot = container.querySelector('.emphasis-dot.route-dot');
+		expect(dot).toBeInTheDocument();
+		expect(dot).toHaveStyle('border-color: #b02a37');
+		expect(container.querySelector('.bus-icon')).not.toBeInTheDocument();
+	});
+
+	test('renders a quiet gray dot for muted', () => {
+		const { container } = renderMarker({ emphasis: 'muted' });
+		expect(container.querySelector('.emphasis-dot.muted-dot')).toBeInTheDocument();
+		expect(container.querySelector('.bus-icon')).not.toBeInTheDocument();
+	});
+
+	test('draws no dot for hidden', () => {
+		const { container } = renderMarker({ emphasis: 'hidden' });
+		expect(container.querySelector('.emphasis-dot')).not.toBeInTheDocument();
+		expect(container.querySelector('.bus-icon')).not.toBeInTheDocument();
+	});
+
+	// The selected stop is always in the ring-dot set (those are the trips that
+	// serve it), so these two props WILL collide. isHighlighted has to win, or the
+	// rider's selected stop becomes the least distinguishable thing on the map.
+	test('isHighlighted wins over routeDot', () => {
+		const { container } = renderMarker({
+			emphasis: 'routeDot',
+			dotColor: '#b02a37',
+			isHighlighted: true
+		});
+		expect(container.querySelector('.custom-marker.highlight')).toBeInTheDocument();
+		expect(container.querySelector('.emphasis-dot')).not.toBeInTheDocument();
+	});
+
+	test.each(['full', 'routeDot', 'muted', 'hidden'])(
+		'keeps an accessible 32px button in the %s tier',
+		(emphasis) => {
+			const { container } = renderMarker({ emphasis, dotColor: '#b02a37' });
+			const button = screen.getByRole('button', { name: stop.name });
+			expect(button).toBeInTheDocument();
+			expect(container.querySelector('.marker-hit-area')).toBeInTheDocument();
+		}
+	);
+
+	test.each(['routeDot', 'muted', 'hidden'])(
+		'hides the routes label in the %s tier',
+		(emphasis) => {
+			const withRoutes = { ...stop, routes: [{ shortName: 'C' }, { shortName: '22' }] };
+			render(StopMarker, {
+				props: { stop: withRoutes, icon: faBus, onClick: vi.fn(), showRoutesLabel: true, emphasis }
+			});
+			expect(screen.queryByText('C, 22')).not.toBeInTheDocument();
+		}
+	);
+
+	test('shows the routes label in the full tier', () => {
+		const withRoutes = { ...stop, routes: [{ shortName: 'C' }, { shortName: '22' }] };
+		render(StopMarker, {
+			props: {
+				stop: withRoutes,
+				icon: faBus,
+				onClick: vi.fn(),
+				showRoutesLabel: true,
+				emphasis: 'full'
+			}
+		});
+		expect(screen.getByText('C, 22')).toBeInTheDocument();
+	});
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/components/map/__tests__/StopMarker.test.js`
+Expected: FAIL — no `.emphasis-dot`, and the routeDot tier still renders the pin.
+
+- [ ] **Step 3: Branch the template**
+
+In `src/components/map/StopMarker.svelte`, update the props block:
+
+```js
+/**
+ * @typedef {Object} Props
+ * @property {any} stop
+ * @property {any} onClick
+ * @property {any} icon
+ * @property {boolean} [isHighlighted]
+ * @property {boolean} [showRoutesLabel]
+ * @property {'full'|'routeDot'|'muted'|'hidden'} [emphasis] - Marker prominence,
+ *   decided by the map layer from the current selection. `full` is today's pin.
+ * @property {string|null} [dotColor] - Ring color for the `routeDot` tier.
+ */
+
+/** @type {Props} */
+let {
+	stop,
+	onClick,
+	icon,
+	isHighlighted = false,
+	showRoutesLabel = false,
+	emphasis = 'full',
+	dotColor = null
+} = $props();
+```
+
+Add a derived resolution below the existing `routesLabelText` derivation:
+
+```js
+// The selected stop is always among the stops served by the drawn routes, so
+// `emphasis: 'routeDot'` and `isHighlighted` collide by construction. Highlight
+// wins: the stop the rider picked must never be the quietest thing on screen.
+const resolvedEmphasis = $derived(isHighlighted ? 'full' : emphasis);
+const isFullPin = $derived(resolvedEmphasis === 'full');
+```
+
+Replace the markup block (currently lines 71-103) with:
+
+```svelte
+<div class="marker-container">
+	<!-- The button keeps its 32px box in every tier. Collapsing the *icon* to a
+	     dot is the whole point, but collapsing the hit target with it would put
+	     the control under the WCAG 2.5.8 minimum and make it unusable on touch. -->
+	<button
+		class="marker-hit-area {isFullPin ? '' : 'as-dot'}"
+		onclick={onClick}
+		aria-label={stop.name}
+	>
+		{#if isFullPin}
+			<span class="custom-marker dark:border-[#5a2c2c] {isHighlighted ? 'highlight' : ''}">
+				<span class="bus-icon dark:text-white">
+					<FontAwesomeIcon {icon} class=" text-black" />
+					{#if stop.direction}
+						<span class="direction-arrow {stop.direction.toLowerCase()} dark:text-white">
+							<FontAwesomeIcon icon={faCaretUp} class="dark:text-white" />
+						</span>
+					{/if}
+				</span>
+			</span>
+		{:else if resolvedEmphasis === 'routeDot'}
+			<span class="emphasis-dot route-dot" style="border-color: {dotColor};"></span>
+		{:else if resolvedEmphasis === 'muted'}
+			<span class="emphasis-dot muted-dot"></span>
+		{/if}
+	</button>
+
+	{#if isFullPin && showRoutesLabel && routesLabelText}
+		<div
+			role="button"
+			tabindex="0"
+			class="routes-label {isExpanded ? 'expanded' : ''} position-{labelPosition}"
+			onclick={toggleRoutesList}
+			onkeydown={handleRoutesLabelKeydown}
+			aria-expanded={isExpanded}
+			aria-label={isExpanded ? 'Collapse route list' : `Show all ${routeNames.length} routes`}
+		>
+			<span class="label-text">{routesLabelText}</span>
+			{#if remainingRoutesCount > 0 && !isExpanded}
+				<span class="expand-indicator" title="Click to see all routes">⋯</span>
+			{/if}
+		</div>
+	{/if}
+</div>
+```
+
+Note the `<span class="sr-only">{stop.name}</span>` is replaced by `aria-label` on the button — the sr-only span inside a flex button interfered with dot centering, and `aria-label` gives the same accessible name in all four tiers.
+
+Update the styles. Replace the `.custom-marker` rule and add the new ones; leave every other rule untouched:
+
+```css
+.marker-hit-area {
+	@apply h-8 w-8;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	background: none;
+	border: none;
+	padding: 0;
+	position: relative;
+}
+
+.marker-hit-area:hover {
+	cursor: pointer;
+}
+
+.custom-marker {
+	@apply h-8 w-8 rounded-md;
+	@apply bg-white/80 dark:bg-neutral-200;
+	@apply border-2 border-gray-400;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	position: relative;
+}
+
+.emphasis-dot {
+	border-radius: 50%;
+	display: block;
+	flex: none;
+}
+
+/* "Beads on a string" along the drawn route: reads as a stop on a line the
+   rider cares about, without competing with the line itself. */
+.route-dot {
+	height: 14px;
+	width: 14px;
+	background: #fff;
+	border-width: 2.5px;
+	border-style: solid;
+	box-shadow: 0 1px 2px rgb(0 0 0 / 0.28);
+}
+
+/* Present for spatial context, but recedes. The white halo keeps it legible on
+   a dark basemap without adding visual weight. */
+.muted-dot {
+	height: 9px;
+	width: 9px;
+	background: #8b93a1;
+	opacity: 0.6;
+	box-shadow: 0 0 0 2px rgb(255 255 255 / 0.65);
+}
+```
+
+Also update `.highlight` to tint the caret, which does not exist today:
+
+```css
+.highlight {
+	@apply scale-125 border-brand-accent drop-shadow-md;
+}
+
+/* The caret is otherwise hard-coded black; tint it to match the selected
+   marker's brand-accent border. */
+.highlight .direction-arrow {
+	@apply text-brand-accent;
+}
+
+:global(.dark) .highlight .direction-arrow {
+	@apply text-brand;
+}
+```
+
+Because `.direction-arrow` carries `dark:text-white` from the markup, add `!important`-free specificity by keeping these rules after it in the file.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/components/map/__tests__/StopMarker.test.js`
+Expected: all PASS.
+
+- [ ] **Step 5: Verify with the Svelte MCP autofixer**
+
+Call `mcp__svelte__svelte-autofixer` with the full contents of `StopMarker.svelte`. Apply any corrections it reports, then re-run the tests. Call it again to confirm the file is clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+npx prettier --write src/components/map/StopMarker.svelte src/components/map/__tests__/StopMarker.test.js
+git add src/components/map/StopMarker.svelte src/components/map/__tests__/StopMarker.test.js
+git commit -m "feat: add emphasis tiers to StopMarker
+
+A 32px pin carries the same visual weight dimmed or not, so background stops
+collapse to dots instead — keeping position, dropping the icon and the caret
+clutter. The button keeps its 32px hit area in every tier."
+```
+
+---
+
+## Task 7: Provider emphasis, dimming, and casing
+
+**Files:**
+
+- Modify: `src/lib/Provider/OpenStreetMapProvider.svelte.js`
+- Modify: `src/lib/Provider/GoogleMapProvider.svelte.js`
+- Modify: `src/assets/styles/leaflet-map.css`
+- Test: `src/tests/lib/OpenStreetMapProvider.test.js`, `src/tests/lib/GoogleMapProvider.test.js`
+
+**Interfaces:**
+
+- Consumes: `StopMarker`'s `emphasis` / `dotColor` props from Task 6.
+- Produces, on **both** providers:
+
+```js
+addMarker({ position, stop, isHighlighted, emphasis, dotColor, onClick }); // two new option keys
+setStopEmphasis(byStopId, defaultEmphasis, selectedStopId); // Map<stopId, {emphasis, dotColor}>
+resetStopEmphasis(); // all markers back to 'full'
+setBasemapDimmed(dimmed);
+createPolyline(points, { color, casing, pane, weight, withArrow, opacity, dashArray });
+```
+
+Panes on OSM: `obaRouteCasing` (z 402), `obaRoute` (403), `obaRoutePromoted` (404).
+
+- [ ] **Step 1: Write the failing tests (OSM)**
+
+Add to `src/tests/lib/OpenStreetMapProvider.test.js`:
+
+```js
+describe('stop emphasis', () => {
+	function providerWithMarkers(entries) {
+		const provider = new OpenStreetMapProvider(vi.fn());
+		provider.markersMap = new Map(entries);
+		return provider;
+	}
+
+	test('applies per-stop emphasis and the default to everything else', () => {
+		const a = { props: { emphasis: 'full', dotColor: null } };
+		const b = { props: { emphasis: 'full', dotColor: null } };
+		const provider = providerWithMarkers([
+			['stop_a', a],
+			['stop_b', b]
+		]);
+
+		provider.setStopEmphasis(
+			new Map([['stop_a', { emphasis: 'routeDot', dotColor: '#b02a37' }]]),
+			'muted',
+			null
+		);
+
+		expect(a.props.emphasis).toBe('routeDot');
+		expect(a.props.dotColor).toBe('#b02a37');
+		expect(b.props.emphasis).toBe('muted');
+		expect(b.props.dotColor).toBeNull();
+	});
+
+	// The selected stop is served by the drawn trips, so it is always in the
+	// ring-dot map. Forcing 'full' here keeps the invariant in one place rather
+	// than at every call site.
+	test('forces the selected stop to full even when it is in the ring-dot map', () => {
+		const selected = { props: { emphasis: 'full', dotColor: null } };
+		const provider = providerWithMarkers([['stop_sel', selected]]);
+
+		provider.setStopEmphasis(
+			new Map([['stop_sel', { emphasis: 'routeDot', dotColor: '#b02a37' }]]),
+			'muted',
+			'stop_sel'
+		);
+
+		expect(selected.props.emphasis).toBe('full');
+	});
+
+	// GoogleMapProvider.addStopRouteMarker writes bare google.maps.Marker objects
+	// into markersMap; those have no reactive props to mutate.
+	test('skips markers with no props', () => {
+		const provider = providerWithMarkers([['stop_a', { noProps: true }]]);
+		expect(() => provider.setStopEmphasis(new Map(), 'muted', null)).not.toThrow();
+	});
+
+	test('resetStopEmphasis returns every marker to full', () => {
+		const a = { props: { emphasis: 'muted', dotColor: '#b02a37' } };
+		const provider = providerWithMarkers([['stop_a', a]]);
+		provider.resetStopEmphasis();
+		expect(a.props.emphasis).toBe('full');
+		expect(a.props.dotColor).toBeNull();
+	});
+});
+
+describe('setBasemapDimmed', () => {
+	test('toggles the dim class on the map container', () => {
+		const provider = new OpenStreetMapProvider(vi.fn());
+		const container = document.createElement('div');
+		provider.map = { getContainer: () => container };
+
+		provider.setBasemapDimmed(true);
+		expect(container.classList.contains('oba-dim-basemap')).toBe(true);
+
+		provider.setBasemapDimmed(false);
+		expect(container.classList.contains('oba-dim-basemap')).toBe(false);
+	});
+});
+```
+
+For the casing, add to the same file. The file's existing `makeFakeL(fakeMarker)` helper returns only `{ divIcon, marker }`, so extend it with the polyline pieces `createPolyline` needs — add these keys to `makeFakeL` itself so every existing caller keeps working:
+
+```js
+function makeFakeL(fakeMarker) {
+	return {
+		divIcon: vi.fn(() => ({})),
+		marker: vi.fn(() => fakeMarker),
+		Polyline: vi.fn(function FakePolyline(latlngs, options) {
+			this.options = options;
+			this.addTo = vi.fn().mockReturnThis();
+			this.remove = vi.fn();
+			this.getLatLngs = vi.fn(() => latlngs);
+			this.getBounds = vi.fn(() => ({}));
+		}),
+		polylineDecorator: vi.fn(() => ({ addTo: vi.fn().mockReturnThis(), remove: vi.fn() })),
+		Symbol: { arrowHead: vi.fn(() => ({})) }
+	};
+}
+```
+
+`createPolyline` decodes with `PolylineUtil.decode`, so mock that module at the top of the file:
+
+```js
+vi.mock('polyline-encoded', () => ({
+	default: {
+		decode: vi.fn(() => [
+			[47.6, -122.3],
+			[47.61, -122.31]
+		])
+	}
+}));
+```
+
+Then:
+
+```js
+describe('createPolyline casing', () => {
+	function makeProvider() {
+		const provider = new OpenStreetMapProvider(vi.fn());
+		provider.L = makeFakeL(makeFakeMarker());
+		provider.map = { hasLayer: () => true, removeLayer: vi.fn() };
+		return provider;
+	}
+
+	test('draws a wider white casing under the colored stroke', () => {
+		const provider = makeProvider();
+		const line = provider.createPolyline('encoded', { color: '#b02a37', casing: true, weight: 5 });
+
+		expect(line._casing).toBeTruthy();
+		expect(line._casing.options.color).toBe('#ffffff');
+		expect(line._casing.options.weight).toBeGreaterThan(line.options.weight);
+	});
+
+	test('gives the polyline and its casing the panes it was asked for', () => {
+		const provider = makeProvider();
+		const line = provider.createPolyline('encoded', {
+			color: '#b02a37',
+			casing: true,
+			pane: 'obaRoute',
+			casingPane: 'obaRouteCasing'
+		});
+
+		expect(line.options.pane).toBe('obaRoute');
+		expect(line._casing.options.pane).toBe('obaRouteCasing');
+	});
+
+	// Without this the arrow decorator builds its polyline in overlayPane (400),
+	// below the casings at 402, and every arrow vanishes under a white stroke.
+	test('draws the arrow decorator in the same pane as its polyline', () => {
+		const provider = makeProvider();
+		provider.createPolyline('encoded', { color: '#b02a37', pane: 'obaRoute' });
+
+		const decoratorOptions = provider.L.polylineDecorator.mock.calls[0][1];
+		expect(decoratorOptions.patterns[0].symbol).toBeDefined();
+		expect(provider.L.Symbol.arrowHead.mock.calls[0][0].pathOptions.pane).toBe('obaRoute');
+	});
+
+	// The casing must stay out of this.polylines or fitToPolylines,
+	// getPolylinesCount, and _getRoutePaths all double-count it.
+	test('does not track the casing in this.polylines', () => {
+		const provider = makeProvider();
+		provider.createPolyline('encoded', { color: '#b02a37', casing: true });
+		expect(provider.getPolylinesCount()).toBe(1);
+	});
+
+	test('removes the casing with its polyline', () => {
+		const provider = makeProvider();
+		const line = provider.createPolyline('encoded', { color: '#b02a37', casing: true });
+		const casing = line._casing;
+		provider.removePolyline(line);
+		expect(casing.remove).toHaveBeenCalled();
+	});
+
+	test('clearAllPolylines removes casings too', () => {
+		const provider = makeProvider();
+		const line = provider.createPolyline('encoded', { color: '#b02a37', casing: true });
+		const casing = line._casing;
+		provider.clearAllPolylines();
+		expect(casing.remove).toHaveBeenCalled();
+	});
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/tests/lib/OpenStreetMapProvider.test.js`
+Expected: FAIL — the new methods and the `casing` option do not exist.
+
+- [ ] **Step 3: Implement on the OSM provider**
+
+Add pane creation at the end of `initMap`, after the maplibre layer is added:
+
+Custom panes give the route layer explicit stacking: every casing below every colored stroke, and the promoted route above its peers. `createPane` does **not** assign a z-index — `.leaflet-pane` sets 400 for all of them — so it must be set here, or the panes tie with `overlayPane` and order only by DOM insertion. The constants come from the new `$lib/mapPanes.js` defined just below.
+
+Put the pane names in a **provider-neutral** module so `StopRoutesLayer` can reference them without importing the OSM provider — importing it would pull Leaflet, MapLibre, and `leaflet.css` into the bundle even on deployments configured for Google.
+
+Create `src/lib/mapPanes.js`:
+
+```js
+/**
+ * Stacking layers for the stop-selection route overlay.
+ *
+ * The OSM provider maps these to Leaflet panes (whose z-index it assigns
+ * explicitly — createPane does not). The Google provider maps them to Polyline
+ * zIndex values. Callers pick a layer by name and stay provider-agnostic.
+ *
+ * Every casing must render below every colored stroke, or one route's casing
+ * paints over its neighbor's line. The promoted layer carries the route whose
+ * arrival the rider has expanded.
+ */
+export const ROUTE_PANE = {
+	CASING: 'obaRouteCasing',
+	LINE: 'obaRoute',
+	PROMOTED: 'obaRoutePromoted'
+};
+
+/** Leaflet pane z-indexes. Below markerPane (600) so markers stay on top. */
+export const ROUTE_PANE_Z_INDEX = {
+	[ROUTE_PANE.CASING]: 402,
+	[ROUTE_PANE.LINE]: 403,
+	[ROUTE_PANE.PROMOTED]: 404
+};
+```
+
+and import it in the OSM provider's `initMap`:
+
+```js
+import { ROUTE_PANE_Z_INDEX } from '$lib/mapPanes.js';
+// ...
+for (const [name, zIndex] of Object.entries(ROUTE_PANE_Z_INDEX)) {
+	this.map.createPane(name);
+	this.map.getPane(name).style.zIndex = String(zIndex);
+}
+```
+
+Add the emphasis and dim methods next to `highlightMarker`:
+
+```js
+/**
+ * Applies marker prominence across the map. Called by the map layer whenever the
+ * selection or the drawn route set changes.
+ *
+ * @param {Map<string, {emphasis: string, dotColor: string|null}>} byStopId
+ * @param {'full'|'muted'|'hidden'} defaultEmphasis - for stops not in byStopId
+ * @param {string|null} selectedStopId - always rendered as the full pin
+ */
+setStopEmphasis(byStopId, defaultEmphasis = 'full', selectedStopId = null) {
+    for (const [stopId, marker] of this.markersMap) {
+        // addStopRouteMarker writes plain markers into markersMap on the Google
+        // provider; those have no reactive props to mutate.
+        if (!marker?.props) continue;
+
+        if (stopId === selectedStopId) {
+            marker.props.emphasis = 'full';
+            marker.props.dotColor = null;
+            continue;
+        }
+
+        const tier = byStopId.get(stopId);
+        marker.props.emphasis = tier?.emphasis ?? defaultEmphasis;
+        marker.props.dotColor = tier?.dotColor ?? null;
+    }
+}
+
+resetStopEmphasis() {
+    for (const marker of this.markersMap.values()) {
+        if (!marker?.props) continue;
+        marker.props.emphasis = 'full';
+        marker.props.dotColor = null;
+    }
+}
+
+/**
+ * Fades the basemap so the colored routes and vehicles carry the map.
+ *
+ * The MapLibre GL canvas is the only thing in Leaflet's tilePane, so a CSS
+ * filter scoped there dims the basemap and nothing else — routes and markers
+ * live in overlayPane/markerPane and keep full contrast. The class goes on the
+ * container rather than the layer so it survives setTheme's layer rebuild.
+ */
+setBasemapDimmed(dimmed) {
+    if (!browser || !this.map) return;
+    this.map.getContainer().classList.toggle('oba-dim-basemap', dimmed);
+}
+```
+
+Add `emphasis` and `dotColor` to the `$state` literal in `addMarker` (currently line 123). Seed them at creation rather than patching after: `batchAddMarkers` defers `addMarker` into a `requestAnimationFrame`, so a caller that patched emphasis right after would find `markersMap` still empty and leave panned-in stops as full pins.
+
+```js
+const props = $state({
+	stop: options.stop,
+	icon: icon,
+	onClick: options.onClick,
+	isHighlighted: options.isHighlighted ?? false,
+	showRoutesLabel: this.map.getZoom() >= this.showStopsRoutesAtZoom,
+	emphasis: options.emphasis ?? 'full',
+	dotColor: options.dotColor ?? null
+});
+```
+
+Extend `createPolyline` for casing and panes. Insert before the colored polyline is created, and pass the pane through to both the polyline and the arrow decorator:
+
+```js
+const weight = options.weight || 4;
+const pane = options.pane;
+
+// White casing underneath, so the route reads on any basemap tile without a
+// halo hack. Created first so it renders below; kept off this.polylines (like
+// arrowDecorator) so fitToPolylines/getPolylinesCount/_getRoutePaths don't
+// double-count it, and torn down with its polyline.
+let casing = null;
+if (options.casing) {
+	casing = new this.L.Polyline(decodedPolyline, {
+		color: '#ffffff',
+		weight: weight + 5,
+		opacity: 0.95,
+		lineCap: 'round',
+		lineJoin: 'round',
+		...(options.casingPane ? { pane: options.casingPane } : {})
+	}).addTo(this.map);
+}
+
+const polylineOpts = {
+	color: options.color || COLORS.POLYLINE,
+	weight,
+	opacity: options.opacity ?? 1,
+	lineCap: 'round',
+	lineJoin: 'round'
+};
+if (pane) polylineOpts.pane = pane;
+if (options.dashArray) {
+	polylineOpts.dashArray = options.dashArray;
+}
+const polyline = new this.L.Polyline(decodedPolyline, polylineOpts).addTo(this.map);
+polyline._casing = casing;
+
+this.polylines.push(polyline);
+```
+
+In the arrow decorator's `pathOptions`, add the pane — without it, `L.Symbol.arrowHead` builds its polyline in `overlayPane` (400) and every arrow disappears under the casings at 402:
+
+```js
+pathOptions: {
+    color: arrowColor,
+    fill: true,
+    fillColor: arrowColor,
+    fillOpacity: 0.85,
+    ...(pane ? { pane } : {})
+}
+```
+
+In `removePolyline` and `clearAllPolylines`, remove the casing alongside the arrow decorator — same shape as the existing `arrowDecorator` handling:
+
+```js
+if (polyline._casing) {
+	polyline._casing.remove();
+	polyline._casing = null;
+}
+```
+
+- [ ] **Step 4: Add the dim CSS**
+
+Append to `src/assets/styles/leaflet-map.css`:
+
+```css
+/* Basemap dim for stop selection. Scoped to the tile pane, which holds only the
+   MapLibre GL canvas — routes (overlayPane and the oba route panes) and markers
+   (markerPane) keep full contrast. Transitioned so selecting a stop doesn't
+   snap. */
+.leaflet-container.oba-dim-basemap .leaflet-tile-pane {
+	filter: saturate(0.55) brightness(1.05) opacity(0.72);
+}
+
+.leaflet-container .leaflet-tile-pane {
+	transition: filter 220ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.leaflet-container .leaflet-tile-pane {
+		transition: none;
+	}
+}
+```
+
+- [ ] **Step 5: Mirror on the Google provider**
+
+Add the same `setStopEmphasis` and `resetStopEmphasis` (identical bodies — they only touch `markersMap` and `marker.props`), and add `emphasis`/`dotColor` to its `$state` literal at line 100.
+
+Google has no panes, so it maps the same layer names to `zIndex` values. Add near the top of the module:
+
+```js
+import { ROUTE_PANE } from '$lib/mapPanes.js';
+
+// Google orders polylines by zIndex rather than by pane. Same contract as the
+// OSM panes: every casing below every colored stroke, promoted above its peers.
+const ROUTE_LAYER_Z_INDEX = {
+	[ROUTE_PANE.CASING]: 10,
+	[ROUTE_PANE.LINE]: 20,
+	[ROUTE_PANE.PROMOTED]: 30
+};
+```
+
+Then in `createPolyline`, honor `pane`/`casingPane` and draw the casing:
+
+```js
+const weight = options.weight || 5;
+const zIndex = ROUTE_LAYER_Z_INDEX[options.pane];
+
+if (zIndex !== undefined) {
+	polylineOptions.zIndex = zIndex;
+}
+polylineOptions.strokeWeight = weight;
+
+if (options.casing) {
+	polyline._casing = new google.maps.Polyline({
+		path,
+		geodesic: true,
+		strokeColor: '#ffffff',
+		strokeOpacity: 0.95,
+		strokeWeight: weight + 5,
+		zIndex: ROUTE_LAYER_Z_INDEX[options.casingPane] ?? ROUTE_LAYER_Z_INDEX[ROUTE_PANE.CASING],
+		map: this.map
+	});
+}
+```
+
+and remove it in `removePolyline` / `clearAllPolylines` with `polyline._casing.setMap(null)`, keeping it out of `this.polylines` exactly as on OSM.
+
+For dimming, both `setTheme` and `setBasemapDimmed` must compose through one place, because `setTheme` replaces `styles` wholesale and would otherwise wipe the dim on the next `themeChange` event (one is dispatched unconditionally at `MapView.svelte:275`):
+
+```js
+/**
+ * Google replaces the whole `styles` array on setOptions, so theme and dim have
+ * to be composed in one place — otherwise a theme toggle silently drops the dim.
+ */
+_applyStyles() {
+    const base = this._darkTheme ? nightModeStyles() : [];
+    const dim = this._dimmed
+        ? [{ featureType: 'all', elementType: 'all', stylers: [{ saturation: -45 }, { lightness: 25 }] }]
+        : [];
+    const styles = [...base, ...dim];
+    this.map.setOptions({ styles: styles.length ? styles : null });
+}
+
+setTheme(theme) {
+    this._darkTheme = theme === 'dark';
+    this._applyStyles();
+}
+
+setBasemapDimmed(dimmed) {
+    this._dimmed = dimmed;
+    this._applyStyles();
+}
+```
+
+Initialize `this._darkTheme = false;` and `this._dimmed = false;` in the constructor.
+
+- [ ] **Step 6: Add the matching Google tests**
+
+Mirror the emphasis and casing tests in `src/tests/lib/GoogleMapProvider.test.js`, plus one for the composition bug:
+
+```js
+test('a theme change preserves the basemap dim', () => {
+	const provider = makeProvider();
+	const setOptions = vi.fn();
+	provider.map = { setOptions };
+
+	provider.setBasemapDimmed(true);
+	provider.setTheme('dark');
+
+	const lastStyles = setOptions.mock.calls.at(-1)[0].styles;
+	expect(lastStyles.some((s) => s.stylers?.some((v) => 'saturation' in v))).toBe(true);
+});
+```
+
+- [ ] **Step 7: Run all provider tests**
+
+Run: `npx vitest run src/tests/lib/OpenStreetMapProvider.test.js src/tests/lib/GoogleMapProvider.test.js`
+Expected: all PASS, including pre-existing tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+npx prettier --write src/lib/Provider src/tests/lib src/assets/styles/leaflet-map.css
+git add src/lib/Provider src/tests/lib src/assets/styles/leaflet-map.css
+git commit -m "feat: add stop emphasis, basemap dimming, and polyline casing to both providers
+
+Emphasis is seeded in addMarker rather than patched afterward, because
+batchAddMarkers defers marker creation into a rAF and a later patch would miss
+stops panned in mid-selection. Route panes get explicit z-indexes (createPane
+does not assign one) and the arrow decorator inherits its polyline's pane, or
+arrows render under the casings."
+```
+
+---
+
+## Task 8: Multi-route vehicle polling
+
+**Files:**
+
+- Modify: `src/lib/vehicleUtils.js`
+- Test: `src/lib/__tests__/vehicleUtils.test.js`
+
+**Interfaces:**
+
+- Consumes: `ActiveRoute[]` from Task 4 (uses `.id` and `.type`), `RouteColors` from Task 5.
+- Produces:
+
+```js
+// BREAKING: was `{references:{trips:[]}, list:[]}` on failure, now null.
+export async function fetchVehicles(routeId): Promise<Object|null>
+
+export async function fetchAndUpdateVehiclesForRoutes(
+    routes,      // [{ id, type }]
+    mapProvider,
+    { highlightedTripId = null, colorsByRouteId = new Map(), onCounts = null } = {}
+): Promise<number>  // one interval id for all routes
+```
+
+`fetchAndUpdateVehicles(routeId, mapProvider, routeType, highlightedTripId, routeColor)` keeps its exact signature and behavior as a wrapper.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/lib/__tests__/vehicleUtils.test.js`:
+
+```js
+import { fetchVehicles, fetchAndUpdateVehiclesForRoutes } from '$lib/vehicleUtils.js';
+
+function tripsResponse(routeId, vehicles) {
+	return {
+		data: {
+			references: { trips: vehicles.map((v) => ({ id: v.tripId, routeId })) },
+			list: vehicles.map((v) => ({
+				status: {
+					activeTripId: v.tripId,
+					vehicleId: v.vehicleId,
+					position: { lat: 47.6, lon: -122.3 },
+					predicted: true,
+					orientation: 0
+				}
+			}))
+		}
+	};
+}
+
+function makeProvider() {
+	return {
+		addVehicleMarker: vi.fn((status) => ({ id: status.vehicleId })),
+		updateVehicleMarker: vi.fn(),
+		removeVehicleMarker: vi.fn()
+	};
+}
+
+describe('fetchVehicles failure contract', () => {
+	test('returns null when the request fails', async () => {
+		global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+		expect(await fetchVehicles('route_1')).toBeNull();
+	});
+
+	test('returns null for a malformed body', async () => {
+		global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: {} }) });
+		expect(await fetchVehicles('route_1')).toBeNull();
+	});
+
+	test('returns the data for a well-formed empty response', async () => {
+		global.fetch = vi
+			.fn()
+			.mockResolvedValue({ ok: true, json: async () => tripsResponse('route_1', []) });
+		expect(await fetchVehicles('route_1')).toEqual({ references: { trips: [] }, list: [] });
+	});
+});
+
+describe('fetchAndUpdateVehiclesForRoutes', () => {
+	beforeEach(() => {
+		clearVehicleMarkersMap();
+		vi.useFakeTimers();
+	});
+	afterEach(() => vi.useRealTimers();
+
+	// The old per-route sweep deleted every marker absent from the single polled
+	// route's active set, so three concurrent route polls each wiped the other two.
+	test('polling three routes keeps all three routes markers', async () => {
+		const provider = makeProvider();
+		global.fetch = vi.fn(async (url) => {
+			const routeId = url.split('/').pop();
+			return { ok: true, json: async () => tripsResponse(routeId, [{ tripId: `t_${routeId}`, vehicleId: `v_${routeId}` }]) };
+		});
+
+		const intervalId = await fetchAndUpdateVehiclesForRoutes(
+			[{ id: 'r_a', type: 3 }, { id: 'r_b', type: 3 }, { id: 'r_c', type: 3 }],
+			provider
+		);
+		clearInterval(intervalId);
+
+		expect(provider.addVehicleMarker).toHaveBeenCalledTimes(3);
+		expect(provider.removeVehicleMarker).not.toHaveBeenCalled();
+	});
+
+	test('removes only the vehicle a route stopped reporting', async () => {
+		const provider = makeProvider();
+		let secondTick = false;
+		global.fetch = vi.fn(async (url) => {
+			const routeId = url.split('/').pop();
+			const vehicles =
+				routeId === 'r_a' && secondTick ? [] : [{ tripId: `t_${routeId}`, vehicleId: `v_${routeId}` }];
+			return { ok: true, json: async () => tripsResponse(routeId, vehicles) };
+		});
+
+		const routes = [{ id: 'r_a', type: 3 }, { id: 'r_b', type: 3 }];
+		const intervalId = await fetchAndUpdateVehiclesForRoutes(routes, provider);
+		secondTick = true;
+		await vi.advanceTimersByTimeAsync(30000);
+		clearInterval(intervalId);
+
+		expect(provider.removeVehicleMarker).toHaveBeenCalledTimes(1);
+	});
+
+	// fetchVehicles used to return an empty list for a failed request, which a
+	// scoped sweep would read as "this route has no vehicles" and clear them all.
+	test('a failed fetch for one route leaves that routes markers alone', async () => {
+		const provider = makeProvider();
+		let failSecond = false;
+		global.fetch = vi.fn(async (url) => {
+			const routeId = url.split('/').pop();
+			if (routeId === 'r_a' && failSecond) return { ok: false, status: 503 };
+			return { ok: true, json: async () => tripsResponse(routeId, [{ tripId: `t_${routeId}`, vehicleId: `v_${routeId}` }]) };
+		});
+
+		const intervalId = await fetchAndUpdateVehiclesForRoutes(
+			[{ id: 'r_a', type: 3 }, { id: 'r_b', type: 3 }],
+			provider
+		);
+		failSecond = true;
+		await vi.advanceTimersByTimeAsync(30000);
+		clearInterval(intervalId);
+
+		expect(provider.removeVehicleMarker).not.toHaveBeenCalled();
+	});
+
+	test('reports a live vehicle count per route', async () => {
+		const provider = makeProvider();
+		global.fetch = vi.fn(async (url) => {
+			const routeId = url.split('/').pop();
+			const count = routeId === 'r_a' ? 2 : 1;
+			const vehicles = Array.from({ length: count }, (_, i) => ({
+				tripId: `t_${routeId}_${i}`,
+				vehicleId: `v_${routeId}_${i}`
+			}));
+			return { ok: true, json: async () => tripsResponse(routeId, vehicles) };
+		});
+		const onCounts = vi.fn();
+
+		const intervalId = await fetchAndUpdateVehiclesForRoutes(
+			[{ id: 'r_a', type: 3 }, { id: 'r_b', type: 3 }],
+			provider,
+			{ onCounts }
+		);
+		clearInterval(intervalId);
+
+		const counts = onCounts.mock.calls.at(-1)[0];
+		expect(counts.get('r_a')).toBe(2);
+		expect(counts.get('r_b')).toBe(1);
+	});
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/lib/__tests__/vehicleUtils.test.js`
+Expected: FAIL — `fetchAndUpdateVehiclesForRoutes` is not exported, and `fetchVehicles` returns an empty object rather than `null`. **Existing tests asserting the old empty-object failure return will also fail; update them to expect `null`.**
+
+- [ ] **Step 3: Rework `vehicleUtils.js`**
+
+Change `fetchVehicles` to signal failure, and record route ownership per marker:
+
+```js
+/**
+ * @type {Map<vehicleId, {marker, routeId}>}
+ * Keyed by the physical vehicle id. The trips-for-route response can report the
+ * same activeTripId for two different vehicles (e.g. the vehicle actually serving
+ * the trip plus a second one still parked at the base), so keying by trip id
+ * collapsed both into one marker that flipped between their positions on every
+ * refresh. Falls back to activeTripId only when a status has no vehicleId.
+ * see (https://developer.onebusaway.org/api/where/elements/trip-status)
+ *
+ * `routeId` records which route owns each marker, so a sweep across several
+ * concurrently-polled routes only removes markers belonging to routes it
+ * actually fetched.
+ */
+const vehicleMarkersMap = new Map();
+
+/**
+ * @returns {Promise<Object|null>} the trips-for-route payload, or `null` when
+ * the request failed or came back malformed.
+ *
+ * Failure and emptiness must be distinguishable: a caller sweeping stale markers
+ * across several routes would otherwise read a 500 as "this route has no
+ * vehicles" and delete every marker the route owns.
+ */
+export async function fetchVehicles(routeId) {
+	const response = await fetch(`/api/oba/trips-for-route/${routeId}`);
+	if (!response.ok) {
+		console.warn('fetchVehicles: request failed', routeId, response.status);
+		return null;
+	}
+	const responseBody = await response.json();
+	const data = responseBody.data;
+	if (!data?.references?.trips || !Array.isArray(data.list)) {
+		console.warn('fetchVehicles: unexpected response structure for route', routeId);
+		return null;
+	}
+	return data;
+}
+```
+
+Replace `updateVehicleMarkers` and `removeInactiveMarkers` with route-scoped versions and add the batched entry point:
+
+```js
+/**
+ * Draws/updates the vehicles for one route from an already-fetched payload, and
+ * returns the marker keys this route currently owns.
+ */
+function applyRouteVehicles(data, routeId, mapProvider, routeType, highlightedTripId, routeColor) {
+	const activeKeys = new Set();
+
+	for (const trip of data.references.trips) {
+		if (!activeTripMap.has(trip.id)) {
+			activeTripMap.set(trip.id, trip);
+		}
+	}
+
+	for (const tripStatus of data.list) {
+		const activeTripId = tripStatus?.status?.activeTripId;
+		const activeTrip = activeTripMap.get(activeTripId);
+
+		// OBA puts the trip state string on status.status (e.g. SCHEDULED, CANCELED), not on status itself
+		if (activeTrip && activeTrip.routeId === routeId && tripStatus.status?.status !== 'CANCELED') {
+			const vehicleStatus = tripStatus.status;
+			const isHighlighted = highlightedTripId != null && activeTripId === highlightedTripId;
+			const markerKey = vehicleStatus.vehicleId || activeTripId;
+
+			activeKeys.add(markerKey);
+
+			const existing = vehicleMarkersMap.get(markerKey);
+			if (existing) {
+				mapProvider.updateVehicleMarker(
+					existing.marker,
+					vehicleStatus,
+					activeTrip,
+					routeType,
+					isHighlighted,
+					routeColor
+				);
+				// A physical vehicle can move between routes across a shift; re-stamp
+				// ownership so the sweep attributes it to the route reporting it now.
+				existing.routeId = routeId;
+			} else {
+				const marker = mapProvider.addVehicleMarker(
+					vehicleStatus,
+					activeTrip,
+					routeType,
+					isHighlighted,
+					routeColor
+				);
+				vehicleMarkersMap.set(markerKey, { marker, routeId });
+			}
+		}
+	}
+
+	return activeKeys;
+}
+
+/**
+ * Removes markers that are no longer active — but only among routes we actually
+ * polled successfully. A route whose fetch failed keeps its markers.
+ */
+export function removeInactiveMarkers(activeKeys, mapProvider, polledRouteIds = null) {
+	for (const [markerKey, entry] of vehicleMarkersMap) {
+		if (polledRouteIds && !polledRouteIds.has(entry.routeId)) continue;
+		if (!activeKeys.has(markerKey)) {
+			mapProvider.removeVehicleMarker(entry.marker);
+			vehicleMarkersMap.delete(markerKey);
+		}
+	}
+}
+
+const VEHICLE_POLL_INTERVAL_MS = 30000;
+
+/**
+ * Polls several routes' vehicles on one interval.
+ *
+ * @param {Array<{id: string, type?: number}>} routes
+ * @param {Object} mapProvider
+ * @param {{highlightedTripId?: string|null, colorsByRouteId?: Map<string,{line:string}>, onCounts?: Function}} [options]
+ * @returns {Promise<number>} interval id
+ */
+export async function fetchAndUpdateVehiclesForRoutes(
+	routes,
+	mapProvider,
+	{ highlightedTripId = null, colorsByRouteId = new Map(), onCounts = null } = {}
+) {
+	const tick = async () => {
+		const results = await Promise.all(
+			routes.map((route) =>
+				fetchVehicles(route.id).catch((error) => {
+					console.error('fetchAndUpdateVehiclesForRoutes: fetch failed', route.id, error);
+					return null;
+				})
+			)
+		);
+
+		const activeKeys = new Set();
+		const polledRouteIds = new Set();
+		const counts = new Map();
+
+		routes.forEach((route, index) => {
+			const data = results[index];
+			// null means the fetch failed, which is NOT the same as "no vehicles".
+			// Leave this route out of the sweep scope so its markers survive.
+			if (!data) return;
+
+			polledRouteIds.add(route.id);
+			const routeKeys = applyRouteVehicles(
+				data,
+				route.id,
+				mapProvider,
+				route.type,
+				highlightedTripId,
+				colorsByRouteId.get(route.id)?.line
+			);
+			routeKeys.forEach((key) => activeKeys.add(key));
+			counts.set(route.id, routeKeys.size);
+		});
+
+		removeInactiveMarkers(activeKeys, mapProvider, polledRouteIds);
+		if (onCounts) onCounts(counts);
+	};
+
+	try {
+		await tick();
+	} catch (error) {
+		console.error('fetchAndUpdateVehiclesForRoutes: initial tick failed', error);
+	}
+
+	return setInterval(() => {
+		tick().catch((error) => {
+			console.error('fetchAndUpdateVehiclesForRoutes: polling tick failed', error);
+		});
+	}, VEHICLE_POLL_INTERVAL_MS);
+}
+
+/**
+ * Single-route wrapper, kept so SearchPane and RouteMap run through the same
+ * code path. Signature and behavior are unchanged.
+ */
+export async function fetchAndUpdateVehicles(
+	routeId,
+	mapProvider,
+	routeType,
+	highlightedTripId = null,
+	routeColor = undefined
+) {
+	return fetchAndUpdateVehiclesForRoutes([{ id: routeId, type: routeType }], mapProvider, {
+		highlightedTripId,
+		colorsByRouteId: routeColor ? new Map([[routeId, { line: routeColor }]]) : new Map()
+	});
+}
+```
+
+Keep `updateVehicleMarkers` exported as a thin single-route wrapper if the existing test file imports it; otherwise remove it and delete those tests.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/lib/__tests__/vehicleUtils.test.js`
+Expected: all PASS.
+
+- [ ] **Step 5: Verify the existing callers still work**
+
+Run: `npx vitest run src/components/search/__tests__/SearchPane.test.js`
+Expected: PASS — `fetchAndUpdateVehicles` is unchanged from `SearchPane`'s perspective.
+
+- [ ] **Step 6: Commit**
+
+```bash
+npx prettier --write src/lib/vehicleUtils.js src/lib/__tests__/vehicleUtils.test.js
+git add src/lib/vehicleUtils.js src/lib/__tests__/vehicleUtils.test.js
+git commit -m "feat: poll several routes' vehicles on one interval
+
+The old sweep removed every marker absent from the single polled route's active
+set, so N concurrent route polls each deleted the other N-1 routes' vehicles.
+Scope the sweep to routes that actually fetched successfully, which needs
+fetchVehicles to distinguish failure (now null) from a genuinely empty route."
+```
+
+---
+
+## Task 9: Plumb arrivals and colors through to the map and the badges
+
+**Files:**
+
+- Modify: `src/components/stops/StopBottomSheet.svelte`
+- Modify: `src/components/stops/StopPane.svelte`
+- Modify: `src/components/ArrivalDeparture.svelte`
+- Modify: `src/components/MapExperience.svelte`
+- Test: `src/components/__tests__/ArrivalDeparture.test.js`, `src/components/__tests__/MapExperience.test.js`
+
+**Interfaces:**
+
+- Consumes: `activeRoutesFromArrivals` and `assignRouteColors` from Tasks 4-5.
+- Produces: `MapExperience` exposes `stopArrivals`, `activeRoutes` (`ActiveRoute[]`), and `routeColors` (`Map<string, RouteColors>`), passed to `MapContainer` (which spreads `...restProps` into `MapView`) and down the sheet to `RouteBadge`.
+
+- [ ] **Step 1: Write the failing test for the badge**
+
+Add to `src/components/__tests__/ArrivalDeparture.test.js`:
+
+```js
+describe('route colors', () => {
+	const arrival = {
+		routeId: 'r_c',
+		routeShortName: 'C Line',
+		tripHeadsign: 'Downtown Seattle',
+		scheduledArrivalTime: Date.now() + 300000,
+		predictedArrivalTime: Date.now() + 300000,
+		predicted: true,
+		stopSequence: 1
+	};
+
+	test('uses the resolved route color for the badge when provided', () => {
+		render(ArrivalDeparture, {
+			props: {
+				arrivalDeparture: arrival,
+				route: { id: 'r_c', shortName: 'C Line', color: 'b02a37', textColor: 'ffffff' },
+				routeColors: { line: '#1565C0', badgeBg: '1565C0', badgeFg: 'ffffff' }
+			}
+		});
+		expect(screen.getByText('C Line')).toHaveStyle('background-color: #1565C0');
+		expect(screen.getByText('C Line')).toHaveStyle('color: #ffffff');
+	});
+
+	test('falls back to the GTFS color when no resolved color is given', () => {
+		render(ArrivalDeparture, {
+			props: {
+				arrivalDeparture: arrival,
+				route: { id: 'r_c', shortName: 'C Line', color: 'b02a37', textColor: 'ffffff' }
+			}
+		});
+		expect(screen.getByText('C Line')).toHaveStyle('background-color: #b02a37');
+	});
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/components/__tests__/ArrivalDeparture.test.js`
+Expected: FAIL — the badge still uses `b02a37`.
+
+- [ ] **Step 3: Thread the prop through the sheet**
+
+In `src/components/ArrivalDeparture.svelte`, add to the props:
+
+```js
+let {
+	arrivalDeparture,
+	includeArrivalDepartureInStatusLabel = true,
+	route = null,
+	expanded = false,
+	// Resolved by the map layer so the badge, the polyline, the vehicle markers,
+	// and the legend all use one color per route. mapContrastColor adjusts most
+	// GTFS colors for the basemap, so without this the badge and the line would
+	// differ for nearly every route in dark mode.
+	routeColors = null
+} = $props();
+```
+
+and where `RouteBadge` is rendered, prefer the resolved values:
+
+```svelte
+<RouteBadge
+	shortName={routeShortName}
+	color={routeColors?.badgeBg ?? route?.color}
+	textColor={routeColors?.badgeFg ?? route?.textColor}
+/>
+```
+
+In `src/components/stops/StopPane.svelte`, accept and forward:
+
+```js
+let {
+	stop,
+	handleUpdateRouteMap = null,
+	tripSelected = null,
+	showHeroCard = true,
+	arrivalsAndDeparturesResponse = $bindable(null),
+	loading = $bindable(false),
+	routeColors = null
+} = $props();
+```
+
+```svelte
+<ArrivalDeparture
+	arrivalDeparture={arrival}
+	route={routeById.get(arrival.routeId)}
+	routeColors={routeColors?.get(arrival.routeId) ?? null}
+	expanded={isActive}
+/>
+```
+
+In `src/components/stops/StopBottomSheet.svelte`, promote the response to a binding and forward `routeColors`:
+
+```js
+let {
+	stop,
+	closePane,
+	tripSelected,
+	handleUpdateRouteMap,
+	snap = $bindable('half'),
+	// Bound up to MapExperience so the map layer can draw the routes behind
+	// these arrivals without issuing a second fetch.
+	arrivalsAndDeparturesResponse = $bindable(null),
+	routeColors = null
+} = $props();
+```
+
+Remove the local `let arrivalsAndDeparturesResponse = $state(null);` declaration and pass `{routeColors}` into `<StopPane>`.
+
+- [ ] **Step 4: Wire up `MapExperience`**
+
+In `src/components/MapExperience.svelte`, add imports and derivations:
+
+```js
+import { activeRoutesFromArrivals, assignRouteColors } from '$lib/activeRoutes.js';
+```
+
+```js
+// Bound up from StopBottomSheet -> StopPane, so the map draws the routes behind
+// the arrivals the rider is actually looking at, with no second fetch.
+let stopArrivals = $state(null);
+let isDarkMode = $state(false);
+
+// Gate on the stop id, not on truthiness: tapping stop A -> stop B keeps the
+// sheet mounted, so `stopArrivals` still holds A's response until B's fetch
+// lands. Without this the map would briefly draw A's routes around B's marker.
+let arrivalsMatchSelection = $derived(
+	stopArrivals?.data?.entry?.stopId != null && stopArrivals.data.entry.stopId === selectedStopId
+);
+let activeRoutes = $derived(arrivalsMatchSelection ? activeRoutesFromArrivals(stopArrivals) : []);
+let routeColors = $derived(assignRouteColors(activeRoutes, { dark: isDarkMode }));
+```
+
+Track the theme so colors recompute on toggle:
+
+```js
+onMount(() => {
+	// ...existing body...
+	if (browser) {
+		isDarkMode = document.documentElement.classList.contains('dark');
+		const onThemeChange = (event) => {
+			isDarkMode = event.detail.darkMode;
+		};
+		window.addEventListener('themeChange', onThemeChange);
+		themeChangeHandler = onThemeChange;
+	}
+});
+```
+
+Declare `let themeChangeHandler = null;` alongside the other handler variables and remove the listener in `onDestroy`.
+
+In the framing effect's `if (id)` branch, clear the previous stop's arrivals before framing:
+
+```js
+// Stop A -> stop B keeps the sheet mounted, so without this the map would keep
+// drawing A's routes, ring dots, and vehicles around B's marker until B's
+// arrivals land ~300ms later.
+stopArrivals = null;
+```
+
+Update the markup to bind and forward:
+
+```svelte
+<StopBottomSheet
+	stop={selectedStopData}
+	{closePane}
+	{tripSelected}
+	{handleUpdateRouteMap}
+	{routeColors}
+	bind:arrivalsAndDeparturesResponse={stopArrivals}
+	bind:snap={sheetSnap}
+/>
+```
+
+```svelte
+<MapContainer
+	{selectedTrip}
+	{selectedRoute}
+	stop={selectedStopData}
+	{handleStopMarkerSelect}
+	{isRouteSelected}
+	{showRouteMap}
+	{initialCoords}
+	{activeRoutes}
+	{routeColors}
+	bind:mapProvider
+/>
+```
+
+`MapContainer` already spreads `...restProps` into `MapView`, so no change is needed there.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npx vitest run src/components/__tests__ src/components/stops/__tests__`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+npx prettier --write src/components/ArrivalDeparture.svelte src/components/stops src/components/MapExperience.svelte src/components/__tests__
+git add src/components src/components/stops
+git commit -m "feat: resolve route colors once and share them with map and badges
+
+Arrivals now bind up from StopPane to MapExperience, which derives the active
+route set and one color per route, then feeds both the map layer and the
+arrival badges. Nulls the response between selections so the map can't draw the
+previous stop's routes around the new stop."
+```
+
+---
+
+## Task 10: The stop routes layer
+
+**Files:**
+
+- Create: `src/components/map/StopRoutesLayer.svelte`
+- Test: `src/components/map/__tests__/StopRoutesLayer.test.js` (create)
+
+**Interfaces:**
+
+- Consumes: `ActiveRoute[]` and `Map<string, RouteColors>` (Tasks 4-5), provider `createPolyline`/`revealPolylines`/`clearAllPolylines` (Tasks 3, 7), `fetchAndUpdateVehiclesForRoutes` (Task 8), `ROUTE_PANE` (Task 7).
+- Produces: `routeStopIds = $bindable(new Map())` — `Map<stopId, string>` from stop id to that stop's ring-dot color, consumed by `MapView` in Task 12. Also `liveCounts = $bindable(new Map())` for the legend.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/components/map/__tests__/StopRoutesLayer.test.js`:
+
+```js
+import { render } from '@testing-library/svelte';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import StopRoutesLayer from '../StopRoutesLayer.svelte';
+
+vi.mock('$lib/vehicleUtils.js', () => ({
+	fetchAndUpdateVehiclesForRoutes: vi.fn().mockResolvedValue(42),
+	clearVehicleMarkersMap: vi.fn()
+}));
+import { fetchAndUpdateVehiclesForRoutes, clearVehicleMarkersMap } from '$lib/vehicleUtils.js';
+import { createLayerBindings } from './support/layerBindings.svelte.js';
+
+function makeProvider() {
+	return {
+		createPolyline: vi.fn(async () => ({ id: 'polyline' })),
+		revealPolylines: vi.fn(),
+		clearAllPolylines: vi.fn(),
+		clearVehicleMarkers: vi.fn()
+	};
+}
+
+const routes = [
+	{ id: 'r_c', shortName: 'C Line', type: 3, tripId: 't_c', gtfsColor: 'b02a37' },
+	{ id: 'r_22', shortName: '22', type: 3, tripId: 't_22', gtfsColor: 'e0a021' }
+];
+const colors = new Map([
+	['r_c', { line: '#b02a37', badgeBg: 'b02a37', badgeFg: 'ffffff' }],
+	['r_22', { line: '#e0a021', badgeBg: 'e0a021', badgeFg: '000000' }]
+]);
+
+function mockShapeFetches({ failRouteId = null } = {}) {
+	global.fetch = vi.fn(async (url) => {
+		if (url.includes('/trip-details/')) {
+			const tripId = url.split('/trip-details/')[1].split('?')[0];
+			if (failRouteId && tripId === `t_${failRouteId.replace('r_', '')}`) {
+				return { ok: false, status: 500 };
+			}
+			return {
+				ok: true,
+				json: async () => ({
+					data: {
+						entry: { schedule: { stopTimes: [{ stopId: `stop_${tripId}` }] } },
+						references: { trips: [{ id: tripId, shapeId: `shape_${tripId}` }] }
+					}
+				})
+			};
+		}
+		return { ok: true, json: async () => ({ data: { entry: { points: 'encoded' } } }) };
+	});
+}
+
+describe('StopRoutesLayer', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockShapeFetches();
+	});
+
+	test('draws one polyline per active route, in its resolved color', async () => {
+		const mapProvider = makeProvider();
+		render(StopRoutesLayer, { props: { mapProvider, activeRoutes: routes, routeColors: colors } });
+
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
+		const usedColors = mapProvider.createPolyline.mock.calls.map(([, options]) => options.color);
+		expect(usedColors).toEqual(expect.arrayContaining(['#b02a37', '#e0a021']));
+	});
+
+	test('requests casings and skips the status payload it does not need', async () => {
+		const mapProvider = makeProvider();
+		render(StopRoutesLayer, { props: { mapProvider, activeRoutes: routes, routeColors: colors } });
+
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalled());
+		expect(mapProvider.createPolyline.mock.calls[0][1].casing).toBe(true);
+		const tripDetailsUrl = global.fetch.mock.calls
+			.map(([url]) => url)
+			.find((u) => u.includes('/trip-details/'));
+		expect(tripDetailsUrl).toContain('includeStatus=false');
+	});
+
+	// $bindable writes land on the parent's reactive state, and $state is a runes
+	// macro that only compiles in a .svelte/.svelte.js module — so a plain
+	// .test.js can't create the proxy to read back. Use a support harness, the
+	// same pattern as the existing support/reactiveStop.svelte.js.
+	test('reports the ring-dot stops from the drawn trips', async () => {
+		const mapProvider = makeProvider();
+		const bindings = createLayerBindings();
+		render(StopRoutesLayer, {
+			props: {
+				mapProvider,
+				activeRoutes: routes,
+				routeColors: colors,
+				get routeStopIds() {
+					return bindings.routeStopIds;
+				},
+				set routeStopIds(value) {
+					bindings.routeStopIds = value;
+				}
+			}
+		});
+
+		await vi.waitFor(() => expect(bindings.routeStopIds.size).toBe(2));
+		expect(bindings.routeStopIds.get('stop_t_c')).toBe('#b02a37');
+	});
+
+	test('drops a route whose shape fetch fails without losing the others', async () => {
+		mockShapeFetches({ failRouteId: 'r_22' });
+		const mapProvider = makeProvider();
+		render(StopRoutesLayer, { props: { mapProvider, activeRoutes: routes, routeColors: colors } });
+
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(1));
+		expect(mapProvider.createPolyline.mock.calls[0][1].color).toBe('#b02a37');
+	});
+
+	test('starts one vehicle poll for all routes', async () => {
+		const mapProvider = makeProvider();
+		render(StopRoutesLayer, { props: { mapProvider, activeRoutes: routes, routeColors: colors } });
+
+		await vi.waitFor(() => expect(fetchAndUpdateVehiclesForRoutes).toHaveBeenCalledTimes(1));
+		expect(fetchAndUpdateVehiclesForRoutes.mock.calls[0][0]).toHaveLength(2);
+	});
+
+	test('tears down polylines, vehicles, and the interval on destroy', async () => {
+		const mapProvider = makeProvider();
+		const { unmount } = render(StopRoutesLayer, {
+			props: { mapProvider, activeRoutes: routes, routeColors: colors }
+		});
+		await vi.waitFor(() => expect(fetchAndUpdateVehiclesForRoutes).toHaveBeenCalled());
+
+		unmount();
+
+		expect(mapProvider.clearAllPolylines).toHaveBeenCalled();
+		expect(mapProvider.clearVehicleMarkers).toHaveBeenCalled();
+		expect(clearVehicleMarkersMap).toHaveBeenCalled();
+	});
+});
+```
+
+- [ ] **Step 2: Add the bindings support harness**
+
+Create `src/components/map/__tests__/support/layerBindings.svelte.js`:
+
+```js
+// Test-only helper: $state is a runes macro, so it only compiles inside a
+// .svelte/.svelte.js module — a plain .test.js can't create the reactive proxy
+// a $bindable prop writes back into. Mirrors support/reactiveStop.svelte.js.
+export function createLayerBindings() {
+	let routeStopIds = $state(new Map());
+	let liveCounts = $state(new Map());
+	return {
+		get routeStopIds() {
+			return routeStopIds;
+		},
+		set routeStopIds(value) {
+			routeStopIds = value;
+		},
+		get liveCounts() {
+			return liveCounts;
+		},
+		set liveCounts(value) {
+			liveCounts = value;
+		}
+	};
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `npx vitest run src/components/map/__tests__/StopRoutesLayer.test.js`
+Expected: FAIL — the component does not exist.
+
+- [ ] **Step 4: Implement the layer**
+
+Create `src/components/map/StopRoutesLayer.svelte`:
+
+```svelte
+<!--
+    @component
+    Draws the routes a rider can actually board from the selected stop, plus the
+    live vehicles feeding those arrivals.
+
+    Deliberately narrower than RouteMap, which draws a single trip's shape and
+    clears the map first. This layer draws one shape per *route* in the arrivals
+    list and owns its own teardown, so a stop selection and a trip expansion can
+    coexist.
+
+    @prop {Object} mapProvider
+    @prop {ActiveRoute[]} activeRoutes - soonest arrival first; drives draw order
+    @prop {Map<string, RouteColors>} routeColors
+    @prop {string|null} promotedRouteId - the expanded arrival's route, drawn on top
+    @prop {string|null} highlightedTripId - the expanded arrival's trip; its vehicle glows
+    @prop {Map<string,string>} routeStopIds - bindable out: stop id -> ring-dot color
+    @prop {Map<string,number>} liveCounts - bindable out: route id -> live vehicle count
+-->
+<script>
+	import { onDestroy } from 'svelte';
+	import { fetchAndUpdateVehiclesForRoutes, clearVehicleMarkersMap } from '$lib/vehicleUtils.js';
+	// From the provider-neutral module, NOT from a provider: importing either
+	// provider here would pull its whole map stack into the bundle regardless of
+	// which one PUBLIC_OBA_MAP_PROVIDER selects.
+	import { ROUTE_PANE } from '$lib/mapPanes.js';
+
+	let {
+		mapProvider,
+		activeRoutes = [],
+		routeColors = new Map(),
+		promotedRouteId = null,
+		highlightedTripId = null,
+		routeStopIds = $bindable(new Map()),
+		liveCounts = $bindable(new Map())
+	} = $props();
+
+	const SHOW_VEHICLES = true;
+
+	// Widest route draws first and each subsequent route is a little narrower, so
+	// a route underneath shows as a colored fringe either side of the one above
+	// it. This is what keeps two routes legible in a shared corridor: all casings
+	// live in one pane below all colored strokes, so the fringe isn't covered.
+	// A true perpendicular offset would need a zoom-reactive screen-space
+	// transform and has no cross-provider primitive — see the design spec.
+	const BASE_WEIGHT = 7;
+	const MIN_WEIGHT = 4;
+
+	let vehicleIntervalId = null;
+	// Incremented per load so a superseded selection's in-flight fetches bail out
+	// instead of drawing over the newer one.
+	let loadToken = 0;
+
+	function weightFor(index) {
+		return Math.max(MIN_WEIGHT, BASE_WEIGHT - index);
+	}
+
+	async function fetchRouteShape(route) {
+		// includeStatus=false: the endpoint defaults it to true, and we need only
+		// the shape id and the stop times.
+		const tripResponse = await fetch(`/api/oba/trip-details/${route.tripId}?includeStatus=false`);
+		if (!tripResponse.ok) {
+			throw new Error(`trip-details ${tripResponse.status} for trip ${route.tripId}`);
+		}
+		const tripData = await tripResponse.json();
+
+		const tripRef = tripData?.data?.references?.trips?.find((trip) => trip.id === route.tripId);
+		const shapeId = tripRef?.shapeId;
+		if (!shapeId) {
+			throw new Error(`no shapeId for trip ${route.tripId}`);
+		}
+
+		const shapeResponse = await fetch(`/api/oba/shape/${shapeId}`);
+		if (!shapeResponse.ok) {
+			throw new Error(`shape ${shapeResponse.status} for shape ${shapeId}`);
+		}
+		const shapeData = await shapeResponse.json();
+
+		const stopIds = (tripData?.data?.entry?.schedule?.stopTimes ?? [])
+			.map((stopTime) => stopTime.stopId)
+			.filter(Boolean);
+
+		return { points: shapeData?.data?.entry?.points, stopIds };
+	}
+
+	async function drawRoutes(routes, colors, token) {
+		const nextStopIds = new Map();
+
+		await Promise.all(
+			routes.map(async (route, index) => {
+				const color = colors.get(route.id)?.line;
+				let shape;
+				try {
+					shape = await fetchRouteShape(route);
+				} catch (error) {
+					// One missing shape degrades the map rather than breaking it: the
+					// other routes still draw, and this one is simply absent from the
+					// lines, the legend, and the ring dots.
+					console.error('StopRoutesLayer: could not load shape', route.id, error);
+					return;
+				}
+				if (token !== loadToken || !shape.points) return;
+
+				const isPromoted = promotedRouteId != null && route.id === promotedRouteId;
+				const polyline = await mapProvider.createPolyline(shape.points, {
+					color,
+					casing: true,
+					weight: weightFor(index),
+					pane: isPromoted ? ROUTE_PANE.PROMOTED : ROUTE_PANE.LINE,
+					casingPane: ROUTE_PANE.CASING
+				});
+				if (token !== loadToken) return;
+				if (!polyline) return;
+
+				// Reveal only this route: its neighbors may already be drawn, and
+				// re-animating them on every resolution would look like a glitch.
+				mapProvider.revealPolylines({ only: [polyline], duration: 0.8 });
+
+				// First route to claim a stop wins, and routes arrive soonest-first,
+				// so a shared stop takes the color of the route arriving next.
+				for (const stopId of shape.stopIds) {
+					if (!nextStopIds.has(stopId)) nextStopIds.set(stopId, color);
+				}
+				routeStopIds = new Map(nextStopIds);
+			})
+		);
+	}
+
+	function stopVehiclePolling() {
+		if (vehicleIntervalId) {
+			clearInterval(vehicleIntervalId);
+			vehicleIntervalId = null;
+		}
+	}
+
+	function teardown() {
+		stopVehiclePolling();
+		mapProvider.clearAllPolylines();
+		mapProvider.clearVehicleMarkers();
+		// clearVehicleMarkers only detaches markers; the module-level map would
+		// otherwise hand stale entries to the next selection.
+		clearVehicleMarkersMap();
+	}
+
+	$effect(() => {
+		const routes = activeRoutes;
+		const colors = routeColors;
+		const token = ++loadToken;
+
+		if (!mapProvider || routes.length === 0) return;
+
+		teardown();
+		drawRoutes(routes, colors, token);
+
+		if (SHOW_VEHICLES) {
+			fetchAndUpdateVehiclesForRoutes(routes, mapProvider, {
+				highlightedTripId,
+				colorsByRouteId: colors,
+				onCounts: (counts) => {
+					if (token === loadToken) liveCounts = counts;
+				}
+			}).then((intervalId) => {
+				// A newer load took over while this poll was starting; don't leak it.
+				if (token !== loadToken) {
+					clearInterval(intervalId);
+					return;
+				}
+				vehicleIntervalId = intervalId;
+			});
+		}
+	});
+
+	onDestroy(() => {
+		loadToken++;
+		teardown();
+	});
+</script>
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run src/components/map/__tests__/StopRoutesLayer.test.js`
+Expected: all PASS.
+
+- [ ] **Step 6: Verify with the Svelte MCP autofixer**
+
+Call `mcp__svelte__svelte-autofixer` with the full contents of `StopRoutesLayer.svelte`. Pay particular attention to whether the `$effect` correctly tracks `activeRoutes`/`routeColors` without also tracking `promotedRouteId` and `highlightedTripId` in a way that redraws every polyline on expansion. Apply corrections, re-run the tests, then call it again to confirm the file is clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+npx prettier --write src/components/map/StopRoutesLayer.svelte src/components/map/__tests__/StopRoutesLayer.test.js
+git add src/components/map/StopRoutesLayer.svelte src/components/map/__tests__/StopRoutesLayer.test.js
+git commit -m "feat: draw the selected stop's active routes and their vehicles"
+```
+
+---
+
+## Task 11: The route legend
+
+**Files:**
+
+- Create: `src/components/map/RouteLegend.svelte`
+- Create: `src/components/map/__tests__/RouteLegend.test.js`
+- Modify: `src/locales/en.json`
+
+**Interfaces:**
+
+- Consumes: `ActiveRoute[]`, `Map<string, RouteColors>`, `Map<string, number>` live counts.
+- Produces: a presentational component; no bindings out.
+
+- [ ] **Step 1: Add the i18n key**
+
+In `src/locales/en.json`, inside the existing `map` object:
+
+```json
+"map": {
+	"find_my_location": "...existing value, leave unchanged...",
+	"routes_shown": "Routes shown",
+	"live_vehicle_count": "{count} live"
+}
+```
+
+Only `en.json` changes — `en` is the synchronous fallback, so the other 24 locales keep working and translations are a follow-up.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `src/components/map/__tests__/RouteLegend.test.js`:
+
+```js
+import { render, screen } from '@testing-library/svelte';
+import { describe, test, expect } from 'vitest';
+import RouteLegend from '../RouteLegend.svelte';
+
+const routes = [
+	{ id: 'r_c', shortName: 'C Line', type: 3, tripId: 't_c', gtfsColor: 'b02a37' },
+	{ id: 'r_22', shortName: '22', type: 3, tripId: 't_22', gtfsColor: 'e0a021' }
+];
+const colors = new Map([
+	['r_c', { line: '#b02a37', badgeBg: 'b02a37', badgeFg: 'ffffff' }],
+	['r_22', { line: '#e0a021', badgeBg: 'e0a021', badgeFg: '000000' }]
+]);
+
+describe('RouteLegend', () => {
+	test('lists one row per drawn route', () => {
+		render(RouteLegend, { props: { routes, routeColors: colors, liveCounts: new Map() } });
+		expect(screen.getByText('C Line')).toBeInTheDocument();
+		expect(screen.getByText('22')).toBeInTheDocument();
+	});
+
+	test('colors each swatch with its route color', () => {
+		const { container } = render(RouteLegend, {
+			props: { routes, routeColors: colors, liveCounts: new Map() }
+		});
+		const swatches = container.querySelectorAll('.legend-swatch');
+		expect(swatches[0]).toHaveStyle('background-color: #b02a37');
+	});
+
+	test('shows the live vehicle count when there is one', () => {
+		render(RouteLegend, {
+			props: { routes, routeColors: colors, liveCounts: new Map([['r_c', 3]]) }
+		});
+		expect(screen.getByText('3 live')).toBeInTheDocument();
+	});
+
+	test('renders nothing when no routes are drawn', () => {
+		const { container } = render(RouteLegend, {
+			props: { routes: [], routeColors: new Map(), liveCounts: new Map() }
+		});
+		expect(container.querySelector('.route-legend')).not.toBeInTheDocument();
+	});
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `npx vitest run src/components/map/__tests__/RouteLegend.test.js`
+Expected: FAIL — the component does not exist.
+
+- [ ] **Step 4: Implement**
+
+Create `src/components/map/RouteLegend.svelte`:
+
+```svelte
+<!--
+    @component
+    Names the colors on the map. Two routes in a shared corridor are only
+    distinguishable if the rider can map a color back to a route, so this pane
+    makes the badge -> line -> vehicle mapping explicit while a stop is selected.
+
+    Desktop only: at phone width the bottom sheet already owns this space, and
+    the arrival badges carry the same mapping.
+-->
+<script>
+	import '$lib/i18n.js';
+	import { isLoading, t } from 'svelte-i18n';
+
+	let { routes = [], routeColors = new Map(), liveCounts = new Map() } = $props();
+</script>
+
+{#if routes.length > 0}
+	<div
+		class="route-legend pointer-events-auto absolute right-4 top-4 z-30 hidden min-w-44 rounded-lg border border-gray-300 bg-white/95 p-3 shadow-md backdrop-blur-sm dark:border-gray-600 dark:bg-gray-800/95 md:block"
+	>
+		<h2
+			class="mb-2 text-[10.5px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+		>
+			{$isLoading ? '' : $t('map.routes_shown')}
+		</h2>
+		<ul class="flex flex-col gap-2">
+			{#each routes as route (route.id)}
+				<li class="flex items-center gap-2">
+					<span
+						class="legend-swatch h-1.5 w-5 flex-none rounded-full"
+						style="background-color: {routeColors.get(route.id)?.line};"
+					></span>
+					<span class="text-[13px] font-bold text-gray-900 dark:text-white">{route.shortName}</span>
+					{#if liveCounts.get(route.id)}
+						<span class="ml-auto text-[11px] text-gray-500 dark:text-gray-400">
+							{$isLoading
+								? ''
+								: $t('map.live_vehicle_count', { values: { count: liveCounts.get(route.id) } })}
+						</span>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	</div>
+{/if}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run src/components/map/__tests__/RouteLegend.test.js`
+Expected: all PASS.
+
+- [ ] **Step 6: Verify with the Svelte MCP autofixer, then commit**
+
+```bash
+npx prettier --write src/components/map/RouteLegend.svelte src/components/map/__tests__/RouteLegend.test.js src/locales/en.json
+git add src/components/map/RouteLegend.svelte src/components/map/__tests__/RouteLegend.test.js src/locales/en.json
+git commit -m "feat: add a route legend to the stop-selection map"
+```
+
+---
+
+## Task 12: Wire the layer into MapView
+
+**Files:**
+
+- Modify: `src/components/map/MapView.svelte`
+- Test: `src/components/__tests__/MapView.test.js`
+
+**Interfaces:**
+
+- Consumes: everything from Tasks 6-11.
+- Produces: the finished feature.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/components/__tests__/MapView.test.js`:
+
+```js
+describe('stop selection layer', () => {
+	test('tiers markers when routes are drawn: route stops ring, everything else muted', async () => {
+		const mapProvider = makeProvider();
+		const { component } = render(MapView, {
+			props: {
+				handleStopMarkerSelect: vi.fn(),
+				mapProvider,
+				stop: { id: 'stop_sel', lat: 47.6, lon: -122.3 },
+				activeRoutes: [
+					{ id: 'r_c', shortName: 'C Line', type: 3, tripId: 't_c', gtfsColor: 'b02a37' }
+				],
+				routeColors: new Map([['r_c', { line: '#b02a37', badgeBg: 'b02a37', badgeFg: 'ffffff' }]])
+			}
+		});
+
+		await vi.waitFor(() => expect(mapProvider.setStopEmphasis).toHaveBeenCalled());
+		const [, defaultEmphasis, selectedStopId] = mapProvider.setStopEmphasis.mock.calls.at(-1);
+		expect(defaultEmphasis).toBe('muted');
+		expect(selectedStopId).toBe('stop_sel');
+	});
+
+	test('does not tier or dim when there are no active routes', async () => {
+		const mapProvider = makeProvider();
+		render(MapView, {
+			props: {
+				handleStopMarkerSelect: vi.fn(),
+				mapProvider,
+				stop: { id: 'stop_sel', lat: 47.6, lon: -122.3 },
+				activeRoutes: [],
+				routeColors: new Map()
+			}
+		});
+
+		await vi.waitFor(() => expect(mapProvider.initMap).toHaveBeenCalled());
+		expect(mapProvider.setStopEmphasis).not.toHaveBeenCalled();
+		expect(mapProvider.setBasemapDimmed).not.toHaveBeenCalledWith(true);
+	});
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/components/__tests__/MapView.test.js`
+Expected: FAIL — `setStopEmphasis` is never called.
+
+- [ ] **Step 3: Wire it up**
+
+In `src/components/map/MapView.svelte`, add the imports and props:
+
+```js
+import StopRoutesLayer from './StopRoutesLayer.svelte';
+import RouteLegend from './RouteLegend.svelte';
+```
+
+```js
+let {
+	handleStopMarkerSelect,
+	selectedTrip = null,
+	selectedRoute = null,
+	isRouteSelected = false,
+	showRouteMap = false,
+	mapProvider = null,
+	stop = null,
+	initialCoords = null,
+	activeRoutes = [],
+	routeColors = new Map()
+} = $props();
+
+// Non-selected stops collapse to quiet dots so the selected stop and the drawn
+// routes are the only loud things on the map. Kept as a constant rather than
+// config: 'faded' and 'hidden' are one edit away if an agency ever wants them.
+const STOP_TREATMENT = 'dots';
+const DIM_BASEMAP = true;
+
+let routeStopIds = $state(new Map());
+let liveCounts = $state(new Map());
+
+// The layer only draws once the arrivals belong to this stop, so gate everything
+// on there actually being routes. A stop with no arrivals in-window keeps
+// today's map exactly — there's no catchable bus to point at, so dots on a
+// washed-out basemap would be noise.
+let routeLayerActive = $derived(!!stop && activeRoutes.length > 0);
+let mutedTier = $derived(STOP_TREATMENT === 'hidden' ? 'hidden' : 'muted');
+
+// Ring-dot tier for every stop the drawn routes serve.
+let emphasisByStopId = $derived(
+	new Map(
+		[...routeStopIds].map(([stopId, color]) => [stopId, { emphasis: 'routeDot', dotColor: color }])
+	)
+);
+
+$effect(() => {
+	if (!mapInstance) return;
+	if (routeLayerActive) {
+		mapInstance.setStopEmphasis(emphasisByStopId, mutedTier, stop.id);
+		if (DIM_BASEMAP) mapInstance.setBasemapDimmed(true);
+	} else {
+		mapInstance.resetStopEmphasis();
+		mapInstance.setBasemapDimmed(false);
+	}
+});
+```
+
+Seed emphasis at marker creation. In `addMarker` (currently line 219), after `shouldHighlight`:
+
+```js
+// Seeded here rather than patched after batchAddMarkers, which defers creation
+// into a rAF — a later setStopEmphasis() would iterate a markersMap that doesn't
+// hold these markers yet, and stops panned in mid-selection would stay full pins.
+const tier = routeLayerActive
+	? (emphasisByStopId.get(s.id) ?? { emphasis: mutedTier, dotColor: null })
+	: null;
+
+const markerObj = mapInstance.addMarker({
+	position: { lat: s.lat, lng: s.lon },
+	stop: s,
+	isHighlighted: shouldHighlight,
+	emphasis: shouldHighlight ? 'full' : (tier?.emphasis ?? 'full'),
+	dotColor: tier?.dotColor ?? null,
+	onClick: () => {
+		handleStopMarkerSelect(s);
+	}
+});
+```
+
+Update the markup:
+
+```svelte
+<div class="map-container">
+	<div id="map" bind:this={mapElement}></div>
+
+	{#if stop && activeRoutes.length > 0}
+		<StopRoutesLayer
+			mapProvider={mapInstance}
+			{activeRoutes}
+			{routeColors}
+			promotedRouteId={selectedRoute?.id ?? null}
+			highlightedTripId={selectedTrip?.tripId ?? null}
+			bind:routeStopIds
+			bind:liveCounts
+		/>
+	{/if}
+
+	<!-- RouteMap opens with clearAllPolylines() + removeStopMarkers(), which would
+	     wipe the stop-selection layer. While a stop is selected, StopRoutesLayer
+	     owns the map instead and expansion just promotes a route. -->
+	{#if selectedTrip && showRouteMap && !stop}
+		<RouteMap mapProvider={mapInstance} tripId={selectedTrip.tripId} currentSelectedStop={stop} />
+	{/if}
+
+	<RouteLegend routes={stop ? activeRoutes : []} {routeColors} {liveCounts} />
+</div>
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `npx vitest run`
+Expected: all PASS.
+
+- [ ] **Step 5: Check coverage against the 70% gate**
+
+Run: `npx vitest run --coverage`
+Expected: branches, functions, lines, and statements all ≥ 70%. If a new file drags it down, add the missing cases before committing rather than lowering the threshold.
+
+- [ ] **Step 6: Verify with the Svelte MCP autofixer, then commit**
+
+```bash
+npx prettier --write src/components/map/MapView.svelte src/components/__tests__/MapView.test.js
+git add src/components/map/MapView.svelte src/components/__tests__/MapView.test.js
+git commit -m "feat: re-compose the map around the selected stop
+
+Selecting a stop now de-emphasizes every other stop into route-colored or gray
+dots, draws the routes behind its arrivals with their live vehicles, dims the
+basemap, and names the colors in a legend."
+```
+
+---
+
+## Task 13: End-to-end verification
+
+**Files:** none — this is the `/go` exercise step.
+
+- [ ] **Step 1: Boot the dev server**
+
+```bash
+npm run dev
+```
+
+- [ ] **Step 2: Drive the golden path in a browser**
+
+Use the `example-skills:webapp-testing` skill (Playwright). Watch the console throughout; a clean run has no errors.
+
+- [ ] Select a stop with several routes. Confirm: selected stop keeps the emphasized pin with a brand-accent caret; stops on the drawn routes are ring dots in their route's color; every other stop is a small gray dot; one line per route in the arrivals list, each with a white casing; vehicles in matching colors; the legend lists each route with a live count; the basemap is dimmed.
+- [ ] Confirm a route the stop is signed for but which has **no** arrival in-window is **not** drawn.
+- [ ] Expand an arrival row. Confirm **stop markers do not vanish** (the P1 regression), the expanded route draws on top, and its vehicle glows amber.
+- [ ] Collapse the row, then close the sheet. Confirm every stop returns to a full bus pin, the lines and vehicles are gone, and the basemap is undimmed.
+- [ ] Re-open a stop and confirm vehicles appear (the P3 regression — they would be missing if `vehicleMarkersMap` leaked).
+- [ ] Tap straight from stop A to stop B. Confirm no A-colored lines or dots ever appear around B.
+- [ ] Pan the map with a stop selected. Confirm newly-loaded stops arrive already tiered, not as full pins.
+- [ ] Toggle dark mode with a stop selected. Confirm lines, vehicles, badges, and legend all recolor together and stay legible.
+- [ ] Open a stop whose routes share a GTFS color. Confirm the lines are distinguishable and each badge matches its line.
+- [ ] Search for a route (not a stop) and confirm route search still draws its polyline and vehicles — the `vehicleUtils` regression check.
+
+- [ ] **Step 3: Repeat on the Google provider**
+
+Set `PUBLIC_OBA_MAP_PROVIDER=google` in `.env`, restart, and repeat the golden path. Google has no draw-in reveal by design; everything else should match.
+
+- [ ] **Step 4: Check mobile**
+
+Resize to a phone viewport. Confirm the tiers, lines, vehicles, and dim all apply, the legend is hidden, and panning stays smooth (the OSM dim is a CSS filter over a WebGL canvas — watch for jank).
+
+- [ ] **Step 5: Full check**
+
+```bash
+npx prettier --check . && npx eslint . && npx vitest run
+```
+
+Expected: all clean.

--- a/docs/superpowers/plans/2026-07-23-map-stop-selection.md
+++ b/docs/superpowers/plans/2026-07-23-map-stop-selection.md
@@ -1374,7 +1374,7 @@ Replace the markup block (currently lines 71-103) with:
 	     dot is the whole point, but collapsing the hit target with it would put
 	     the control under the WCAG 2.5.8 minimum and make it unusable on touch. -->
 	<button
-		class="marker-hit-area {isFullPin ? '' : 'as-dot'}"
+		class="marker-hit-area"
 		onclick={onClick}
 		aria-label={stop.name}
 	>
@@ -1383,8 +1383,12 @@ Replace the markup block (currently lines 71-103) with:
 				<span class="bus-icon dark:text-white">
 					<FontAwesomeIcon {icon} class=" text-black" />
 					{#if stop.direction}
+						<!-- No class on the caret icon itself: svelte-fontawesome spreads it onto
+						     the <svg>, and an element's own rule always beats a color inherited
+						     from an ancestor — which would make the .highlight caret tint below
+						     dead in dark mode. Let the svg inherit currentColor from this span. -->
 						<span class="direction-arrow {stop.direction.toLowerCase()} dark:text-white">
-							<FontAwesomeIcon icon={faCaretUp} class="dark:text-white" />
+							<FontAwesomeIcon icon={faCaretUp} />
 						</span>
 					{/if}
 				</span>

--- a/docs/superpowers/plans/2026-07-23-map-stop-selection.md
+++ b/docs/superpowers/plans/2026-07-23-map-stop-selection.md
@@ -13,7 +13,8 @@
 ## Global Constraints
 
 - **Run tests with `npx vitest run`**, never `npm run test` — it hangs in a non-TTY shell.
-- **Settings are module constants, not env vars:** `STOP_TREATMENT = 'dots'`, `SHOW_VEHICLES = true`, `DIM_BASEMAP = true`. There is no `animateFlow` constant and no flow-dash overlay.
+- **The mockup's four settings are inlined, not configurable and not named constants.** Non-route stops always collapse to gray dots, vehicles are always drawn, the basemap is always dimmed while routes are drawn, and there is no flow-dash overlay. Do **not** add `STOP_TREATMENT` / `SHOW_VEHICLES` / `DIM_BASEMAP` constants or an unreachable `hidden` marker tier — a constant that is never false is dead code. Re-introducing configurability later is a deliberate, separate change.
+- **`StopMarker.emphasis` has exactly three values:** `'full' | 'routeDot' | 'muted'`.
 - **Both map providers must stay at parity** for every new method. `PUBLIC_OBA_MAP_PROVIDER` selects between them at runtime; a method on one must exist on the other.
 - **Coverage:** `vite.config.js` sets `all: true` with a global 70% threshold and no `include`, so every new file counts toward coverage whether or not it has a test.
 - **`RouteBadge` takes hex WITHOUT a leading `#`** (`RouteBadge.svelte:12` does `` `#${color}` ``). Map-facing colors carry the `#`. `assignRouteColors` returns both forms; do not convert anywhere else.
@@ -1203,7 +1204,7 @@ light/dark palette, keyed on route id so colors are stable across refreshes."
 **Interfaces:**
 
 - Consumes: nothing.
-- Produces: `StopMarker` accepts `emphasis: 'full' | 'routeDot' | 'muted' | 'hidden'` (default `'full'`) and `dotColor: string | null`. `isHighlighted` is unchanged and **wins over `emphasis`** — a highlighted marker always renders the full pin.
+- Produces: `StopMarker` accepts `emphasis: 'full' | 'routeDot' | 'muted'` (default `'full'`) and `dotColor: string | null`. `isHighlighted` is unchanged and **wins over `emphasis`** — a highlighted marker always renders the full pin.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -1249,12 +1250,6 @@ describe('StopMarker emphasis', () => {
 		expect(container.querySelector('.bus-icon')).not.toBeInTheDocument();
 	});
 
-	test('draws no dot for hidden', () => {
-		const { container } = renderMarker({ emphasis: 'hidden' });
-		expect(container.querySelector('.emphasis-dot')).not.toBeInTheDocument();
-		expect(container.querySelector('.bus-icon')).not.toBeInTheDocument();
-	});
-
 	// The selected stop is always in the ring-dot set (those are the trips that
 	// serve it), so these two props WILL collide. isHighlighted has to win, or the
 	// rider's selected stop becomes the least distinguishable thing on the map.
@@ -1268,7 +1263,7 @@ describe('StopMarker emphasis', () => {
 		expect(container.querySelector('.emphasis-dot')).not.toBeInTheDocument();
 	});
 
-	test.each(['full', 'routeDot', 'muted', 'hidden'])(
+	test.each(['full', 'routeDot', 'muted'])(
 		'keeps an accessible 32px button in the %s tier',
 		(emphasis) => {
 			const { container } = renderMarker({ emphasis, dotColor: '#b02a37' });
@@ -1278,16 +1273,13 @@ describe('StopMarker emphasis', () => {
 		}
 	);
 
-	test.each(['routeDot', 'muted', 'hidden'])(
-		'hides the routes label in the %s tier',
-		(emphasis) => {
-			const withRoutes = { ...stop, routes: [{ shortName: 'C' }, { shortName: '22' }] };
-			render(StopMarker, {
-				props: { stop: withRoutes, icon: faBus, onClick: vi.fn(), showRoutesLabel: true, emphasis }
-			});
-			expect(screen.queryByText('C, 22')).not.toBeInTheDocument();
-		}
-	);
+	test.each(['routeDot', 'muted'])('hides the routes label in the %s tier', (emphasis) => {
+		const withRoutes = { ...stop, routes: [{ shortName: 'C' }, { shortName: '22' }] };
+		render(StopMarker, {
+			props: { stop: withRoutes, icon: faBus, onClick: vi.fn(), showRoutesLabel: true, emphasis }
+		});
+		expect(screen.queryByText('C, 22')).not.toBeInTheDocument();
+	});
 
 	test('shows the routes label in the full tier', () => {
 		const withRoutes = { ...stop, routes: [{ shortName: 'C' }, { shortName: '22' }] };
@@ -1322,7 +1314,7 @@ In `src/components/map/StopMarker.svelte`, update the props block:
  * @property {any} icon
  * @property {boolean} [isHighlighted]
  * @property {boolean} [showRoutesLabel]
- * @property {'full'|'routeDot'|'muted'|'hidden'} [emphasis] - Marker prominence,
+ * @property {'full'|'routeDot'|'muted'} [emphasis] - Marker prominence,
  *   decided by the map layer from the current selection. `full` is today's pin.
  * @property {string|null} [dotColor] - Ring color for the `routeDot` tier.
  */
@@ -1765,7 +1757,7 @@ Add the emphasis and dim methods next to `highlightMarker`:
  * selection or the drawn route set changes.
  *
  * @param {Map<string, {emphasis: string, dotColor: string|null}>} byStopId
- * @param {'full'|'muted'|'hidden'} defaultEmphasis - for stops not in byStopId
+ * @param {'full'|'muted'} defaultEmphasis - for stops not in byStopId
  * @param {string|null} selectedStopId - always rendered as the full pin
  */
 setStopEmphasis(byStopId, defaultEmphasis = 'full', selectedStopId = null) {
@@ -2875,8 +2867,6 @@ Create `src/components/map/StopRoutesLayer.svelte`:
 		liveCounts = $bindable(new Map())
 	} = $props();
 
-	const SHOW_VEHICLES = true;
-
 	// Widest route draws first and each subsequent route is a little narrower, so
 	// a route underneath shows as a colored fringe either side of the one above
 	// it. This is what keeps two routes legible in a shared corridor: all casings
@@ -2992,22 +2982,20 @@ Create `src/components/map/StopRoutesLayer.svelte`:
 		teardown();
 		drawRoutes(routes, colors, token);
 
-		if (SHOW_VEHICLES) {
-			fetchAndUpdateVehiclesForRoutes(routes, mapProvider, {
-				highlightedTripId,
-				colorsByRouteId: colors,
-				onCounts: (counts) => {
-					if (token === loadToken) liveCounts = counts;
-				}
-			}).then((intervalId) => {
-				// A newer load took over while this poll was starting; don't leak it.
-				if (token !== loadToken) {
-					clearInterval(intervalId);
-					return;
-				}
-				vehicleIntervalId = intervalId;
-			});
-		}
+		fetchAndUpdateVehiclesForRoutes(routes, mapProvider, {
+			highlightedTripId,
+			colorsByRouteId: colors,
+			onCounts: (counts) => {
+				if (token === loadToken) liveCounts = counts;
+			}
+		}).then((intervalId) => {
+			// A newer load took over while this poll was starting; don't leak it.
+			if (token !== loadToken) {
+				clearInterval(intervalId);
+				return;
+			}
+			vehicleIntervalId = intervalId;
+		});
 	});
 
 	onDestroy(() => {
@@ -3269,12 +3257,6 @@ let {
 	routeColors = new Map()
 } = $props();
 
-// Non-selected stops collapse to quiet dots so the selected stop and the drawn
-// routes are the only loud things on the map. Kept as a constant rather than
-// config: 'faded' and 'hidden' are one edit away if an agency ever wants them.
-const STOP_TREATMENT = 'dots';
-const DIM_BASEMAP = true;
-
 let routeStopIds = $state(new Map());
 let liveCounts = $state(new Map());
 
@@ -3283,7 +3265,6 @@ let liveCounts = $state(new Map());
 // today's map exactly — there's no catchable bus to point at, so dots on a
 // washed-out basemap would be noise.
 let routeLayerActive = $derived(!!stop && activeRoutes.length > 0);
-let mutedTier = $derived(STOP_TREATMENT === 'hidden' ? 'hidden' : 'muted');
 
 // Ring-dot tier for every stop the drawn routes serve.
 let emphasisByStopId = $derived(
@@ -3295,8 +3276,10 @@ let emphasisByStopId = $derived(
 $effect(() => {
 	if (!mapInstance) return;
 	if (routeLayerActive) {
-		mapInstance.setStopEmphasis(emphasisByStopId, mutedTier, stop.id);
-		if (DIM_BASEMAP) mapInstance.setBasemapDimmed(true);
+		// Non-selected stops collapse to quiet dots so the selected stop and the
+		// drawn routes are the only loud things on the map.
+		mapInstance.setStopEmphasis(emphasisByStopId, 'muted', stop.id);
+		mapInstance.setBasemapDimmed(true);
 	} else {
 		mapInstance.resetStopEmphasis();
 		mapInstance.setBasemapDimmed(false);
@@ -3311,7 +3294,7 @@ Seed emphasis at marker creation. In `addMarker` (currently line 219), after `sh
 // into a rAF — a later setStopEmphasis() would iterate a markersMap that doesn't
 // hold these markers yet, and stops panned in mid-selection would stay full pins.
 const tier = routeLayerActive
-	? (emphasisByStopId.get(s.id) ?? { emphasis: mutedTier, dotColor: null })
+	? (emphasisByStopId.get(s.id) ?? { emphasis: 'muted', dotColor: null })
 	: null;
 
 const markerObj = mapInstance.addMarker({

--- a/docs/superpowers/plans/2026-07-23-map-stop-selection.md
+++ b/docs/superpowers/plans/2026-07-23-map-stop-selection.md
@@ -1122,10 +1122,17 @@ function paletteIndexFor(routeId) {
 
 // Badge text: the background is no longer the agency's own color, so the
 // agency's textColor (chosen for that original hex) may be unreadable against
-// it. Pick from the resolved background instead. 140 is the midpoint of
-// colorUtils' own brightness scale.
+// it. Pick from the resolved background instead — by true WCAG contrast, NOT by
+// getBrightness, which is NTSC-weighted (G .587) where WCAG luminance weights
+// green .7152 and red .2126. A brightness threshold fails ~14% of colors,
+// including ordinary agency greens/reds/oranges (#009900 -> 3.78:1,
+// #ff6600 -> 2.94:1).
+//
+// Choosing whichever of white/black scores higher is a *structural* guarantee of
+// >= 4.58:1 on any background: the worst case is the luminance where the two tie,
+// (L+0.05)/0.05 == 1.05/(L+0.05), giving L ~ 0.1791 and a ratio of ~4.58.
 function badgeForeground(hex) {
-	return getBrightness(hexToRgb(hex)) > 140 ? '000000' : 'ffffff';
+	return contrastRatio(hex, '#ffffff') >= contrastRatio(hex, '#000000') ? 'ffffff' : '000000';
 }
 
 /**
@@ -1151,6 +1158,14 @@ export function assignRouteColors(routes, { dark = false } = {}) {
 	// keep its own GTFS color claims it first, and only then do the leftovers pick
 	// from the palette. A single pass would let an early colorless route grab a
 	// palette slot that a later route's GTFS color also maps to.
+	//
+	// The keeper within a color group must be chosen by a data-only rule, NOT by
+	// array position. Routes arrive in draw order (soonest arrival first), so two
+	// routes with close arrival times swap between 30s polls — and picking the
+	// first-seen route as keeper flips BOTH routes' colors on screen with no
+	// underlying data change (the loser's fallback depends on what's in `taken` by
+	// the time it is processed). Group by resolved color, then let the lowest
+	// routeId keep it.
 	const needsFallback = [];
 	for (const route of routes) {
 		const resolved = mapContrastColor(route.gtfsColor, { dark });

--- a/docs/superpowers/specs/2026-07-23-map-stop-selection-design.md
+++ b/docs/superpowers/specs/2026-07-23-map-stop-selection-design.md
@@ -1,9 +1,15 @@
 # Map Stop Selection: De-emphasized Stops + Active Routes & Vehicles
 
 **Date:** 2026-07-23
-**Status:** Approved (design)
+**Status:** Approved (design), revised after review
 **Reference mockup:** `Map Stop Selection.dc.html` (Claude Design project
 `aecacf9f-fdfa-41ba-950c-5922677d07a1`)
+
+> **Revision note.** The first draft assumed stop markers stay mounted while a
+> stop is selected. They do not — expanding an arrival row flips `mapMode` to
+> `ROUTE` and destroys every marker. That invalidated the central mechanism, and
+> the fix (§Prerequisite fixes) is now the first work item. Four other blockers
+> and a set of smaller corrections from the same review are folded in below.
 
 ## Problem
 
@@ -42,6 +48,16 @@ all stops back to full bus markers, no route lines, no vehicles.
   any of them to `PUBLIC_*` config later is a small, additive change.
 - **No directional flow animation.** `animateFlow` is off, so the dashed white
   overlay stroke in the mockup is not built at all.
+- **No geometric corridor offset.** The brief asks for a ~2px perpendicular
+  offset where routes share a corridor. A true parallel offset is a screen-space
+  transform that must be recomputed on every zoom, and there is no cross-provider
+  primitive for it (Leaflet would need `leaflet-polylineoffset`; Google has no
+  equivalent). Instead we use **graduated stroke weights** — see §Polyline
+  styling — which achieves the same legibility goal with no geometry work and
+  works identically on both providers. True offset stays a follow-up.
+- **No draw-in reveal on Google.** Google's `Polyline` exposes no SVG path, so
+  the `stroke-dashoffset` technique has no analogue. Google draws instantly.
+  Stated here because the first draft wrongly assumed both providers had it.
 - **The standalone `/stops/[stopID]` page is unchanged.** It has no map, so it
   gets no route layer and no color de-collision.
 - **Route-search selection is unchanged.** `SearchPane`'s route click and
@@ -67,7 +83,86 @@ and only `'dots'` is tested.
 not built, and a dead constant guarding code that doesn't exist would be worse
 than its absence. It is recorded in Non-Goals instead.
 
+## Prerequisite fixes
+
+These are corrections to existing behavior that the feature cannot be built on
+top of. They land in the same PR, before the feature work.
+
+### P1 — `mapMode` must not leave `NORMAL` while a stop is selected
+
+`MapView.svelte:77-84` calls `clearAllMarkers()` → `clearAllStopMarkers()`
+whenever `mapMode !== NORMAL`, which destroys every `StopMarker` and empties
+`markersMap`. Expanding an arrival row reaches that state: `StopPane:179-189`
+calls `tripSelected` **and** `handleUpdateRouteMap`, which in
+`MapExperience:253-260`/`:277` set `selectedTrip`, `isRouteSelected = true`,
+`selectedRoute`, and `showRouteMap = true` — and `MapView.svelte:60` turns any
+of those into `Modes.ROUTE`.
+
+So the exact interaction §Trip expansion is designed around currently unmounts
+every marker, and the 100ms debounce back to `NORMAL` on collapse re-mounts them
+fresh at `emphasis: 'full'` over the route lines.
+
+**Fix:** gate the ROUTE branch on there being no selected stop. `MapView`
+already receives the stop as a prop:
+
+```js
+} else if (!stop && (selectedRoute || isRouteSelected || showRouteMap || selectedTrip)) {
+    newMode = Modes.ROUTE;
+```
+
+The claim that markers are never destroyed and recreated is **false** in
+general — `onDestroy` (`MapView.svelte:292`) and this effect both do it. What is
+true after this fix is narrower and sufficient: markers survive for the lifetime
+of a stop selection.
+
+### P2 — closing the sheet with a row expanded strands the map
+
+`closePane()` (`MapExperience.svelte:211-214`) short-circuits for the stop case
+(`if (stopSheetOpen) { pushState('/', {}); return; }`) and never resets
+`showRouteMap`, `isRouteSelected`, or `selectedRoute`. The framing effect's
+`else` branch (`:173-186`) clears only `selectedTrip`. The accordion's collapse
+callback never fires, because `StopPane` is destroyed rather than collapsed.
+
+After expand → close, those three stay truthy, `mapMode` sticks at `ROUTE`
+forever, `clearAllMarkers()` keeps running, and `debouncedLoadMarkers`
+early-returns (`MapView.svelte:157`). No stop markers return until a full
+navigation.
+
+This is a **pre-existing bug**, not one we introduce, but the feature surfaces
+it on every close. **Fix:** reset `showRouteMap = false`, `isRouteSelected = false`,
+`selectedRoute = null` alongside `selectedTrip = null` in the framing effect's
+`else` branch.
+
+### P3 — `clearVehicleMarkersMap()` is missing from stop teardown
+
+`vehicleMarkersMap` is module-scoped (`vehicleUtils.js:17`).
+`mapProvider.clearVehicleMarkers()` removes markers from the map but leaves the
+module map full of detached references; the next selection finds them via
+`.has(markerKey)` and calls `updateVehicleMarker` on dead markers, so those
+vehicles never appear. `RouteMap.svelte:31-33` calls both. The stop teardown at
+`MapExperience.svelte:184` calls only the first.
+
+**Fix:** add `clearVehicleMarkersMap()` there. This is the brief's "respect
+existing cleanup on deselect so nothing leaks between selections."
+
+### P4 — a camera-free polyline reveal
+
+`_revealPolylinesWithDraw` exists only on the OSM provider and is reachable only
+from inside `fitToPolylines` (`OpenStreetMapProvider.svelte.js:858`), which hides
+every polyline and flies the camera to their bounds. We keep the existing stop
+`flyTo` framing, so there is no path today that reveals without refitting. It
+also iterates `this.polylines` wholesale, so calling it per-route as shapes
+resolve would re-animate every already-drawn route.
+
+**Fix:** extract a public `revealPolylines({ only, duration })` on the OSM
+provider that animates exactly the polylines passed to it (plus their
+`_casing`) and never touches the camera; `fitToPolylines` delegates to it with
+`only` omitted, so its behavior is unchanged. Google gets a no-op — see
+Non-Goals.
+
 ## Current State (for reference)
+
+Line references verified against the tree at `d16dfbb`.
 
 - **Selection lives in `page.state`.** `MapExperience.svelte:87` derives
   `selectedStopData` from `$page.state?.stopData`; a marker tap sets it via
@@ -80,32 +175,52 @@ than its absence. It is recorded in Non-Goals instead.
   a `$state` props object and keep the marker in `markersMap`
   (`OpenStreetMapProvider.svelte.js:123`, `GoogleMapProvider.svelte.js:100`).
   `highlightMarker` and `updateMarkersRouteLabelVisibility` already mutate
-  `marker.props` in place. This is the channel emphasis will use — markers are
-  never destroyed and recreated.
-- **`MapView` clears all markers outside NORMAL mode.** The effect at
-  `MapView.svelte:77` calls `clearAllMarkers()` whenever `mapMode !== NORMAL`.
-  A stop selection does _not_ change `mapMode` (it sets no `selectedRoute`), so
-  stop markers stay on screen throughout — which is what makes tiering possible.
+  `marker.props` in place. This is the channel emphasis uses.
+- **`markersMap` is polluted on Google.** `GoogleMapProvider.addStopRouteMarker`
+  (`:217`) does `markersMap.set(stop.id, marker)` with a bare
+  `google.maps.Marker` that has no `.props`, and can overwrite the real
+  `StopMarker` entry for the same stop id. The OSM provider does not do this
+  (`:260-291` uses `stopMarkers`). Any `markersMap` iteration must guard on
+  `marker?.props`, as `updateMarkersRouteLabelVisibility` (`:192`) already does.
 - **`RouteMap` draws one trip and clears everything first.**
   `RouteMap.svelte:43` calls `clearAllPolylines()` + `removeStopMarkers()` on
   load, and its `onDestroy` repeats the teardown. It mounts only when
   `selectedTrip && showRouteMap` (`MapView.svelte:302`).
-- **`vehicleUtils.js` is a module singleton with a global sweep.**
-  `vehicleMarkersMap` is module-scoped, and `removeInactiveMarkers`
-  (`vehicleUtils.js:95`) deletes **every** marker whose key is absent from the
-  single polled route's `activeKeys`. See Risks.
+- **`fetchVehicles` cannot report failure.** `vehicleUtils.js:19-32` returns
+  `{ references: { trips: [] }, list: [] }` for both a failed request and a
+  malformed body — byte-identical to a route with genuinely zero active
+  vehicles.
 - **`createPolyline` already models attached sub-layers.** The OSM provider
   hangs `polyline.arrowDecorator` off the polyline and tears it down in
-  `removePolyline` and `clearAllPolylines`. The white casing follows this exact
-  pattern.
+  `removePolyline` and `clearAllPolylines`. The white casing follows this
+  pattern. `arrowDecorator` is correctly excluded from `this.polylines`; the
+  casing must be too, or `fitToPolylines`, `getPolylinesCount`, and
+  `_getRoutePaths` all double-count.
+- **The arrow decorator lands in `overlayPane`.** `L.Symbol.arrowHead` builds an
+  `L.polyline` from `pathOptions`, and `createPolyline` (`:652-668`) passes no
+  `pane` — so arrows render at z-index 400, **below** any custom route pane.
+- **Leaflet's `createPane` does not set a z-index.** It stamps
+  `leaflet-<name>-pane` and `.leaflet-pane { z-index: 400 }` applies, so every
+  custom pane ties with `overlayPane` and orders only by DOM insertion. The
+  z-index must be assigned explicitly. Each pane does get its own SVG renderer
+  (`Map.getRenderer` → `_getPaneRenderer`), and each `Polyline` keeps its own
+  `_path`, so the `stroke-dashoffset` technique survives the pane split.
+  `markerPane` is 600, so 402/403/404 sit below all markers.
 - **The MapLibre GL basemap renders into Leaflet's `tilePane`.** Confirmed in
   `node_modules/@maplibre/maplibre-gl-leaflet/leaflet-maplibre-gl.js:23`. So a
   CSS filter scoped to `.leaflet-tile-pane` dims the basemap and nothing else.
 - **The Google map is created without a `mapId`** (`src/lib/googleMaps.js:49`),
-  so `map.setOptions({ styles })` still applies.
+  so `map.setOptions({ styles })` still applies. JSON styling is not deprecated
+  (cloud-based styling is), and it affects only basemap features — `Polyline`,
+  `Marker`, and the `OverlayView` that hosts `StopMarker` are untouched.
+- **`GoogleMapProvider.setTheme` replaces styles wholesale** (`:486-489`), so
+  any dim styler it doesn't know about is destroyed on the next `themeChange`
+  — one of which is dispatched unconditionally at `MapView.svelte:275-276`.
 - **`RouteBadge` takes hex without `#`.** `RouteBadge.svelte:12` does
   `` `#${color}` ``. Any override must follow the same convention or normalize
   at the boundary.
+- **Unpredicted arrivals carry `predictedArrivalTime: 0`, not `null`.**
+  `ArrivalDeparture.svelte:74` guards with `arrivalDeparture.predicted && predicted > 0`.
 
 ## Architecture
 
@@ -121,35 +236,62 @@ change below) the arrivals.
 New pure module `src/lib/activeRoutes.js`:
 
 ```js
-// Distinct routes present in the arrivals list, each with the soonest trip.
+// Distinct routes present in the arrivals list, each with its representative trip.
 // Routes signed at the stop but with no arrival in-window are excluded.
-activeRoutesFromArrivals(response) -> [{ routeId, shortName, tripId, route }]
+activeRoutesFromArrivals(response) -> [{ id, shortName, type, tripId, gtfsColor }]
 
-// routeId -> '#rrggbb', de-collided.
-assignRouteColors(routes, { dark }) -> Map<string, string>
+// id -> { line: '#rrggbb', badgeBg: 'rrggbb', badgeFg: 'ffffff' | '000000' }
+assignRouteColors(routes, { dark }) -> Map<string, RouteColors>
 ```
 
-`activeRoutesFromArrivals` dedupes `routeId` across
-`response.data.entry.arrivalsAndDepartures`, keeping the earliest
-`predictedArrivalTime ?? scheduledArrivalTime` per route as the representative
-trip, and joins `data.references.routes` for the GTFS color and type. This is
-what keeps the map honest: a line on the map means a bus you can actually catch
-from this stop is running that route now. In the mockup's stop, 773 is signed
-but has no arrival in-window, so it is never drawn.
+One object shape flows everywhere: `activeRoutesFromArrivals` emits `id`/`type`
+so its output feeds `fetchAndUpdateVehiclesForRoutes` directly without a
+remapping step.
 
-`assignRouteColors` runs each route's GTFS color through
-`mapContrastColor(route.color, { dark })`. Two failure cases get a fallback:
+**Representative trip.** Dedupe `routeId` across
+`response.data.entry.arrivalsAndDepartures`, keeping the soonest arrival per
+route. The comparison must mirror `ArrivalDeparture`'s own predicate, because
+OBA sends `0` rather than `null` for an absent prediction and `??` would sort
+every unpredicted arrival to the front:
+
+```js
+const bestTime = (a) =>
+	a.predicted && a.predictedArrivalTime > 0 ? a.predictedArrivalTime : a.scheduledArrivalTime;
+```
+
+We sort on **arrival** time throughout, including at terminals where
+`ArrivalDeparture` displays departure time (`:54-62`). One ordering for the
+legend and the layer; the list keeps its own display rule.
+
+This is what keeps the map honest: a line on the map means a bus you can
+actually catch from this stop is running that route now. In the mockup's stop,
+773 is signed but has no arrival in-window, so it is never drawn.
+
+**Color.** `assignRouteColors` runs each route's GTFS color through
+`mapContrastColor(gtfsColor, { dark })`. Two cases fall back:
 
 - **Collision.** Real Metro 22 and 128 share a generic color; two identical
   lines in one corridor are unreadable.
 - **Missing color.** `mapContrastColor` returns `null` for absent or invalid
   input.
 
-Both fall back to a new `ROUTE_FALLBACK_PALETTE` in `src/lib/colors.js`: a set
-of distinct hues, each chosen to stay legible on both the light and dark
-basemaps **and** to clear 4.5:1 against white badge text. Because the palette
-entries satisfy both constraints directly, they are used verbatim — no dark-mode
-adjustment — so the badge and the line are guaranteed to be the same hex.
+Both fall back to `ROUTE_FALLBACK_PALETTE` in `src/lib/colors.js`. Because a
+single hex cannot clear both a light and a dark basemap, each entry is a
+light/dark pair, mirroring what `mapContrastColor` does for GTFS colors. These
+eight were chosen by computation, not by eye — every entry clears 3:1 against
+both basemaps and 4.5:1 against its own computed foreground, and the closest
+pair in either mode is 65 units apart in RGB:
+
+| Name    | Light     | Dark      |
+| ------- | --------- | --------- |
+| Crimson | `#C2185B` | `#F06292` |
+| Blue    | `#1565C0` | `#64B5F6` |
+| Green   | `#2E7D32` | `#81C784` |
+| Orange  | `#E65100` | `#FFB74D` |
+| Purple  | `#6A1B9A` | `#BA68C8` |
+| Teal    | `#00695C` | `#4DB6AC` |
+| Brown   | `#5D4037` | `#BCAAA4` |
+| Olive   | `#827717` | `#DCE775` |
 
 Assignment is deterministic: hash `routeId` to a palette index, then linear-probe
 to the next unused entry. Keyed on the id rather than list position, so the color
@@ -170,20 +312,47 @@ theme, and passes the result down two paths:
 the binding. No second fetch, and the map and sheet can never disagree about
 which arrivals are current.
 
-`stopArrivals` resets to `null` when the selection clears, in the same branch of
-the framing effect that runs the existing teardown.
+**`stopArrivals` must be nulled on _both_ selection transitions**, not just on
+close. Tapping stop A → stop B keeps `StopBottomSheet` mounted (`stopSheetOpen`
+stays true; only `stop` changes), so without an explicit reset the map would
+draw A's routes, A's ring dots, and A's vehicles around B's marker for the
+~300ms until B's fetch resolves. The framing effect nulls it in the `if (id)`
+branch as well as the `else` branch.
 
-### Badge color override
+Belt and braces, because a stale-but-non-null value is still possible mid-fetch:
+`StopRoutesLayer` mounts only when
+`stopArrivals?.data?.entry?.stopId === selectedStopId`, not on truthiness.
 
-`ArrivalDeparture` gains an optional `colorOverride` prop, forwarded to
-`RouteBadge` as `color`. **It is only set for routes whose color we assigned** —
-that is, de-collided or previously colorless routes. A route with a unique GTFS
-color passes `null` and renders exactly as it does today, so existing badge text
-contrast and `textColor` handling are untouched.
+Two consequences worth stating rather than discovering:
 
-The value is passed hex-without-`#` to match `RouteBadge`'s existing contract;
-`activeRoutes.js` returns `#rrggbb` (what the map wants), so the sheet side
-strips the `#` at the prop boundary. One conversion point, named explicitly.
+- A `bind:` write-back does **not** reset on unmount — the parent keeps the last
+  value written. That is exactly why the explicit null is required. Because
+  effects run after DOM updates, the sheet unmounts _before_ the framing effect
+  fires, so there is no write-back race.
+- Making the prop bindable means `MapExperience` can now push values _down_ into
+  `StopPane`. The null-on-deselect travels to `StopPane`'s `routeById`
+  derivation (`:175`) and blanks badge colors for one frame, while
+  `arrivalsAndDepartures` (`:48`, a separate `$state`) keeps the rows rendered.
+  Acceptable; noted so it isn't mistaken for a bug.
+
+### Badge color
+
+`ArrivalDeparture` gains an optional `routeColors` prop (the `RouteColors` entry
+for its route), forwarded to `RouteBadge` as `color` and `textColor`.
+
+It is applied **unconditionally**, not only to de-collided routes. This corrects
+the first draft: `mapContrastColor` is not the identity function — in dark mode
+it lightens anything below 180 brightness by 20–50%, and in light mode it darkens
+anything above 200 brightness by 45%. Applying it to the line but not the badge
+would leave badge and line different hexes for essentially every route in dark
+mode, which is the precise ambiguity this feature exists to remove.
+
+Because the background is no longer the GTFS color, the GTFS `textColor` (chosen
+for the original hex) can go unreadable against it. `assignRouteColors` therefore
+returns `badgeFg` computed from `getBrightness()` on the resolved background
+rather than forwarding `route.textColor`. Values are returned hex-without-`#` to
+match `RouteBadge`'s contract; the `#`-prefixed `line` is the map's form. One
+conversion point, in `assignRouteColors`, named explicitly.
 
 ### Change 1 — Marker emphasis tiers
 
@@ -194,16 +363,28 @@ strips the `#` at the prop boundary. One conversion point, named explicitly.
 
 `isHighlighted` **stays as-is** and remains the sole signal for "this is the
 selected stop." Emphasis decides the marker's _shape_; `isHighlighted` decides
-whether the pin is emphasized. The selected stop is always
-`emphasis: 'full', isHighlighted: true`, so there is exactly one source of truth
-for selection and `highlightMarker`/`unHighlightMarker` keep working unchanged.
+whether the pin is emphasized. `highlightMarker`/`unHighlightMarker` keep working
+unchanged.
 
-| Tier       | Which stops                                        | Rendering                                                                                                                                 |
-| ---------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `full`     | all stops when nothing selected; the selected stop | Today's pin. With `isHighlighted`, the existing `.highlight` (`scale-125 border-brand-accent drop-shadow-md`), caret tinted brand-accent. |
-| `routeDot` | stops served by a drawn route                      | 14px white-filled circle, 2.5px border in `dotColor`, small drop shadow. No glyph, no caret.                                              |
-| `muted`    | every other stop on screen                         | ~9px solid `#8b93a1` at 60% opacity with a thin white halo.                                                                               |
-| `hidden`   | (unused at `STOP_TREATMENT: 'dots'`)               | Renders nothing.                                                                                                                          |
+**The two props have different owners** — `isHighlighted` is written by
+`MapExperience`'s framing effect (`:159-161`), `emphasis` by `MapView` — so they
+can disagree, and in the obvious implementation they always would: the ring-dot
+set is the union of stops across the fetched trips, and the selected stop is
+always in that union, since those are the trips that serve it. It would render as
+a plain ring dot with no highlight, no glyph, and no caret — the selected stop
+becoming the least distinguishable thing on screen.
+
+The invariant lives in one place rather than at every call site:
+`setStopEmphasis(byStopId, defaultEmphasis, selectedStopId)` forces `'full'` for
+`selectedStopId` inside the provider. A component test asserts that
+`emphasis: 'routeDot'` + `isHighlighted: true` never renders as a dot.
+
+| Tier       | Which stops                                        | Rendering                                                                                                      |
+| ---------- | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `full`     | all stops when nothing selected; the selected stop | Today's pin. With `isHighlighted`, the existing `.highlight` (`scale-125 border-brand-accent drop-shadow-md`). |
+| `routeDot` | stops served by a drawn route, minus the selected  | 14px white-filled circle, 2.5px border in `dotColor`, small drop shadow. No glyph, no caret.                   |
+| `muted`    | every other stop on screen                         | ~9px solid `#8b93a1` at 60% opacity with a thin white halo.                                                    |
+| `hidden`   | (unused at `STOP_TREATMENT: 'dots'`)               | Button retained and focusable; the inner dot is not drawn. Not "renders nothing" — see a11y below.             |
 
 Why dots rather than dimming: a 32px pinned icon carries the same visual weight
 dimmed or not — shape and size dominate opacity. Collapsing to a dot removes the
@@ -211,62 +392,100 @@ _icon_ and keeps only _position_, which is all a background stop needs to
 contribute. It also removes the caret clutter, and it lets ringed route-dots
 read as beads on a string along each polyline.
 
-**Accessibility:** every tier including `muted` renders a real `<button>` with
-the `sr-only` stop name and the same `onClick`. Collapsing to a dot is a visual
-change only — keyboard order, screen-reader output, and hit targets are
-preserved. The `routes-label` chip renders for `full` only.
+**Accessibility.** The `<button>` keeps its `h-8 w-8` (32px) box in **every**
+tier, with a transparent background; the dot is a centered inner `<span>`. A 9px
+button would be well under the 24px WCAG 2.5.8 target size, and worse on touch.
+Every tier keeps the `sr-only` stop name and the same `onClick`, so keyboard
+order and screen-reader output are unchanged. The `routes-label` chip renders for
+`full` only.
+
+**The brand-accent caret tint is new work, not existing.** `.highlight`
+(`StopMarker.svelte:126-128`) is exactly `scale-125 border-brand-accent
+drop-shadow-md`; the caret is hard-coded `color: #000` (`:139-143`) with
+`dark:text-white` on the icon (`:81`). There is no `.highlight .direction-arrow`
+rule. Adding one needs a dark-mode variant checked against the
+`dark:bg-neutral-200` marker background.
+
+**Emphasis is seeded at creation, not patched afterward.** `batchAddMarkers`
+(`MapView.svelte:206-217`) defers `addMarker` into a `requestAnimationFrame`, so
+a synchronous `setStopEmphasis()` after it would iterate a `markersMap` that does
+not yet hold the new markers — stops panned into view mid-selection would arrive
+as full pins and stay that way. Instead, `emphasis` and `dotColor` join the
+`addMarker(options)` contract and the initial `$state({…})` literal in both
+providers, and `MapView.addMarker` (`:219`) looks the stop up in the current tier
+map the same way it already computes `shouldHighlight` (`:230`).
+
+Seeding both keys in the initial literal also avoids relying on Svelte tracking
+_added_ properties on an existing proxy. That does work, but `mount()` effects
+do not flush synchronously and the fragility is unnecessary.
 
 New provider methods on both providers:
 
 ```js
-setStopEmphasis(byStopId, defaultEmphasis); // Map<stopId, {emphasis, dotColor}>
-resetStopEmphasis(); // everything back to 'full'
+setStopEmphasis(byStopId, defaultEmphasis, selectedStopId);
+resetStopEmphasis();
 ```
 
-Both iterate `markersMap` and mutate `marker.props`, the same reactive channel
-`updateMarkersRouteLabelVisibility` already uses. `MapView` calls
-`setStopEmphasis` when the active-route stop set changes and after
-`batchAddMarkers` (stops panned into view mid-selection must arrive already
-tiered, not as full pins that then collapse).
+Both iterate `markersMap`, skip entries without `.props` (Google's
+`addStopRouteMarker` pollution), and mutate `marker.props` — the same reactive
+channel `updateMarkersRouteLabelVisibility` already uses in production.
 
 ### Change 2 — Routes and vehicles
 
 New `src/components/map/StopRoutesLayer.svelte`, sibling to `RouteMap.svelte`,
-mounted by `MapView` when a stop is selected and arrivals have loaded.
+mounted by `MapView` when the stop-id guard above passes.
 
-**Shapes, per route:** `/api/oba/trip-details/{tripId}` → `shapeId` +
-`schedule.stopTimes`, then `/api/oba/shape/{shapeId}` → encoded points →
-`createPolyline(points, { color, casing: true })`. Fetches run in parallel across
-routes. Cost is 2 requests × N routes; a 4-route stop is 8 requests, issued once
-per selection, not per poll.
+**Shapes, per route:** `/api/oba/trip-details/{tripId}?includeStatus=false` →
+`shapeId` + `schedule.stopTimes`, then `/api/oba/shape/{shapeId}` → encoded
+points → `createPolyline(points, { color, casing: true, pane })`. Fetches run in
+parallel across routes. `includeStatus=false` (the endpoint defaults it to
+`true`, `+server.js:9`) halves the payload — we need only the shape and the stop
+times.
 
 Per-trip shapes rather than `stops-for-route` because the trip's shape is the
 single direction the rider can actually board, and its `stopTimes` gives the
 ring-dot set for free — the stops a catchable bus will actually serve.
 
+**Load token.** A token per selection, following `SearchPane.handleRouteClick`'s
+`routeLoadToken` pattern; a superseded load returns without touching the map.
+
 **Ring-dot set:** the union of `stopIds` across the fetched trips, each mapped to
-its route's color. A stop served by more than one drawn route takes the color of
-the route whose arrival is soonest.
+its route's color, **minus the selected stop**. A stop served by more than one
+drawn route takes the color of the route whose arrival is soonest.
 
 **Polyline styling:**
 
 - **White casing underneath.** Each route draws twice: a ~9–10px white stroke,
-  then the ~5–5.5px colored stroke on top. The line then reads on any basemap
-  tile without a halo hack. The casing hangs off the polyline as
-  `polyline._casing` and is torn down by `removePolyline` and
-  `clearAllPolylines`, exactly as `arrowDecorator` already is.
+  then the colored stroke on top. The line then reads on any basemap tile without
+  a halo hack. The casing hangs off the polyline as `polyline._casing`, is torn
+  down by `removePolyline` and `clearAllPolylines`, and is **not** pushed into
+  `this.polylines`.
+- **Graduated stroke weights** in place of a geometric offset. Routes draw
+  back-to-front with decreasing weight (7px, 6px, 5px…, floor 4px), so a route
+  underneath shows as a colored fringe on either side of the one above it.
+  Because all casings live in one pane below all colored strokes, the fringe is
+  not covered by the upper route's casing. This is what makes coincident routes
+  legible; see Non-Goals for why not a true offset.
 - **Rounded joins and caps** on both strokes.
 - **Z-order.** OSM creates three custom panes — `obaRouteCasing` (402),
-  `obaRoute` (403), `obaRoutePromoted` (404) — all below `markerPane` (600), so
-  every casing sits under every colored stroke and the promoted route sits above
-  its peers. Google uses `zIndex` on the polyline options.
-- **Draw-in reveal.** The providers' existing `_revealPolylinesWithDraw` already
-  animates `stroke-dashoffset`; it is extended to drive the casing in sync so
-  the two strokes reveal together.
+  `obaRoute` (403), `obaRoutePromoted` (404) — **assigning `style.zIndex`
+  explicitly**, since `createPane` does not. All sit below `markerPane` (600).
+  The arrow decorator's `pathOptions` must carry the same `pane` as its polyline,
+  or arrows render at 400 and disappear under every casing. Google uses `zIndex`
+  on the polyline options.
+- **Draw-in reveal** via the new camera-free `revealPolylines({ only })` from P4,
+  called per route as its shape resolves. OSM only.
 - **Direction arrows stay on** (`withArrow` keeps its `true` default). With
-  `ANIMATE_FLOW: false` there is no other direction cue on the line, and we draw
+  `animateFlow` false there is no other direction cue on the line, and we draw
   one direction per route, so the existing `polylineDecorator` arrows earn their
-  place. This is a deliberate divergence from the mockup, which has none.
+  place. A deliberate divergence from the mockup, which has none.
+
+The repo's `getTotalLength()` reveal is kept rather than the brief's
+`pathLength="100"`. They are equivalent, except that Leaflet rewrites the `d`
+attribute on zoom, so a zoom during the ~1.2s reveal leaves a stale
+`strokeDasharray`. `pathLength` would be immune. Keeping the existing approach
+for consistency with `_revealPolylinesWithDraw`; the staleness is pre-existing
+and cosmetic.
 
 **Vehicles:** `generateVehicleIcon.js` is reused unchanged — white circle,
 2px route-colored stroke, route-type glyph, direction arrow snapped to 8 compass
@@ -276,17 +495,23 @@ highlighted trip. Positions animate via `animateMarker.js`.
 **Legend:** new `src/components/map/RouteLegend.svelte`, rendered by `MapView`
 top-right (opposite the sheet), visible only while a stop is selected. Each row
 is a color swatch + route short name + live-vehicle count. Needs one new i18n
-key, `map.routes_shown`; route names come from existing data.
+key, `map.routes_shown`; `en.json` already has a `map` namespace and `en` is the
+sync fallback, so the other 24 locales are unaffected and translations are
+follow-up, not blocking.
 
 **Basemap dim:** new `setBasemapDimmed(boolean)` on both providers. A shared DOM
 overlay is not viable — a sibling `<div>` over `#map` cannot slot between
 Leaflet's internal panes, so it would dim the routes and markers too.
 
 - **OSM:** toggle a class on the map container; CSS applies a
-  saturate/brightness/opacity filter to `.leaflet-tile-pane`, which holds the
-  MapLibre GL canvas and nothing else.
-- **Google:** `setOptions({ styles })` with a desaturate/lighten styler appended
-  to the current theme styles.
+  saturate/brightness/opacity filter to `.leaflet-tile-pane`. The class sits on
+  the container rather than the layer, so it survives `setTheme`'s MapLibre layer
+  rebuild (`:607-613`).
+- **Google:** `setOptions({ styles })` with a desaturate/lighten styler. Because
+  `setTheme` (`:486-489`) replaces styles wholesale, both it and
+  `setBasemapDimmed` must funnel through a single private `_applyStyles()` that
+  composes theme + dim from stored state, or a theme toggle silently wipes the
+  dim.
 
 ### Vehicle polling for N routes
 
@@ -294,37 +519,55 @@ This is the one place the existing code is actively wrong for the new use, not
 merely insufficient. `removeInactiveMarkers` sweeps **every** entry in the
 module-level `vehicleMarkersMap` that is absent from the single polled route's
 `activeKeys`. Three concurrent per-route polls would each delete the other two
-routes' markers on every tick, and the vehicles would flicker in and out.
+routes' markers on every tick.
 
 `vehicleUtils.js` gains:
 
 ```js
 fetchAndUpdateVehiclesForRoutes(routes, mapProvider, { highlightedTripId, onCounts });
-// routes: [{ id, type, color }] -> single interval id
+// routes: the activeRoutesFromArrivals shape -> single interval id
 ```
 
-It fetches all routes in parallel, unions their `activeKeys`, and **scopes the
-sweep to the routes actually polled** by recording the owning `routeId` alongside
-each marker. `onCounts(Map<routeId, number>)` feeds the legend's live counts.
+It fetches all routes in parallel and **scopes the sweep to the routes that
+actually succeeded**. Distinguishing failure from emptiness requires a contract
+change, because today they are identical:
+
+- `fetchVehicles` returns `null` on a failed request or malformed body, and
+  `{ references: { trips: [] }, list: [] }` only for a well-formed empty
+  response. **This is a breaking change to an exported, tested function**
+  (`src/lib/__tests__/vehicleUtils.test.js`) and must be updated there. The
+  wrapper `fetchAndUpdateVehicles` keeps its signature and behavior.
+- The sweep scope is built from the successful routes only, so a route whose
+  fetch failed keeps its markers rather than having them read as "all gone."
+
+Each entry becomes `{ marker, routeId }` so ownership is explicit. `markerKey` is
+`vehicleId || activeTripId` (`:64`), and a physical vehicle can legitimately move
+between routes across a shift, so an entry whose `routeId` changes is re-keyed
+rather than orphaned.
+
+`onCounts(Map<routeId, number>)` feeds the legend's live counts.
 
 The existing single-route `fetchAndUpdateVehicles` becomes a thin wrapper over
 the new function, so `SearchPane` and `RouteMap` keep working through one code
-path rather than two divergent ones. Its signature and behavior are unchanged.
+path rather than two divergent ones.
 
 ### Trip expansion
 
 When the rider expands an arrival row, the multi-route layer **stays**. The
-expanded row's route moves to the `obaRoutePromoted` pane (drawn above its
-peers) and its vehicle takes the amber highlight glow; the other routes stay
-drawn at normal weight. This reads as focus rather than replacement, and matches
-the brief's "primary route on top."
+expanded row's route moves to the `obaRoutePromoted` pane and its vehicle takes
+the amber highlight glow; the other routes stay drawn at normal weight. This
+reads as focus rather than replacement, and matches the brief's "primary route on
+top."
 
-`RouteMap` therefore must not mount while a stop is selected — its
-`loadRouteData` opens with `clearAllPolylines()` + `removeStopMarkers()`, which
-would wipe the layer. `MapView` already receives the selected stop as its `stop`
-prop, so its mount condition (`MapView.svelte:302`) becomes
+`RouteMap` must not mount while a stop is selected — its `loadRouteData` opens
+with `clearAllPolylines()` + `removeStopMarkers()`, which would wipe the layer.
+Its mount condition (`MapView.svelte:302`) becomes
 `selectedTrip && showRouteMap && !stop`. `RouteMap` is otherwise untouched and
 keeps serving route-search selection.
+
+Note this is **separate from** P1: the mount guard stops `RouteMap` from
+drawing, while P1 stops `mapMode` from destroying the markers. Both are required;
+neither substitutes for the other.
 
 ## State Model
 
@@ -335,73 +578,112 @@ keeps serving route-search selection.
 | Stop + row expanded    | unchanged                                                                 | expanded route promoted       | expanded trip's vehicle glows amber   | dimmed  |
 
 Selecting a stop keeps the existing `flyTo` framing. Deselecting clears
-polylines and casings, vehicle markers, the poll interval, `stopArrivals`, and
-the dim, and restores all markers to `full` — reusing the teardown already in
-`MapExperience`'s framing effect and `closePane`.
+polylines and casings, vehicle markers, `vehicleMarkersMap` (P3), the poll
+interval, `stopArrivals`, the dim, and the stranded route flags (P2), and
+restores all markers to `full`.
 
 ## Error Handling
 
 - **A shape fetch fails.** That route is dropped from the layer, the legend, and
-  the ring-dot set; the other routes draw normally. Logged, not surfaced — a
-  missing line degrades the map rather than breaking it, matching how
-  `SearchPane` already skips an undecodable polyline segment.
+  the ring-dot set; the other routes draw normally. Logged, not surfaced —
+  matching how `SearchPane` already skips an undecodable polyline segment.
 - **No arrivals, or arrivals still loading.** The layer draws nothing, stops stay
   `full`, and the basemap stays undimmed. All three flip together once there is a
   real route set to tier against, so the map never shows a screen of gray dots on
   a washed-out basemap with no lines to justify them. A stop with genuinely zero
   arrivals therefore keeps today's map exactly — which is correct: there is no
   catchable bus to point at.
-- **Selection changes mid-fetch.** A load token per selection, following the
-  `routeLoadToken` pattern already in `SearchPane.handleRouteClick` — a
-  superseded load returns without touching the map.
-- **A vehicle poll fails for one route.** Already handled: `fetchVehicles`
-  returns an empty result and warns. The scoped sweep must treat a failed route
-  as "no data this tick" and leave its markers alone, rather than reading the
-  empty result as "all gone" and clearing them.
+- **Selection changes mid-fetch.** The load token above, plus the stop-id mount
+  guard. Note that switching stops while a row is expanded also enters the
+  framing effect's teardown branch (`:130-148`), which clears polylines and
+  vehicles — correct here, since it is tearing down the previous stop's layer,
+  and the token prevents the superseded fetch from redrawing.
+- **A vehicle poll fails for one route.** Handled by the `null`-on-failure
+  contract above: that route is excluded from the sweep scope and its markers are
+  left alone.
 
 ## Testing
 
 Unit (Vitest, `npx vitest run` — `npm run test` hangs in non-TTY):
 
 - `activeRoutes.js`: dedupe by `routeId`; soonest-trip selection when a route has
-  several arrivals; predicted-vs-scheduled time fallback; exclusion of signed
+  several arrivals; **`predictedArrivalTime: 0` does not sort first** (this case
+  passes under the naive `??` and is the point of the test); exclusion of signed
   routes with no arrival; empty and malformed responses.
 - `assignRouteColors`: collision de-collision; missing/invalid GTFS color; the
-  same `routeId` yielding the same color across reordered inputs; light vs dark.
-- `vehicleUtils.fetchAndUpdateVehiclesForRoutes`: markers for route A survive a
-  tick that also polls B and C; a route dropping a vehicle removes only that
-  marker; a failed fetch for one route leaves its markers intact; the
-  single-route wrapper keeps its current behavior.
+  same `routeId` yielding the same color across reordered inputs; light vs dark;
+  `badgeFg` flipping to black on light backgrounds. Plus a palette test asserting
+  every entry's contrast ratios and the minimum pairwise separation, so the
+  guarantees in this document are enforced rather than asserted.
+- `vehicleUtils`: markers for route A survive a tick that also polls B and C; a
+  route dropping a vehicle removes only that marker; **a failed fetch for one
+  route leaves its markers intact while a genuinely empty one clears them**; a
+  vehicle moving between routes is re-keyed, not orphaned; the single-route
+  wrapper keeps its current behavior.
 
 Component:
 
-- `StopMarker`: each emphasis tier renders its expected shape; `routeDot` uses
-  `dotColor`; the `sr-only` name and the button are present in **every** tier;
-  `routes-label` renders for `full` only.
+- `StopMarker` (net-new file — no test exists today): each tier renders its
+  expected shape; `routeDot` uses `dotColor`; the 32px button, `sr-only` name,
+  and `onClick` are present in **every** tier; `routes-label` renders for `full`
+  only; `emphasis: 'routeDot'` + `isHighlighted: true` renders as the highlighted
+  pin, not a dot.
+- Extend the existing `src/tests/lib/OpenStreetMapProvider.test.js` and
+  `GoogleMapProvider.test.js` for `setStopEmphasis` (including the
+  `marker.props`-less Google entry), `resetStopEmphasis`, `setBasemapDimmed`
+  (including surviving a `setTheme` call), casing creation and teardown, pane
+  z-index assignment, and `revealPolylines({ only })`. This is the cheapest
+  coverage win and it directly tests the `$state` mutation channel everything
+  depends on.
 
-Manual (the `/go` end-to-end pass): select a stop and confirm the tiers, the
-lines, the vehicles, the legend, and the dim; expand a row and confirm promotion
-plus the amber glow; close and confirm full restoration with no leaked interval
-or polyline; pan mid-selection and confirm newly-loaded stops arrive already
-tiered; repeat on a stop whose routes share a GTFS color.
+Regression tests for the two prerequisite fixes, since both are behavioral and
+cheap to assert:
+
+- `MapView`: with `stop` and `selectedTrip` both set, `clearAllStopMarkers` is
+  not called.
+- `MapExperience`: after expand-then-`closePane`, `showRouteMap`,
+  `isRouteSelected`, and `selectedRoute` are all cleared.
+
+Coverage note: `vite.config.js` sets `all: true` with a global 70% threshold and
+no `include`, so **every new file counts whether or not it has a test**.
+`StopRoutesLayer.svelte` and `RouteLegend.svelte` need at least smoke coverage or
+they will drag the global number down on their own.
+
+Manual (the `/go` end-to-end pass): select a stop and confirm the tiers, lines,
+vehicles, legend, and dim; expand a row and confirm promotion plus the amber glow
+**and that stop markers do not vanish**; collapse, then close, and confirm full
+restoration with no leaked interval, polyline, or module-map entry; tap straight
+from stop A to stop B and confirm no cross-contamination; pan mid-selection and
+confirm newly-loaded stops arrive already tiered; toggle dark mode with a stop
+selected; repeat the pass on a stop whose routes share a GTFS color, and again
+with `PUBLIC_OBA_MAP_PROVIDER=google`.
 
 ## Risks
 
-- **The `vehicleUtils` rework touches live code paths.** `SearchPane` and
-  `RouteMap` both call `fetchAndUpdateVehicles`. Keeping it as a wrapper with an
-  unchanged signature contains the blast radius, but route-search vehicles need
-  a manual regression check, not just unit tests.
-- **Request volume on multi-route stops.** 2 requests per route on every
-  selection. Parallel and one-shot, but a downtown stop with 8 routes is 16
-  requests. If this proves heavy, the mitigation is a per-selection cap on routes
-  drawn (soonest N), which the legend already makes legible.
-- **Google provider parity is less exercised than OSM.** Dimming in particular
-  uses a different mechanism per provider. `PUBLIC_OBA_MAP_PROVIDER=google`
-  needs its own manual pass.
-- **Badge override applies only in the map view.** A de-collided route shows its
-  assigned color on `/map/stops/:id` and its GTFS color on `/stops/:id`. This is
-  inherent to resolving color from the map's active-route set, and is preferred
-  over de-colliding globally against routes that aren't on screen.
+- **Two prerequisite fixes touch shared map state.** P1 and P2 change `mapMode`
+  and teardown for every consumer, not just stop selection. Route search, the
+  route modal, and the trip planner all need a manual pass.
+- **The `vehicleUtils` rework changes an exported contract.** `fetchVehicles`
+  returning `null` on failure is a breaking change with existing tests.
+  `fetchAndUpdateVehicles` stays a compatible wrapper, but `SearchPane` and
+  `RouteMap` vehicles need a manual regression check.
+- **Request volume on multi-route stops.** 2 requests per route per selection,
+  parallel and one-shot; `includeStatus=false` reduces payload but not count. A
+  downtown stop with 8 routes is 16 requests. Mitigation if it bites: cap the
+  drawn routes at the soonest N, which the legend already makes legible.
+- **Vehicle path-snapping degrades with N routes.** `_getRoutePaths` feeds
+  `animateMarker`'s `buildRoutePath`, which picks the shape minimizing combined
+  endpoint distance across **all** drawn polylines. In a shared corridor a
+  vehicle can snap to a neighbor route's shape. Pre-existing logic, newly
+  exposed; worth watching in the manual pass.
+- **OSM dim is a CSS filter over a WebGL canvas**, which forces a filtered
+  composite per frame during pan/zoom. Needs a mobile perf check.
+- **Google provider parity is thinner than OSM.** Dimming uses a different
+  mechanism, and there is no draw-in reveal. Needs its own manual pass.
+- **Badge override applies only where the map resolves colors.** A route shows
+  its resolved color on `/map/stops/:id` and its GTFS color on `/stops/:id`.
+  Inherent to resolving color from the map's active-route set, and preferred over
+  de-colliding globally against routes that aren't on screen.
 
 ## Mobile
 

--- a/docs/superpowers/specs/2026-07-23-map-stop-selection-design.md
+++ b/docs/superpowers/specs/2026-07-23-map-stop-selection-design.md
@@ -1,0 +1,411 @@
+# Map Stop Selection: De-emphasized Stops + Active Routes & Vehicles
+
+**Date:** 2026-07-23
+**Status:** Approved (design)
+**Reference mockup:** `Map Stop Selection.dc.html` (Claude Design project
+`aecacf9f-fdfa-41ba-950c-5922677d07a1`)
+
+## Problem
+
+When a rider selects a stop today, the map does two things poorly.
+
+**Every stop looks equally important.** The viewport stays full of identical
+white bus-pin markers (`StopMarker.svelte`: `h-8 w-8 rounded-md`, 2px gray-400
+border, black `fa-bus` glyph, direction caret). Nothing on the map reflects
+_which_ stop the rider just picked, so the selected stop is lost in a field of
+look-alikes. Every marker also draws its own direction caret, so a screenful of
+carets points in every direction at once.
+
+**The arrivals list and the map are disconnected.** The sheet lists real-time
+arrivals for routes C, 22, and 128, but the map shows none of those routes'
+paths and none of the vehicles behind those predictions. The rider can read
+"C Line — 7 min" and still have no idea where that bus is or which way it's
+coming from.
+
+## Goal
+
+On stop selection, re-compose the map around the selection:
+
+1. **De-emphasize every other stop**, so the selected stop and the active routes
+   are the only loud things on the map.
+2. **Draw the routes served by the current arrivals list**, plus the live
+   position of every vehicle feeding those arrivals, each colored by route.
+
+Deselecting (sheet close button, Escape, or back) restores today's default map:
+all stops back to full bus markers, no route lines, no vehicles.
+
+## Non-Goals
+
+- **No new environment variables.** The mockup exposes `stopTreatment`,
+  `showVehicles`, `dimBasemap`, and `animateFlow` as per-deployment props. We
+  ship the chosen values as module constants instead (see Settings). Promoting
+  any of them to `PUBLIC_*` config later is a small, additive change.
+- **No directional flow animation.** `animateFlow` is off, so the dashed white
+  overlay stroke in the mockup is not built at all.
+- **The standalone `/stops/[stopID]` page is unchanged.** It has no map, so it
+  gets no route layer and no color de-collision.
+- **Route-search selection is unchanged.** `SearchPane`'s route click and
+  `RouteModal` keep their current behavior and their current blue polylines.
+- **No new stop-marker interaction.** Dots click through to the same
+  `handleStopMarkerSelect` as the full pins.
+
+## Settings
+
+Module constants, not configuration. Values chosen by the maintainer:
+
+| Setting          | Value    | Effect                                                    |
+| ---------------- | -------- | --------------------------------------------------------- |
+| `STOP_TREATMENT` | `'dots'` | Non-route stops collapse to quiet gray dots.              |
+| `SHOW_VEHICLES`  | `true`   | Live vehicles are drawn for every active route.           |
+| `DIM_BASEMAP`    | `true`   | Basemap gets a faint wash while the route layer is drawn. |
+
+`STOP_TREATMENT` is written as a switch over `'dots' | 'faded' | 'hidden'` so
+the two unused treatments stay one constant away, but only `'dots'` is exercised
+and only `'dots'` is tested.
+
+`animateFlow` gets no constant at all. It is `false`, the flow-dash overlay is
+not built, and a dead constant guarding code that doesn't exist would be worse
+than its absence. It is recorded in Non-Goals instead.
+
+## Current State (for reference)
+
+- **Selection lives in `page.state`.** `MapExperience.svelte:87` derives
+  `selectedStopData` from `$page.state?.stopData`; a marker tap sets it via
+  shallow `pushState`. The framing effect at `MapExperience.svelte:107` reacts
+  to it and calls `provider.highlightMarker(id)`.
+- **Arrivals do not reach the map.** `StopPane.svelte` owns
+  `arrivalsAndDeparturesResponse` as `$bindable`, and `StopBottomSheet.svelte:28`
+  binds it into a local `$state` and stops there. `MapExperience` never sees it.
+- **Stop markers carry reactive props.** Both providers mount `StopMarker` with
+  a `$state` props object and keep the marker in `markersMap`
+  (`OpenStreetMapProvider.svelte.js:123`, `GoogleMapProvider.svelte.js:100`).
+  `highlightMarker` and `updateMarkersRouteLabelVisibility` already mutate
+  `marker.props` in place. This is the channel emphasis will use — markers are
+  never destroyed and recreated.
+- **`MapView` clears all markers outside NORMAL mode.** The effect at
+  `MapView.svelte:77` calls `clearAllMarkers()` whenever `mapMode !== NORMAL`.
+  A stop selection does _not_ change `mapMode` (it sets no `selectedRoute`), so
+  stop markers stay on screen throughout — which is what makes tiering possible.
+- **`RouteMap` draws one trip and clears everything first.**
+  `RouteMap.svelte:43` calls `clearAllPolylines()` + `removeStopMarkers()` on
+  load, and its `onDestroy` repeats the teardown. It mounts only when
+  `selectedTrip && showRouteMap` (`MapView.svelte:302`).
+- **`vehicleUtils.js` is a module singleton with a global sweep.**
+  `vehicleMarkersMap` is module-scoped, and `removeInactiveMarkers`
+  (`vehicleUtils.js:95`) deletes **every** marker whose key is absent from the
+  single polled route's `activeKeys`. See Risks.
+- **`createPolyline` already models attached sub-layers.** The OSM provider
+  hangs `polyline.arrowDecorator` off the polyline and tears it down in
+  `removePolyline` and `clearAllPolylines`. The white casing follows this exact
+  pattern.
+- **The MapLibre GL basemap renders into Leaflet's `tilePane`.** Confirmed in
+  `node_modules/@maplibre/maplibre-gl-leaflet/leaflet-maplibre-gl.js:23`. So a
+  CSS filter scoped to `.leaflet-tile-pane` dims the basemap and nothing else.
+- **The Google map is created without a `mapId`** (`src/lib/googleMaps.js:49`),
+  so `map.setOptions({ styles })` still applies.
+- **`RouteBadge` takes hex without `#`.** `RouteBadge.svelte:12` does
+  `` `#${color}` ``. Any override must follow the same convention or normalize
+  at the boundary.
+
+## Architecture
+
+### One color resolution, two consumers
+
+Route color must be identical across the polyline, the vehicle markers, the
+legend, and the arrival badge — otherwise the badge-to-line mapping the whole
+feature depends on is ambiguous. Resolving it inside the map layer and pushing
+it back into the sheet would be circular, so resolution moves **above both** into
+`MapExperience`, which already holds the selected stop and (after the binding
+change below) the arrivals.
+
+New pure module `src/lib/activeRoutes.js`:
+
+```js
+// Distinct routes present in the arrivals list, each with the soonest trip.
+// Routes signed at the stop but with no arrival in-window are excluded.
+activeRoutesFromArrivals(response) -> [{ routeId, shortName, tripId, route }]
+
+// routeId -> '#rrggbb', de-collided.
+assignRouteColors(routes, { dark }) -> Map<string, string>
+```
+
+`activeRoutesFromArrivals` dedupes `routeId` across
+`response.data.entry.arrivalsAndDepartures`, keeping the earliest
+`predictedArrivalTime ?? scheduledArrivalTime` per route as the representative
+trip, and joins `data.references.routes` for the GTFS color and type. This is
+what keeps the map honest: a line on the map means a bus you can actually catch
+from this stop is running that route now. In the mockup's stop, 773 is signed
+but has no arrival in-window, so it is never drawn.
+
+`assignRouteColors` runs each route's GTFS color through
+`mapContrastColor(route.color, { dark })`. Two failure cases get a fallback:
+
+- **Collision.** Real Metro 22 and 128 share a generic color; two identical
+  lines in one corridor are unreadable.
+- **Missing color.** `mapContrastColor` returns `null` for absent or invalid
+  input.
+
+Both fall back to a new `ROUTE_FALLBACK_PALETTE` in `src/lib/colors.js`: a set
+of distinct hues, each chosen to stay legible on both the light and dark
+basemaps **and** to clear 4.5:1 against white badge text. Because the palette
+entries satisfy both constraints directly, they are used verbatim — no dark-mode
+adjustment — so the badge and the line are guaranteed to be the same hex.
+
+Assignment is deterministic: hash `routeId` to a palette index, then linear-probe
+to the next unused entry. Keyed on the id rather than list position, so the color
+does not jump when a 30s refresh reorders the arrivals.
+
+`MapExperience` computes both as `$derived` from `stopArrivals` and the current
+theme, and passes the result down two paths:
+
+- **Map side** → `MapContainer` → `MapView` → `StopRoutesLayer`
+- **Sheet side** → `StopBottomSheet` → `StopPane` → `ArrivalDeparture` →
+  `RouteBadge`
+
+### Getting arrivals to the map
+
+`StopBottomSheet` promotes its local `arrivalsAndDeparturesResponse` to
+`$bindable(null)`, and `MapExperience` binds it into new
+`let stopArrivals = $state(null)`. `StopPane` is untouched — it already exposes
+the binding. No second fetch, and the map and sheet can never disagree about
+which arrivals are current.
+
+`stopArrivals` resets to `null` when the selection clears, in the same branch of
+the framing effect that runs the existing teardown.
+
+### Badge color override
+
+`ArrivalDeparture` gains an optional `colorOverride` prop, forwarded to
+`RouteBadge` as `color`. **It is only set for routes whose color we assigned** —
+that is, de-collided or previously colorless routes. A route with a unique GTFS
+color passes `null` and renders exactly as it does today, so existing badge text
+contrast and `textColor` handling are untouched.
+
+The value is passed hex-without-`#` to match `RouteBadge`'s existing contract;
+`activeRoutes.js` returns `#rrggbb` (what the map wants), so the sheet side
+strips the `#` at the prop boundary. One conversion point, named explicitly.
+
+### Change 1 — Marker emphasis tiers
+
+`StopMarker.svelte` gains:
+
+- `emphasis: 'full' | 'routeDot' | 'muted' | 'hidden'`, default `'full'`
+- `dotColor: string | null` — the route color for `routeDot`
+
+`isHighlighted` **stays as-is** and remains the sole signal for "this is the
+selected stop." Emphasis decides the marker's _shape_; `isHighlighted` decides
+whether the pin is emphasized. The selected stop is always
+`emphasis: 'full', isHighlighted: true`, so there is exactly one source of truth
+for selection and `highlightMarker`/`unHighlightMarker` keep working unchanged.
+
+| Tier       | Which stops                                        | Rendering                                                                                                                                 |
+| ---------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `full`     | all stops when nothing selected; the selected stop | Today's pin. With `isHighlighted`, the existing `.highlight` (`scale-125 border-brand-accent drop-shadow-md`), caret tinted brand-accent. |
+| `routeDot` | stops served by a drawn route                      | 14px white-filled circle, 2.5px border in `dotColor`, small drop shadow. No glyph, no caret.                                              |
+| `muted`    | every other stop on screen                         | ~9px solid `#8b93a1` at 60% opacity with a thin white halo.                                                                               |
+| `hidden`   | (unused at `STOP_TREATMENT: 'dots'`)               | Renders nothing.                                                                                                                          |
+
+Why dots rather than dimming: a 32px pinned icon carries the same visual weight
+dimmed or not — shape and size dominate opacity. Collapsing to a dot removes the
+_icon_ and keeps only _position_, which is all a background stop needs to
+contribute. It also removes the caret clutter, and it lets ringed route-dots
+read as beads on a string along each polyline.
+
+**Accessibility:** every tier including `muted` renders a real `<button>` with
+the `sr-only` stop name and the same `onClick`. Collapsing to a dot is a visual
+change only — keyboard order, screen-reader output, and hit targets are
+preserved. The `routes-label` chip renders for `full` only.
+
+New provider methods on both providers:
+
+```js
+setStopEmphasis(byStopId, defaultEmphasis); // Map<stopId, {emphasis, dotColor}>
+resetStopEmphasis(); // everything back to 'full'
+```
+
+Both iterate `markersMap` and mutate `marker.props`, the same reactive channel
+`updateMarkersRouteLabelVisibility` already uses. `MapView` calls
+`setStopEmphasis` when the active-route stop set changes and after
+`batchAddMarkers` (stops panned into view mid-selection must arrive already
+tiered, not as full pins that then collapse).
+
+### Change 2 — Routes and vehicles
+
+New `src/components/map/StopRoutesLayer.svelte`, sibling to `RouteMap.svelte`,
+mounted by `MapView` when a stop is selected and arrivals have loaded.
+
+**Shapes, per route:** `/api/oba/trip-details/{tripId}` → `shapeId` +
+`schedule.stopTimes`, then `/api/oba/shape/{shapeId}` → encoded points →
+`createPolyline(points, { color, casing: true })`. Fetches run in parallel across
+routes. Cost is 2 requests × N routes; a 4-route stop is 8 requests, issued once
+per selection, not per poll.
+
+Per-trip shapes rather than `stops-for-route` because the trip's shape is the
+single direction the rider can actually board, and its `stopTimes` gives the
+ring-dot set for free — the stops a catchable bus will actually serve.
+
+**Ring-dot set:** the union of `stopIds` across the fetched trips, each mapped to
+its route's color. A stop served by more than one drawn route takes the color of
+the route whose arrival is soonest.
+
+**Polyline styling:**
+
+- **White casing underneath.** Each route draws twice: a ~9–10px white stroke,
+  then the ~5–5.5px colored stroke on top. The line then reads on any basemap
+  tile without a halo hack. The casing hangs off the polyline as
+  `polyline._casing` and is torn down by `removePolyline` and
+  `clearAllPolylines`, exactly as `arrowDecorator` already is.
+- **Rounded joins and caps** on both strokes.
+- **Z-order.** OSM creates three custom panes — `obaRouteCasing` (402),
+  `obaRoute` (403), `obaRoutePromoted` (404) — all below `markerPane` (600), so
+  every casing sits under every colored stroke and the promoted route sits above
+  its peers. Google uses `zIndex` on the polyline options.
+- **Draw-in reveal.** The providers' existing `_revealPolylinesWithDraw` already
+  animates `stroke-dashoffset`; it is extended to drive the casing in sync so
+  the two strokes reveal together.
+- **Direction arrows stay on** (`withArrow` keeps its `true` default). With
+  `ANIMATE_FLOW: false` there is no other direction cue on the line, and we draw
+  one direction per route, so the existing `polylineDecorator` arrows earn their
+  place. This is a deliberate divergence from the mockup, which has none.
+
+**Vehicles:** `generateVehicleIcon.js` is reused unchanged — white circle,
+2px route-colored stroke, route-type glyph, direction arrow snapped to 8 compass
+points, and the existing `PUBLIC_COLOR_VEHICLE_HIGHLIGHT` amber glow for the
+highlighted trip. Positions animate via `animateMarker.js`.
+
+**Legend:** new `src/components/map/RouteLegend.svelte`, rendered by `MapView`
+top-right (opposite the sheet), visible only while a stop is selected. Each row
+is a color swatch + route short name + live-vehicle count. Needs one new i18n
+key, `map.routes_shown`; route names come from existing data.
+
+**Basemap dim:** new `setBasemapDimmed(boolean)` on both providers. A shared DOM
+overlay is not viable — a sibling `<div>` over `#map` cannot slot between
+Leaflet's internal panes, so it would dim the routes and markers too.
+
+- **OSM:** toggle a class on the map container; CSS applies a
+  saturate/brightness/opacity filter to `.leaflet-tile-pane`, which holds the
+  MapLibre GL canvas and nothing else.
+- **Google:** `setOptions({ styles })` with a desaturate/lighten styler appended
+  to the current theme styles.
+
+### Vehicle polling for N routes
+
+This is the one place the existing code is actively wrong for the new use, not
+merely insufficient. `removeInactiveMarkers` sweeps **every** entry in the
+module-level `vehicleMarkersMap` that is absent from the single polled route's
+`activeKeys`. Three concurrent per-route polls would each delete the other two
+routes' markers on every tick, and the vehicles would flicker in and out.
+
+`vehicleUtils.js` gains:
+
+```js
+fetchAndUpdateVehiclesForRoutes(routes, mapProvider, { highlightedTripId, onCounts });
+// routes: [{ id, type, color }] -> single interval id
+```
+
+It fetches all routes in parallel, unions their `activeKeys`, and **scopes the
+sweep to the routes actually polled** by recording the owning `routeId` alongside
+each marker. `onCounts(Map<routeId, number>)` feeds the legend's live counts.
+
+The existing single-route `fetchAndUpdateVehicles` becomes a thin wrapper over
+the new function, so `SearchPane` and `RouteMap` keep working through one code
+path rather than two divergent ones. Its signature and behavior are unchanged.
+
+### Trip expansion
+
+When the rider expands an arrival row, the multi-route layer **stays**. The
+expanded row's route moves to the `obaRoutePromoted` pane (drawn above its
+peers) and its vehicle takes the amber highlight glow; the other routes stay
+drawn at normal weight. This reads as focus rather than replacement, and matches
+the brief's "primary route on top."
+
+`RouteMap` therefore must not mount while a stop is selected — its
+`loadRouteData` opens with `clearAllPolylines()` + `removeStopMarkers()`, which
+would wipe the layer. `MapView` already receives the selected stop as its `stop`
+prop, so its mount condition (`MapView.svelte:302`) becomes
+`selectedTrip && showRouteMap && !stop`. `RouteMap` is otherwise untouched and
+keeps serving route-search selection.
+
+## State Model
+
+| State                  | Stops                                                                     | Routes                        | Vehicles                              | Basemap |
+| ---------------------- | ------------------------------------------------------------------------- | ----------------------------- | ------------------------------------- | ------- |
+| No selection (default) | all `full`                                                                | none                          | none                                  | normal  |
+| Stop selected          | selected = `full` + highlighted; route stops = `routeDot`; rest = `muted` | one polyline per active route | one per active trip, colored by route | dimmed  |
+| Stop + row expanded    | unchanged                                                                 | expanded route promoted       | expanded trip's vehicle glows amber   | dimmed  |
+
+Selecting a stop keeps the existing `flyTo` framing. Deselecting clears
+polylines and casings, vehicle markers, the poll interval, `stopArrivals`, and
+the dim, and restores all markers to `full` — reusing the teardown already in
+`MapExperience`'s framing effect and `closePane`.
+
+## Error Handling
+
+- **A shape fetch fails.** That route is dropped from the layer, the legend, and
+  the ring-dot set; the other routes draw normally. Logged, not surfaced — a
+  missing line degrades the map rather than breaking it, matching how
+  `SearchPane` already skips an undecodable polyline segment.
+- **No arrivals, or arrivals still loading.** The layer draws nothing, stops stay
+  `full`, and the basemap stays undimmed. All three flip together once there is a
+  real route set to tier against, so the map never shows a screen of gray dots on
+  a washed-out basemap with no lines to justify them. A stop with genuinely zero
+  arrivals therefore keeps today's map exactly — which is correct: there is no
+  catchable bus to point at.
+- **Selection changes mid-fetch.** A load token per selection, following the
+  `routeLoadToken` pattern already in `SearchPane.handleRouteClick` — a
+  superseded load returns without touching the map.
+- **A vehicle poll fails for one route.** Already handled: `fetchVehicles`
+  returns an empty result and warns. The scoped sweep must treat a failed route
+  as "no data this tick" and leave its markers alone, rather than reading the
+  empty result as "all gone" and clearing them.
+
+## Testing
+
+Unit (Vitest, `npx vitest run` — `npm run test` hangs in non-TTY):
+
+- `activeRoutes.js`: dedupe by `routeId`; soonest-trip selection when a route has
+  several arrivals; predicted-vs-scheduled time fallback; exclusion of signed
+  routes with no arrival; empty and malformed responses.
+- `assignRouteColors`: collision de-collision; missing/invalid GTFS color; the
+  same `routeId` yielding the same color across reordered inputs; light vs dark.
+- `vehicleUtils.fetchAndUpdateVehiclesForRoutes`: markers for route A survive a
+  tick that also polls B and C; a route dropping a vehicle removes only that
+  marker; a failed fetch for one route leaves its markers intact; the
+  single-route wrapper keeps its current behavior.
+
+Component:
+
+- `StopMarker`: each emphasis tier renders its expected shape; `routeDot` uses
+  `dotColor`; the `sr-only` name and the button are present in **every** tier;
+  `routes-label` renders for `full` only.
+
+Manual (the `/go` end-to-end pass): select a stop and confirm the tiers, the
+lines, the vehicles, the legend, and the dim; expand a row and confirm promotion
+plus the amber glow; close and confirm full restoration with no leaked interval
+or polyline; pan mid-selection and confirm newly-loaded stops arrive already
+tiered; repeat on a stop whose routes share a GTFS color.
+
+## Risks
+
+- **The `vehicleUtils` rework touches live code paths.** `SearchPane` and
+  `RouteMap` both call `fetchAndUpdateVehicles`. Keeping it as a wrapper with an
+  unchanged signature contains the blast radius, but route-search vehicles need
+  a manual regression check, not just unit tests.
+- **Request volume on multi-route stops.** 2 requests per route on every
+  selection. Parallel and one-shot, but a downtown stop with 8 routes is 16
+  requests. If this proves heavy, the mitigation is a per-selection cap on routes
+  drawn (soonest N), which the legend already makes legible.
+- **Google provider parity is less exercised than OSM.** Dimming in particular
+  uses a different mechanism per provider. `PUBLIC_OBA_MAP_PROVIDER=google`
+  needs its own manual pass.
+- **Badge override applies only in the map view.** A de-collided route shows its
+  assigned color on `/map/stops/:id` and its GTFS color on `/stops/:id`. This is
+  inherent to resolving color from the map's active-route set, and is preferred
+  over de-colliding globally against routes that aren't on screen.
+
+## Mobile
+
+The tiering, routes, vehicles, and dim are viewport-independent and apply on
+mobile as they do on desktop. The legend is desktop-only (`md:` and up) — at
+phone width the bottom sheet already occupies the space, and the badge colors in
+the arrivals list carry the same mapping.

--- a/docs/superpowers/specs/2026-07-23-map-stop-selection-design.md
+++ b/docs/superpowers/specs/2026-07-23-map-stop-selection-design.md
@@ -42,10 +42,8 @@ all stops back to full bus markers, no route lines, no vehicles.
 
 ## Non-Goals
 
-- **No new environment variables.** The mockup exposes `stopTreatment`,
-  `showVehicles`, `dimBasemap`, and `animateFlow` as per-deployment props. We
-  ship the chosen values as module constants instead (see Settings). Promoting
-  any of them to `PUBLIC_*` config later is a small, additive change.
+- **No configuration surface at all for the mockup's four settings.** Not env
+  vars, and not named constants — the chosen values are inlined. See Settings.
 - **No directional flow animation.** `animateFlow` is off, so the dashed white
   overlay stroke in the mockup is not built at all.
 - **No geometric corridor offset.** The brief asks for a ~2px perpendicular
@@ -67,21 +65,24 @@ all stops back to full bus markers, no route lines, no vehicles.
 
 ## Settings
 
-Module constants, not configuration. Values chosen by the maintainer:
+The mockup exposes four behaviors as per-deployment props. All four are decided
+here and **inlined at their chosen values** — not env vars, and not named
+constants either. A constant that is never false is dead code, and an
+unreachable branch behind it is worse: it reads as a supported configuration
+while never having been exercised or tested.
 
-| Setting          | Value    | Effect                                                    |
-| ---------------- | -------- | --------------------------------------------------------- |
-| `STOP_TREATMENT` | `'dots'` | Non-route stops collapse to quiet gray dots.              |
-| `SHOW_VEHICLES`  | `true`   | Live vehicles are drawn for every active route.           |
-| `DIM_BASEMAP`    | `true`   | Basemap gets a faint wash while the route layer is drawn. |
+| Mockup prop     | Decision                                                     |
+| --------------- | ------------------------------------------------------------ |
+| `stopTreatment` | `dots`. Non-route stops always collapse to quiet gray dots.  |
+| `showVehicles`  | On. Vehicles are always drawn for the active routes.         |
+| `dimBasemap`    | On. The basemap is dimmed whenever the route layer is drawn. |
+| `animateFlow`   | Off. The flow-dash overlay is not built at all.              |
 
-`STOP_TREATMENT` is written as a switch over `'dots' | 'faded' | 'hidden'` so
-the two unused treatments stay one constant away, but only `'dots'` is exercised
-and only `'dots'` is tested.
-
-`animateFlow` gets no constant at all. It is `false`, the flow-dash overlay is
-not built, and a dead constant guarding code that doesn't exist would be worse
-than its absence. It is recorded in Non-Goals instead.
+Consequently `StopMarker.emphasis` has exactly three values —
+`'full' | 'routeDot' | 'muted'`. There is no `hidden` tier and no `faded`
+treatment. Re-introducing any of this as real configuration is a deliberate,
+separate change: thread a prop through both providers and the marker, and test
+the branch you add.
 
 ## Prerequisite fixes
 
@@ -358,7 +359,7 @@ conversion point, in `assignRouteColors`, named explicitly.
 
 `StopMarker.svelte` gains:
 
-- `emphasis: 'full' | 'routeDot' | 'muted' | 'hidden'`, default `'full'`
+- `emphasis: 'full' | 'routeDot' | 'muted'`, default `'full'`
 - `dotColor: string | null` — the route color for `routeDot`
 
 `isHighlighted` **stays as-is** and remains the sole signal for "this is the
@@ -384,7 +385,6 @@ The invariant lives in one place rather than at every call site:
 | `full`     | all stops when nothing selected; the selected stop | Today's pin. With `isHighlighted`, the existing `.highlight` (`scale-125 border-brand-accent drop-shadow-md`). |
 | `routeDot` | stops served by a drawn route, minus the selected  | 14px white-filled circle, 2.5px border in `dotColor`, small drop shadow. No glyph, no caret.                   |
 | `muted`    | every other stop on screen                         | ~9px solid `#8b93a1` at 60% opacity with a thin white halo.                                                    |
-| `hidden`   | (unused at `STOP_TREATMENT: 'dots'`)               | Button retained and focusable; the inner dot is not drawn. Not "renders nothing" — see a11y below.             |
 
 Why dots rather than dimming: a 32px pinned icon carries the same visual weight
 dimmed or not — shape and size dominate opacity. Collapsing to a dot removes the

--- a/src/assets/styles/leaflet-map.css
+++ b/src/assets/styles/leaflet-map.css
@@ -46,3 +46,21 @@
 		opacity: 1;
 	}
 }
+
+/* Basemap dim for stop selection. Scoped to the tile pane, which holds only the
+   MapLibre GL canvas — routes (overlayPane and the oba route panes) and markers
+   (markerPane) keep full contrast. Transitioned so selecting a stop doesn't
+   snap. */
+.leaflet-container.oba-dim-basemap .leaflet-tile-pane {
+	filter: saturate(0.55) brightness(1.05) opacity(0.72);
+}
+
+.leaflet-container .leaflet-tile-pane {
+	transition: filter 220ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.leaflet-container .leaflet-tile-pane {
+		transition: none;
+	}
+}

--- a/src/components/ArrivalDeparture.svelte
+++ b/src/components/ArrivalDeparture.svelte
@@ -8,7 +8,12 @@
 		arrivalDeparture,
 		includeArrivalDepartureInStatusLabel = true,
 		route = null,
-		expanded = false
+		expanded = false,
+		// Resolved by the map layer so the badge, the polyline, the vehicle markers,
+		// and the legend all use one color per route. mapContrastColor adjusts most
+		// GTFS colors for the basemap, so without this the badge and the line would
+		// differ for nearly every route in dark mode.
+		routeColors = null
 	} = $props();
 
 	const MS_IN_MINS = 60000;
@@ -222,7 +227,11 @@
 </script>
 
 <div class="flex w-full min-w-0 items-center gap-3 pr-1">
-	<RouteBadge shortName={routeShortName} color={route?.color} textColor={route?.textColor} />
+	<RouteBadge
+		shortName={routeShortName}
+		color={routeColors?.badgeBg ?? route?.color}
+		textColor={routeColors?.badgeFg ?? route?.textColor}
+	/>
 
 	<div class="min-w-0 flex-1">
 		<p class="line-clamp-2 text-lg font-semibold text-gray-900 dark:text-white">

--- a/src/components/MapExperience.svelte
+++ b/src/components/MapExperience.svelte
@@ -31,6 +31,7 @@
 	import { showTripOptionsModal } from '$stores/tripOptionsStore';
 	import { mapStopPath } from '$lib/mapStopUrl.js';
 	import { clearVehicleMarkersMap } from '$lib/vehicleUtils';
+	import { activeRoutesFromArrivals, assignRouteColors } from '$lib/activeRoutes.js';
 
 	// One-time snapshot at mount: on a cold /map/stops/{id} load, `data.stopData` is
 	// present, so boot the map centered on the stop (the selection effect then applies
@@ -47,10 +48,10 @@
 
 	let currentModal = $state(null);
 	let selectedTrip = $state(null);
-	// Declared here so this task's teardown can null it; the arrivals plumbing
-	// that actually populates it lands in a later task.
-	// eslint-disable-next-line no-unused-vars -- write-only until the arrivals plumbing lands
+	// Bound up from StopBottomSheet -> StopPane, so the map draws the routes behind
+	// the arrivals the rider is actually looking at, with no second fetch.
 	let stopArrivals = $state(null);
+	let isDarkMode = $state(false);
 	let isRouteSelected = $state(false);
 	let selectedRoute = $state(null);
 	let showRouteMap = $state(false);
@@ -60,6 +61,7 @@
 	let showAlertModal = $state(false);
 	let stops = $state([]);
 	let polylines = [];
+	let themeChangeHandler = null;
 
 	let tripItineraries = $state([]);
 	let tripPlanError = $state(null);
@@ -91,6 +93,15 @@
 	// (unlike page.data, which lingers after a real navigation).
 	let selectedStopData = $derived($page.state?.stopData ?? null);
 	let selectedStopId = $derived(selectedStopData?.id ?? null);
+
+	// Gate on the stop id, not on truthiness: tapping stop A -> stop B keeps the
+	// sheet mounted, so `stopArrivals` still holds A's response until B's fetch
+	// lands. Without this the map would briefly draw A's routes around B's marker.
+	let arrivalsMatchSelection = $derived(
+		stopArrivals?.data?.entry?.stopId != null && stopArrivals.data.entry.stopId === selectedStopId
+	);
+	let activeRoutes = $derived(arrivalsMatchSelection ? activeRoutesFromArrivals(stopArrivals) : []);
+	let routeColors = $derived(assignRouteColors(activeRoutes, { dark: isDarkMode }));
 
 	// While a stop's bottom sheet is open, the search pane collapses to a single
 	// floating field below the md breakpoint; on wider viewports the pane stays
@@ -127,6 +138,11 @@
 		if (id) {
 			const data = selectedStopData;
 			if (!data) return; // wait for state/load data; re-runs when it arrives
+
+			// Stop A -> stop B keeps the sheet mounted, so without this the map would keep
+			// drawing A's routes, ring dots, and vehicles around B's marker until B's
+			// arrivals land ~300ms later.
+			stopArrivals = null;
 
 			// A stop supersedes any other selection. Tear down the map overlays a route
 			// or trip left behind only when one was active, but always clear currentModal
@@ -409,6 +425,13 @@
 			if (initialCoords) {
 				cleanUrlParams();
 			}
+
+			isDarkMode = document.documentElement.classList.contains('dark');
+			const onThemeChange = (event) => {
+				isDarkMode = event.detail.darkMode;
+			};
+			window.addEventListener('themeChange', onThemeChange);
+			themeChangeHandler = onThemeChange;
 		}
 	});
 
@@ -434,6 +457,9 @@
 		if (browser) {
 			window.removeEventListener('tabSwitched', handleTabSwitched);
 			window.removeEventListener('planTripTabClicked', handlePlanTripTabClicked);
+			if (themeChangeHandler) {
+				window.removeEventListener('themeChange', themeChangeHandler);
+			}
 		}
 		if (currentIntervalId) {
 			clearInterval(currentIntervalId);
@@ -496,6 +522,8 @@
 						{closePane}
 						{tripSelected}
 						{handleUpdateRouteMap}
+						{routeColors}
+						bind:arrivalsAndDeparturesResponse={stopArrivals}
 						bind:snap={sheetSnap}
 					/>
 				{:else if currentModal === Modal.ROUTE}
@@ -535,6 +563,8 @@
 		{isRouteSelected}
 		{showRouteMap}
 		{initialCoords}
+		{activeRoutes}
+		{routeColors}
 		bind:mapProvider
 	/>
 {/if}

--- a/src/components/MapExperience.svelte
+++ b/src/components/MapExperience.svelte
@@ -30,6 +30,7 @@
 	import TripOptionsModal from '$components/trip-planner/TripOptionsModal.svelte';
 	import { showTripOptionsModal } from '$stores/tripOptionsStore';
 	import { mapStopPath } from '$lib/mapStopUrl.js';
+	import { clearVehicleMarkersMap } from '$lib/vehicleUtils';
 
 	// One-time snapshot at mount: on a cold /map/stops/{id} load, `data.stopData` is
 	// present, so boot the map centered on the stop (the selection effect then applies
@@ -46,6 +47,10 @@
 
 	let currentModal = $state(null);
 	let selectedTrip = $state(null);
+	// Declared here so this task's teardown can null it; the arrivals plumbing
+	// that actually populates it lands in a later task.
+	// eslint-disable-next-line no-unused-vars -- write-only until the arrivals plumbing lands
+	let stopArrivals = $state(null);
 	let isRouteSelected = $state(false);
 	let selectedRoute = $state(null);
 	let showRouteMap = $state(false);
@@ -176,13 +181,31 @@
 				provider.unHighlightMarker(currentHighlightedStopId);
 				currentHighlightedStopId = null;
 			}
+			provider.resetStopEmphasis?.();
+			provider.setBasemapDimmed?.(false);
 			provider.cleanupInfoWindow();
 			// Don't wipe vehicle markers a route is drawing: when a route is selected
 			// from an open stop sheet, handleRouteSelected has already set
 			// currentModal = Modal.ROUTE and added the route's vehicles before this
 			// teardown flushes. A normal stop close leaves currentModal null.
-			if (currentModal !== Modal.ROUTE) provider.clearVehicleMarkers();
+			if (currentModal !== Modal.ROUTE) {
+				provider.clearVehicleMarkers();
+				// clearVehicleMarkers only detaches the markers from the map. The module
+				// -level vehicleMarkersMap still holds them, so the next selection would
+				// find stale entries via .has() and update detached markers that never
+				// render. RouteMap's onDestroy already pairs these two calls.
+				clearVehicleMarkersMap();
+			}
 			selectedTrip = null;
+			stopArrivals = null;
+			// closePane() short-circuits for the stop case (pushState + return), and the
+			// accordion never fires its collapse callback because StopPane is destroyed
+			// rather than collapsed. So if the rider had a row expanded, these three are
+			// still truthy — which pins mapMode at ROUTE forever and permanently stops
+			// markers from loading. Reset them here, where every close path converges.
+			showRouteMap = false;
+			isRouteSelected = false;
+			selectedRoute = null;
 		}
 
 		appliedStopId = id;

--- a/src/components/MapExperience.svelte
+++ b/src/components/MapExperience.svelte
@@ -181,8 +181,8 @@
 				provider.unHighlightMarker(currentHighlightedStopId);
 				currentHighlightedStopId = null;
 			}
-			provider.resetStopEmphasis?.(); // TODO: temporary ?. — provider doesn't implement this yet
-			provider.setBasemapDimmed?.(false); // TODO: temporary ?. — provider doesn't implement this yet
+			provider.resetStopEmphasis();
+			provider.setBasemapDimmed(false);
 			provider.cleanupInfoWindow();
 			// Don't wipe vehicle markers or the route-selection flags a route is drawing:
 			// when a route is selected from an open stop sheet, handleRouteSelected has

--- a/src/components/MapExperience.svelte
+++ b/src/components/MapExperience.svelte
@@ -181,13 +181,16 @@
 				provider.unHighlightMarker(currentHighlightedStopId);
 				currentHighlightedStopId = null;
 			}
-			provider.resetStopEmphasis?.();
-			provider.setBasemapDimmed?.(false);
+			provider.resetStopEmphasis?.(); // TODO: temporary ?. — provider doesn't implement this yet
+			provider.setBasemapDimmed?.(false); // TODO: temporary ?. — provider doesn't implement this yet
 			provider.cleanupInfoWindow();
-			// Don't wipe vehicle markers a route is drawing: when a route is selected
-			// from an open stop sheet, handleRouteSelected has already set
-			// currentModal = Modal.ROUTE and added the route's vehicles before this
-			// teardown flushes. A normal stop close leaves currentModal null.
+			// Don't wipe vehicle markers or the route-selection flags a route is drawing:
+			// when a route is selected from an open stop sheet, handleRouteSelected has
+			// already set currentModal = Modal.ROUTE, isRouteSelected = true, and
+			// selectedRoute before this teardown flushes (both run in the same effect
+			// flush). Resetting these unconditionally would stomp that selection back to
+			// null/false while currentModal stays ROUTE, leaving RouteModal rendering with
+			// a null route. A normal stop close leaves currentModal null.
 			if (currentModal !== Modal.ROUTE) {
 				provider.clearVehicleMarkers();
 				// clearVehicleMarkers only detaches the markers from the map. The module
@@ -195,17 +198,17 @@
 				// find stale entries via .has() and update detached markers that never
 				// render. RouteMap's onDestroy already pairs these two calls.
 				clearVehicleMarkersMap();
+				// closePane() short-circuits for the stop case (pushState + return), and the
+				// accordion never fires its collapse callback because StopPane is destroyed
+				// rather than collapsed. So if the rider had a row expanded, these three are
+				// still truthy — which pins mapMode at ROUTE forever and permanently stops
+				// markers from loading. Reset them here, where every close path converges.
+				showRouteMap = false;
+				isRouteSelected = false;
+				selectedRoute = null;
 			}
 			selectedTrip = null;
 			stopArrivals = null;
-			// closePane() short-circuits for the stop case (pushState + return), and the
-			// accordion never fires its collapse callback because StopPane is destroyed
-			// rather than collapsed. So if the rider had a row expanded, these three are
-			// still truthy — which pins mapMode at ROUTE forever and permanently stops
-			// markers from loading. Reset them here, where every close path converges.
-			showRouteMap = false;
-			isRouteSelected = false;
-			selectedRoute = null;
 		}
 
 		appliedStopId = id;

--- a/src/components/MapExperience.svelte
+++ b/src/components/MapExperience.svelte
@@ -101,7 +101,16 @@
 		stopArrivals?.data?.entry?.stopId != null && stopArrivals.data.entry.stopId === selectedStopId
 	);
 	let activeRoutes = $derived(arrivalsMatchSelection ? activeRoutesFromArrivals(stopArrivals) : []);
-	let routeColors = $derived(assignRouteColors(activeRoutes, { dark: isDarkMode }));
+	// Deliberately NOT gated on arrivalsMatchSelection (derived from stopArrivals
+	// directly, not from the gated activeRoutes above). StopPane's rendered rows are
+	// a one-time $state seed that doesn't react to stopArrivals going stale, so
+	// during the A -> B transition the sheet is still showing A's rows — A's colors
+	// are the correct colors for them. The map is separately held back from drawing
+	// anything stale by activeRoutes being empty until B's arrivals land. Two
+	// consumers of routeColors, two different staleness semantics, one source.
+	let routeColors = $derived(
+		assignRouteColors(activeRoutesFromArrivals(stopArrivals), { dark: isDarkMode })
+	);
 
 	// While a stop's bottom sheet is open, the search pane collapses to a single
 	// floating field below the md breakpoint; on wider viewports the pane stays
@@ -138,11 +147,6 @@
 		if (id) {
 			const data = selectedStopData;
 			if (!data) return; // wait for state/load data; re-runs when it arrives
-
-			// Stop A -> stop B keeps the sheet mounted, so without this the map would keep
-			// drawing A's routes, ring dots, and vehicles around B's marker until B's
-			// arrivals land ~300ms later.
-			stopArrivals = null;
 
 			// A stop supersedes any other selection. Tear down the map overlays a route
 			// or trip left behind only when one was active, but always clear currentModal

--- a/src/components/__tests__/ArrivalDeparture.test.js
+++ b/src/components/__tests__/ArrivalDeparture.test.js
@@ -125,4 +125,38 @@ describe('ArrivalDeparture', () => {
 		await rerender({ arrivalDeparture: baseArrival(), expanded: true });
 		expect(chevronOf(container).getAttribute('class')).toContain('rotate-180');
 	});
+
+	describe('route colors', () => {
+		const arrival = {
+			routeId: 'r_c',
+			routeShortName: 'C Line',
+			tripHeadsign: 'Downtown Seattle',
+			scheduledArrivalTime: Date.now() + 300000,
+			predictedArrivalTime: Date.now() + 300000,
+			predicted: true,
+			stopSequence: 1
+		};
+
+		test('uses the resolved route color for the badge when provided', () => {
+			render(ArrivalDeparture, {
+				props: {
+					arrivalDeparture: arrival,
+					route: { id: 'r_c', shortName: 'C Line', color: 'b02a37', textColor: 'ffffff' },
+					routeColors: { line: '#1565C0', badgeBg: '1565C0', badgeFg: 'ffffff' }
+				}
+			});
+			expect(screen.getByText('C Line')).toHaveStyle('background-color: #1565C0');
+			expect(screen.getByText('C Line')).toHaveStyle('color: #ffffff');
+		});
+
+		test('falls back to the GTFS color when no resolved color is given', () => {
+			render(ArrivalDeparture, {
+				props: {
+					arrivalDeparture: arrival,
+					route: { id: 'r_c', shortName: 'C Line', color: 'b02a37', textColor: 'ffffff' }
+				}
+			});
+			expect(screen.getByText('C Line')).toHaveStyle('background-color: #b02a37');
+		});
+	});
 });

--- a/src/components/__tests__/MapExperience.test.js
+++ b/src/components/__tests__/MapExperience.test.js
@@ -8,6 +8,22 @@ let capturedMapContainerProps = null;
 vi.mock('$components/MapContainer.svelte', () => ({
 	default: function MapContainer(anchor, props) {
 		capturedMapContainerProps = props;
+		// The real MapContainer initializes a map provider on mount and binds it back
+		// to the parent (bind:mapProvider). MapExperience's framing effect no-ops until
+		// mapProvider is set, so supply a default stub here — tests that care about a
+		// specific call can still override capturedMapContainerProps.mapProvider after
+		// render.
+		props.mapProvider = {
+			flyTo: vi.fn(),
+			highlightMarker: vi.fn(),
+			unHighlightMarker: vi.fn(),
+			resetStopEmphasis: vi.fn(),
+			setBasemapDimmed: vi.fn(),
+			cleanupInfoWindow: vi.fn(),
+			clearVehicleMarkers: vi.fn(),
+			clearAllPolylines: vi.fn(),
+			removeStopMarkers: vi.fn()
+		};
 		return {};
 	}
 }));
@@ -22,14 +38,18 @@ vi.mock('$components/surveys/SurveyLauncher.svelte', () => ({ default: () => ({}
 vi.mock('$components/navigation/AlertsModal.svelte', () => ({ default: () => ({}) }));
 
 // The one child whose presence we assert on.
+let capturedSheetProps = null;
 vi.mock('$components/stops/StopBottomSheet.svelte', () => ({
-	default: function StopBottomSheet(anchor) {
+	default: function StopBottomSheet(anchor, props) {
+		capturedSheetProps = props;
 		const el = document.createElement('div');
 		el.setAttribute('data-testid', 'stop-bottom-sheet');
 		anchor.before(el);
 		return {};
 	}
 }));
+
+vi.mock('$lib/vehicleUtils.js', () => ({ clearVehicleMarkersMap: vi.fn() }));
 
 vi.mock('$app/navigation', () => ({
 	pushState: vi.fn(),
@@ -73,21 +93,28 @@ vi.mock('$env/static/public', () => ({
 }));
 
 // Per-test controllable page store (overrides the global vitest-setup mock).
+// A real writable, not a one-shot subscribe, so a test can simulate navigating
+// away from a stop after render — which is how the teardown path is reached.
+import { writable } from 'svelte/store';
+
+// eslint-disable-next-line no-unused-vars -- write-only bookkeeping to mirror the brief's setPage() shape
 let pageValue;
+const pageStore = writable(undefined);
 vi.mock('$app/stores', () => ({
-	page: {
-		subscribe: (fn) => {
-			fn(pageValue);
-			return () => {};
-		}
-	}
+	page: { subscribe: (fn) => pageStore.subscribe(fn) }
 }));
+
+function setPage(next) {
+	pageValue = next;
+	pageStore.set(next);
+}
 
 global.fetch = vi.fn(async () => ({ ok: false, status: 204 })); // loadAlerts no-op
 
 import { pushState } from '$app/navigation';
 import MapExperience from '$components/MapExperience.svelte';
 import { createReactiveStop } from './support/reactiveStop.svelte.js';
+import { clearVehicleMarkersMap } from '$lib/vehicleUtils.js';
 
 const STOP = { id: '1_75403', lat: 47.6, lon: -122.3, name: 'Pine St & 3rd Ave' };
 
@@ -96,37 +123,37 @@ beforeEach(() => {
 });
 
 test('renders the stop sheet when the URL is a /map/stops path', () => {
-	pageValue = {
+	setPage({
 		url: new URL('https://example.com/map/stops/1_75403'),
 		params: {},
 		route: { id: '/(map)' },
 		state: { stopData: STOP },
 		data: {}
-	};
+	});
 	const { queryByTestId } = render(MapExperience);
 	expect(queryByTestId('stop-bottom-sheet')).not.toBeNull();
 });
 
 test('does not render the stop sheet on /', () => {
-	pageValue = {
+	setPage({
 		url: new URL('https://example.com/'),
 		params: {},
 		route: { id: '/(map)' },
 		state: {},
 		data: {}
-	};
+	});
 	const { queryByTestId } = render(MapExperience);
 	expect(queryByTestId('stop-bottom-sheet')).toBeNull();
 });
 
 test('handleStopMarkerSelect snapshots reactive stopData before pushState (DataCloneError regression)', () => {
-	pageValue = {
+	setPage({
 		url: new URL('https://example.com/'),
 		params: {},
 		route: { id: '/(map)' },
 		state: {},
 		data: {}
-	};
+	});
 	render(MapExperience);
 
 	// The marker hands handleStopMarkerSelect a $state reactive proxy, not a
@@ -142,4 +169,67 @@ test('handleStopMarkerSelect snapshots reactive stopData before pushState (DataC
 	// Snapshotted: same values, but not the same reactive proxy reference.
 	expect(state.stopData).toEqual(STOP);
 	expect(state.stopData).not.toBe(reactiveStop);
+});
+
+function pageWithStop() {
+	return {
+		url: new URL('https://example.com/map/stops/1_75403'),
+		params: {},
+		route: { id: '/(map)' },
+		state: { stopData: STOP },
+		data: {}
+	};
+}
+
+function pageWithoutStop() {
+	return {
+		url: new URL('https://example.com/'),
+		params: {},
+		route: { id: '/(map)' },
+		state: {},
+		data: {}
+	};
+}
+
+test('clearing the selection resets the route flags an expanded row left behind', async () => {
+	setPage(pageWithStop());
+	render(MapExperience);
+
+	// Expanding an arrival row: StopPane calls both of these.
+	capturedSheetProps.tripSelected({
+		detail: { tripId: 'trip_1', routeId: 'route_1', routeShortName: 'C' }
+	});
+	capturedSheetProps.handleUpdateRouteMap({ detail: { show: true } });
+	await vi.waitFor(() => expect(capturedMapContainerProps.showRouteMap).toBe(true));
+
+	// closePane pushes '/' — mocked, so drive the resulting page change ourselves.
+	capturedSheetProps.closePane();
+	setPage(pageWithoutStop());
+
+	await vi.waitFor(() => {
+		expect(capturedMapContainerProps.showRouteMap).toBe(false);
+		expect(capturedMapContainerProps.isRouteSelected).toBe(false);
+		expect(capturedMapContainerProps.selectedRoute).toBeNull();
+		expect(capturedMapContainerProps.selectedTrip).toBeNull();
+	});
+});
+
+test('clearing the selection empties the module-level vehicle marker map', async () => {
+	setPage(pageWithStop());
+	render(MapExperience);
+
+	// The framing effect needs a provider before it will run its teardown.
+	capturedMapContainerProps.mapProvider = {
+		flyTo: vi.fn(),
+		highlightMarker: vi.fn(),
+		unHighlightMarker: vi.fn(),
+		resetStopEmphasis: vi.fn(),
+		setBasemapDimmed: vi.fn(),
+		cleanupInfoWindow: vi.fn(),
+		clearVehicleMarkers: vi.fn()
+	};
+
+	setPage(pageWithoutStop());
+
+	await vi.waitFor(() => expect(clearVehicleMarkersMap).toHaveBeenCalled());
 });

--- a/src/components/__tests__/MapExperience.test.js
+++ b/src/components/__tests__/MapExperience.test.js
@@ -116,12 +116,45 @@ function setPage(next) {
 
 global.fetch = vi.fn(async () => ({ ok: false, status: 204 })); // loadAlerts no-op
 
+import { tick } from 'svelte';
 import { pushState } from '$app/navigation';
 import MapExperience from '$components/MapExperience.svelte';
 import { createReactiveStop } from './support/reactiveStop.svelte.js';
 import { clearVehicleMarkersMap } from '$lib/vehicleUtils.js';
 
 const STOP = { id: '1_75403', lat: 47.6, lon: -122.3, name: 'Pine St & 3rd Ave' };
+const STOP_B = { id: '1_99999', lat: 47.61, lon: -122.31, name: 'Other St & 4th Ave' };
+
+// Builds a realistic /arrivals-and-departures-for-stop response. `routes` is a list
+// of { id, shortName, etaMin } arrival entries (one per array element, so a route can
+// appear more than once to exercise soonest-wins dedup).
+function arrivalsPayload(stopId, routes) {
+	const now = Date.now();
+	return {
+		data: {
+			entry: {
+				stopId,
+				arrivalsAndDepartures: routes.map((r) => ({
+					routeId: r.id,
+					routeShortName: r.shortName,
+					tripId: `trip_${r.id}_${r.etaMin}`,
+					predicted: true,
+					predictedArrivalTime: now + r.etaMin * 60000,
+					scheduledArrivalTime: now + r.etaMin * 60000
+				}))
+			},
+			references: {
+				routes: [...new Map(routes.map((r) => [r.id, r])).values()].map((r) => ({
+					id: r.id,
+					shortName: r.shortName,
+					type: 3,
+					color: r.color ?? null
+				})),
+				situations: []
+			}
+		}
+	};
+}
 
 beforeEach(() => {
 	vi.clearAllMocks();
@@ -271,4 +304,86 @@ test('clearing the selection empties the module-level vehicle marker map', async
 	setPage(pageWithoutStop());
 
 	await vi.waitFor(() => expect(clearVehicleMarkersMap).toHaveBeenCalled());
+});
+
+// Finding 2: the whole point of lifting stopArrivals is to feed activeRoutes and
+// routeColors to MapContainer -- prove they actually arrive there, with the right
+// shape, and that the arrivalsMatchSelection gate actually withholds them for a
+// mismatched stop.
+test('activeRoutes and routeColors reach MapContainer once a matching arrivals response lands', async () => {
+	setPage(pageWithStop());
+	render(MapExperience);
+
+	// Deliberately unsorted, with a duplicate for route_a (later arrival) to prove
+	// dedup keeps only the soonest.
+	const payload = arrivalsPayload(STOP.id, [
+		{ id: 'route_c', shortName: 'C Line', etaMin: 20 },
+		{ id: 'route_a', shortName: '10', etaMin: 30 },
+		{ id: 'route_a', shortName: '10', etaMin: 5 },
+		{ id: 'route_b', shortName: '8', etaMin: 10 }
+	]);
+	capturedSheetProps.arrivalsAndDeparturesResponse = payload;
+
+	await vi.waitFor(() => expect(capturedMapContainerProps.activeRoutes.length).toBe(3));
+
+	// One entry per distinct route, soonest arrival first.
+	expect(capturedMapContainerProps.activeRoutes.map((r) => r.id)).toEqual([
+		'route_a',
+		'route_b',
+		'route_c'
+	]);
+
+	const colors = capturedMapContainerProps.routeColors;
+	expect(colors.size).toBe(3);
+	for (const route of capturedMapContainerProps.activeRoutes) {
+		const routeColor = colors.get(route.id);
+		expect(routeColor.line).toMatch(/^#/);
+		expect(routeColor.badgeBg).toBe(routeColor.line.slice(1));
+	}
+});
+
+test('activeRoutes stays empty when the arrivals payload belongs to a different stop', async () => {
+	setPage(pageWithStop());
+	render(MapExperience);
+
+	// stopId doesn't match the selected stop -- arrivalsMatchSelection must withhold it.
+	const payload = arrivalsPayload(STOP_B.id, [{ id: 'route_a', shortName: '10', etaMin: 5 }]);
+	capturedSheetProps.arrivalsAndDeparturesResponse = payload;
+
+	await tick();
+
+	expect(capturedMapContainerProps.activeRoutes).toEqual([]);
+});
+
+// Finding 1: switching stop A -> stop B used to null stopArrivals immediately, which
+// emptied StopPane's routeById derived (fed from arrivalsAndDeparturesResponse) while
+// its rendered rows -- a one-time $state seed -- stayed put showing A's rows. Result:
+// A's badges flashed to RouteBadge's hardcoded gray for the ~300ms until B's arrivals
+// landed. routeColors (what actually reaches the badges) must hold steady across that
+// gap even though the map's activeRoutes is correctly withheld in the meantime.
+test('routeColors does not go blank when the stop changes before the new arrivals land', async () => {
+	setPage(pageWithStop());
+	render(MapExperience);
+
+	const payload = arrivalsPayload(STOP.id, [{ id: 'route_a', shortName: '10', etaMin: 5 }]);
+	capturedSheetProps.arrivalsAndDeparturesResponse = payload;
+
+	await vi.waitFor(() => expect(capturedMapContainerProps.routeColors.get('route_a')).toBeTruthy());
+	const colorBefore = capturedMapContainerProps.routeColors.get('route_a');
+
+	// Tap stop B. Its arrivals haven't fetched yet, so stopArrivals still holds A's
+	// response -- which no longer matches the (now B) selection.
+	setPage({
+		url: new URL('https://example.com/map/stops/1_99999'),
+		params: {},
+		route: { id: '/(map)' },
+		state: { stopData: STOP_B },
+		data: {}
+	});
+	await tick();
+
+	// The map is correctly withheld from drawing A's route around B's marker...
+	expect(capturedMapContainerProps.activeRoutes).toEqual([]);
+	// ...but the sheet is still showing A's rows, so A's badge color must not vanish.
+	expect(capturedMapContainerProps.routeColors.get('route_a')).toEqual(colorBefore);
 });

--- a/src/components/__tests__/MapExperience.test.js
+++ b/src/components/__tests__/MapExperience.test.js
@@ -27,7 +27,15 @@ vi.mock('$components/MapContainer.svelte', () => ({
 		return {};
 	}
 }));
-vi.mock('$components/search/SearchPane.svelte', () => ({ default: () => ({}) }));
+// Captures the props MapExperience passes down (incl. handleRouteSelected) so the
+// route-flag-reset regression test below can invoke it the way the app does.
+let capturedSearchPaneProps = null;
+vi.mock('$components/search/SearchPane.svelte', () => ({
+	default: function SearchPane(anchor, props) {
+		capturedSearchPaneProps = props;
+		return {};
+	}
+}));
 vi.mock('$components/search/CollapsedSearchField.svelte', () => ({ default: () => ({}) }));
 vi.mock('$components/routes/RouteModal.svelte', () => ({ default: () => ({}) }));
 vi.mock('$components/routes/ViewAllRoutesModal.svelte', () => ({ default: () => ({}) }));
@@ -97,15 +105,12 @@ vi.mock('$env/static/public', () => ({
 // away from a stop after render — which is how the teardown path is reached.
 import { writable } from 'svelte/store';
 
-// eslint-disable-next-line no-unused-vars -- write-only bookkeeping to mirror the brief's setPage() shape
-let pageValue;
 const pageStore = writable(undefined);
 vi.mock('$app/stores', () => ({
 	page: { subscribe: (fn) => pageStore.subscribe(fn) }
 }));
 
 function setPage(next) {
-	pageValue = next;
 	pageStore.set(next);
 }
 
@@ -212,6 +217,40 @@ test('clearing the selection resets the route flags an expanded row left behind'
 		expect(capturedMapContainerProps.selectedRoute).toBeNull();
 		expect(capturedMapContainerProps.selectedTrip).toBeNull();
 	});
+});
+
+test('selecting a route from an open stop sheet survives the resulting stop-close teardown', async () => {
+	setPage(pageWithStop());
+	render(MapExperience);
+
+	// Mirrors handleRouteSelected: stopSheetOpen is true, so it calls pushState('/', {})
+	// (mocked — doesn't itself change the page store) and then synchronously sets
+	// selectedRoute / currentModal / isRouteSelected. Svelte coalesces these into one
+	// effect flush together with the page-store change we drive next, which is what
+	// makes the framing effect's stop-close branch run with currentModal already
+	// ROUTE — the exact scenario the guard exists for.
+	const route = { id: 'route_1', shortName: 'C' };
+	capturedSearchPaneProps.handleRouteSelected({
+		route,
+		polylines: [],
+		stops: [],
+		currentIntervalId: null
+	});
+
+	// Simulate the navigation handleRouteSelected's pushState('/', {}) triggers: the
+	// stop id goes null, which is what runs the framing effect's else branch.
+	setPage(pageWithoutStop());
+
+	// The else branch is synchronous and unconditionally calls cleanupInfoWindow near
+	// its top, before the route-flag lines run — waiting for that call is proof the
+	// whole branch (including the flag resets under test) has finished executing, so
+	// the assertions below can't pass on a stale, pre-effect snapshot of the state.
+	await vi.waitFor(() => {
+		expect(capturedMapContainerProps.mapProvider.cleanupInfoWindow).toHaveBeenCalled();
+	});
+
+	expect(capturedMapContainerProps.isRouteSelected).toBe(true);
+	expect(capturedMapContainerProps.selectedRoute).toEqual(route);
 });
 
 test('clearing the selection empties the module-level vehicle marker map', async () => {

--- a/src/components/__tests__/MapView.test.js
+++ b/src/components/__tests__/MapView.test.js
@@ -7,14 +7,28 @@ vi.mock('$components/map/RouteMap.svelte', () => ({ default: () => null }));
 vi.mock('$lib/LocationButton/LocationButton.svelte', () => ({ default: () => null }));
 
 // StopRoutesLayer and RouteLegend are unit-tested on their own (their tests
-// cover shape-fetch races, redraw signatures, vehicle polling, i18n). Mocking
-// them here keeps MapView's tests scoped to the wiring it owns: computing the
-// tier map and calling setStopEmphasis/setBasemapDimmed. Rendering the real
-// StopRoutesLayer would also need every method it calls on mapProvider
-// (createPolyline, clearAllPolylines, revealPolylines, ...) added to the stub
-// just to avoid an unhandled rejection unrelated to what these tests assert.
-vi.mock('$components/map/StopRoutesLayer.svelte', () => ({ default: () => null }));
-vi.mock('$components/map/RouteLegend.svelte', () => ({ default: () => null }));
+// cover shape-fetch races, redraw signatures, vehicle polling, i18n). But
+// MapView's own job is the wiring between them — which props reach them, and
+// whether the routeStopIds/liveCounts bindings it exposes are actually live —
+// so unlike a bare stub, these mocks capture the props each child receives
+// (mirroring the MapContainer/SearchPane pattern in MapExperience.test.js).
+// Assigning onto the captured props object exercises the same setter a real
+// bind: would, letting a test drive the bindable props back into MapView.
+let capturedStopRoutesLayerProps = null;
+vi.mock('$components/map/StopRoutesLayer.svelte', () => ({
+	default: function StopRoutesLayer(anchor, props) {
+		capturedStopRoutesLayerProps = props;
+		return {};
+	}
+}));
+
+let capturedRouteLegendProps = null;
+vi.mock('$components/map/RouteLegend.svelte', () => ({
+	default: function RouteLegend(anchor, props) {
+		capturedRouteLegendProps = props;
+		return {};
+	}
+}));
 
 // The global vitest-setup mock omits the region-center coords MapView reads at
 // module init (see MapExperience.test.js for the same override).
@@ -42,8 +56,20 @@ function makeProvider() {
 	};
 }
 
+// Flushes the requestAnimationFrame callback batchAddMarkers defers marker
+// creation into. A bare timer (setTimeout/vi.advanceTimersByTime) would be
+// flushing the wrong queue — jsdom's rAF is real, not timer-backed here.
+function flushRaf() {
+	return new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+const ROUTE_C = { id: 'r_c', shortName: 'C Line', type: 3, tripId: 't_c', gtfsColor: 'b02a37' };
+const ROUTE_COLORS = new Map([['r_c', { line: '#b02a37', badgeBg: 'b02a37', badgeFg: 'ffffff' }]]);
+
 describe('MapView map mode', () => {
 	beforeEach(() => {
+		capturedStopRoutesLayerProps = null;
+		capturedRouteLegendProps = null;
 		global.fetch = vi.fn().mockResolvedValue({
 			ok: true,
 			json: async () => ({ data: { list: [], references: { routes: [] } } })
@@ -85,6 +111,15 @@ describe('MapView map mode', () => {
 });
 
 describe('stop selection layer', () => {
+	beforeEach(() => {
+		capturedStopRoutesLayerProps = null;
+		capturedRouteLegendProps = null;
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ data: { list: [], references: { routes: [] } } })
+		});
+	});
+
 	test('tiers markers when routes are drawn: route stops ring, everything else muted', async () => {
 		const mapProvider = makeProvider();
 		render(MapView, {
@@ -92,10 +127,8 @@ describe('stop selection layer', () => {
 				handleStopMarkerSelect: vi.fn(),
 				mapProvider,
 				stop: { id: 'stop_sel', lat: 47.6, lon: -122.3 },
-				activeRoutes: [
-					{ id: 'r_c', shortName: 'C Line', type: 3, tripId: 't_c', gtfsColor: 'b02a37' }
-				],
-				routeColors: new Map([['r_c', { line: '#b02a37', badgeBg: 'b02a37', badgeFg: 'ffffff' }]])
+				activeRoutes: [ROUTE_C],
+				routeColors: ROUTE_COLORS
 			}
 		});
 
@@ -120,5 +153,184 @@ describe('stop selection layer', () => {
 		await vi.waitFor(() => expect(mapProvider.initMap).toHaveBeenCalled());
 		expect(mapProvider.setStopEmphasis).not.toHaveBeenCalled();
 		expect(mapProvider.setBasemapDimmed).not.toHaveBeenCalledWith(true);
+	});
+
+	// Finding 3: the else branch of the lifecycle effect (resetStopEmphasis +
+	// setBasemapDimmed(false)) previously had nothing asserting it fires at all —
+	// only tests proving it wasn't called on the *other* branch. Drive the actual
+	// transition (routes drawn -> selection cleared) and assert the reset happens.
+	test('resets emphasis and undims the basemap once the selection goes away', async () => {
+		const mapProvider = makeProvider();
+		const { rerender } = render(MapView, {
+			props: {
+				handleStopMarkerSelect: vi.fn(),
+				mapProvider,
+				stop: { id: 'stop_sel', lat: 47.6, lon: -122.3 },
+				activeRoutes: [ROUTE_C],
+				routeColors: ROUTE_COLORS
+			}
+		});
+
+		await vi.waitFor(() => expect(mapProvider.setBasemapDimmed).toHaveBeenCalledWith(true));
+		expect(mapProvider.resetStopEmphasis).not.toHaveBeenCalled();
+
+		await rerender({
+			handleStopMarkerSelect: vi.fn(),
+			mapProvider,
+			stop: null,
+			activeRoutes: [],
+			routeColors: new Map()
+		});
+
+		await vi.waitFor(() => expect(mapProvider.resetStopEmphasis).toHaveBeenCalled());
+		expect(mapProvider.setBasemapDimmed).toHaveBeenCalledWith(false);
+	});
+});
+
+// Finding 1: MapView is the integration point between the stop-selection layer
+// and its two children. These tests exist to catch a broken bind: or a
+// mis-wired prop, which a bare `() => null` stub can never surface.
+describe('StopRoutesLayer / RouteLegend integration', () => {
+	beforeEach(() => {
+		capturedStopRoutesLayerProps = null;
+		capturedRouteLegendProps = null;
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ data: { list: [], references: { routes: [] } } })
+		});
+	});
+
+	test('StopRoutesLayer and RouteLegend receive the live map instance, activeRoutes, and routeColors', async () => {
+		const mapProvider = makeProvider();
+		render(MapView, {
+			props: {
+				handleStopMarkerSelect: vi.fn(),
+				mapProvider,
+				stop: { id: 'stop_sel', lat: 47.6, lon: -122.3 },
+				activeRoutes: [ROUTE_C],
+				routeColors: ROUTE_COLORS
+			}
+		});
+
+		await vi.waitFor(() => expect(capturedStopRoutesLayerProps).not.toBeNull());
+
+		// MapView wraps the mapProvider prop in $state (mapInstance = mapProvider),
+		// so the object StopRoutesLayer receives is Svelte's reactive proxy around
+		// it, not the exact same object reference the test holds — toBe on the
+		// container fails even though it's the live instance. Compare a method
+		// reference instead: Svelte's state proxy forwards function properties
+		// untouched, so this is only true if it's the same underlying instance.
+		expect(capturedStopRoutesLayerProps.mapProvider.setStopEmphasis).toBe(
+			mapProvider.setStopEmphasis
+		);
+		expect(capturedStopRoutesLayerProps.activeRoutes).toEqual([ROUTE_C]);
+		expect(capturedStopRoutesLayerProps.routeColors).toBe(ROUTE_COLORS);
+
+		expect(capturedRouteLegendProps).not.toBeNull();
+		expect(capturedRouteLegendProps.routes).toEqual([ROUTE_C]);
+		expect(capturedRouteLegendProps.routeColors).toBe(ROUTE_COLORS);
+	});
+
+	// The bindable that drives the whole ring-dot tier: routeStopIds flows out of
+	// StopRoutesLayer, into emphasisByStopId, and back down through
+	// setStopEmphasis. Assert the wire is live end to end, not merely present.
+	test('the routeStopIds binding is live: setting it drives setStopEmphasis with the routeDot tier', async () => {
+		const mapProvider = makeProvider();
+		render(MapView, {
+			props: {
+				handleStopMarkerSelect: vi.fn(),
+				mapProvider,
+				stop: { id: 'stop_sel', lat: 47.6, lon: -122.3 },
+				activeRoutes: [ROUTE_C],
+				routeColors: ROUTE_COLORS
+			}
+		});
+
+		await vi.waitFor(() => expect(capturedStopRoutesLayerProps).not.toBeNull());
+
+		capturedStopRoutesLayerProps.routeStopIds = new Map([['stop_a', '#b02a37']]);
+
+		await vi.waitFor(() => {
+			const lastCall = mapProvider.setStopEmphasis.mock.calls.at(-1);
+			expect(lastCall).toBeDefined();
+			expect(lastCall[0].get('stop_a')).toEqual({ emphasis: 'routeDot', dotColor: '#b02a37' });
+		});
+	});
+});
+
+// Finding 2: every other test's fetch mock returns an empty stop list, so
+// allStops never populates and addMarker's emphasis-seeding logic never runs.
+// Feed it a real stop list and assert the seeded emphasis/dotColor for all
+// three tiers addMarker can produce.
+describe('addMarker emphasis seeding', () => {
+	beforeEach(() => {
+		capturedStopRoutesLayerProps = null;
+		capturedRouteLegendProps = null;
+	});
+
+	test('seeds routeDot, muted, and full emphasis onto newly created markers', async () => {
+		const mapProvider = makeProvider();
+		let resolveFetch;
+		global.fetch = vi.fn(
+			() =>
+				new Promise((resolve) => {
+					resolveFetch = resolve;
+				})
+		);
+
+		render(MapView, {
+			props: {
+				handleStopMarkerSelect: vi.fn(),
+				mapProvider,
+				stop: { id: 'stop_sel', lat: 47.6, lon: -122.3 },
+				activeRoutes: [ROUTE_C],
+				routeColors: ROUTE_COLORS
+			}
+		});
+
+		// Wire the ring-dot map before the stop list lands, so batchAddMarkers'
+		// rAF-deferred addMarker calls see it — exactly the ordering addMarker's
+		// own comment (about seeding at creation time, not patching after) exists
+		// to protect against.
+		await vi.waitFor(() => expect(capturedStopRoutesLayerProps).not.toBeNull());
+		capturedStopRoutesLayerProps.routeStopIds = new Map([['stop_ring', '#b02a37']]);
+		await tick();
+
+		resolveFetch({
+			ok: true,
+			json: async () => ({
+				data: {
+					list: [
+						{ id: 'stop_ring', lat: 47.601, lon: -122.301, routeIds: [] },
+						{ id: 'stop_other', lat: 47.602, lon: -122.302, routeIds: [] },
+						{ id: 'stop_sel', lat: 47.6, lon: -122.3, routeIds: [] }
+					],
+					references: { routes: [] }
+				}
+			})
+		});
+
+		await tick();
+		await flushRaf();
+		await tick();
+
+		await vi.waitFor(() =>
+			expect(mapProvider.addMarker.mock.calls.length).toBeGreaterThanOrEqual(3)
+		);
+
+		const calls = mapProvider.addMarker.mock.calls.map(([arg]) => arg);
+		const ring = calls.find((c) => c.stop.id === 'stop_ring');
+		const other = calls.find((c) => c.stop.id === 'stop_other');
+		const selected = calls.find((c) => c.stop.id === 'stop_sel');
+
+		expect(ring.emphasis).toBe('routeDot');
+		expect(ring.dotColor).toBe('#b02a37');
+
+		expect(other.emphasis).toBe('muted');
+		expect(other.dotColor).toBeNull();
+
+		expect(selected.emphasis).toBe('full');
+		expect(selected.isHighlighted).toBe(true);
+		expect(selected.dotColor).toBeNull();
 	});
 });

--- a/src/components/__tests__/MapView.test.js
+++ b/src/components/__tests__/MapView.test.js
@@ -1,5 +1,6 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import MapView from '$components/map/MapView.svelte';
 
 // StopRoutesLayer.svelte and RouteLegend.svelte don't exist yet (later tasks);
@@ -54,11 +55,9 @@ describe('MapView map mode', () => {
 			}
 		});
 		await vi.waitFor(() => expect(mapProvider.initMap).toHaveBeenCalled());
-		// Let the mapInstance assignment (which happens right after initMap
-		// resolves) flush through the $effects before asserting the negative —
-		// otherwise this assertion can pass merely because the effect chain
-		// hasn't run yet, not because markers were preserved.
-		await new Promise((resolve) => setTimeout(resolve, 0));
+		// Use tick() to deterministically flush pending reactive updates and effects,
+		// ensuring the effect chain completes before the negative assertion.
+		await tick();
 		expect(mapProvider.clearAllStopMarkers).not.toHaveBeenCalled();
 	});
 

--- a/src/components/__tests__/MapView.test.js
+++ b/src/components/__tests__/MapView.test.js
@@ -1,0 +1,78 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/svelte';
+import MapView from '$components/map/MapView.svelte';
+
+// StopRoutesLayer.svelte and RouteLegend.svelte don't exist yet (later tasks);
+// MapView doesn't import them, so mocking those paths would fail resolution.
+vi.mock('$components/map/RouteMap.svelte', () => ({ default: () => null }));
+vi.mock('$lib/LocationButton/LocationButton.svelte', () => ({ default: () => null }));
+
+// The global vitest-setup mock omits the region-center coords MapView reads at
+// module init (see MapExperience.test.js for the same override).
+vi.mock('$env/static/public', () => ({
+	PUBLIC_OBA_REGION_NAME: 'Test Region',
+	PUBLIC_OBA_REGION_CENTER_LAT: '47.6',
+	PUBLIC_OBA_REGION_CENTER_LNG: '-122.3'
+}));
+
+function makeProvider() {
+	return {
+		initMap: vi.fn().mockResolvedValue(undefined),
+		eventListeners: vi.fn(),
+		enableContextMenu: vi.fn(),
+		getBoundingBox: vi.fn(() => ({ north: 1, south: 0, east: 1, west: 0 })),
+		getCenter: vi.fn(() => ({ lat: 0, lng: 0 })),
+		map: { getZoom: () => 15 },
+		hasMarker: vi.fn(() => false),
+		addMarker: vi.fn(),
+		clearAllStopMarkers: vi.fn(),
+		setStopEmphasis: vi.fn(),
+		resetStopEmphasis: vi.fn(),
+		setBasemapDimmed: vi.fn(),
+		setTheme: vi.fn()
+	};
+}
+
+describe('MapView map mode', () => {
+	beforeEach(() => {
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ data: { list: [], references: { routes: [] } } })
+		});
+	});
+
+	test('does not clear stop markers when a trip is expanded inside a stop selection', async () => {
+		const mapProvider = makeProvider();
+		render(MapView, {
+			props: {
+				handleStopMarkerSelect: vi.fn(),
+				mapProvider,
+				stop: { id: 'stop_1', lat: 47.6, lon: -122.3 },
+				selectedTrip: { tripId: 'trip_1' },
+				isRouteSelected: true,
+				showRouteMap: true
+			}
+		});
+		await vi.waitFor(() => expect(mapProvider.initMap).toHaveBeenCalled());
+		// Let the mapInstance assignment (which happens right after initMap
+		// resolves) flush through the $effects before asserting the negative —
+		// otherwise this assertion can pass merely because the effect chain
+		// hasn't run yet, not because markers were preserved.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(mapProvider.clearAllStopMarkers).not.toHaveBeenCalled();
+	});
+
+	test('still clears stop markers for a route selection with no stop', async () => {
+		const mapProvider = makeProvider();
+		render(MapView, {
+			props: {
+				handleStopMarkerSelect: vi.fn(),
+				mapProvider,
+				stop: null,
+				selectedRoute: { id: 'route_1' },
+				isRouteSelected: true
+			}
+		});
+		await vi.waitFor(() => expect(mapProvider.clearAllStopMarkers).toHaveBeenCalled());
+	});
+});

--- a/src/components/__tests__/MapView.test.js
+++ b/src/components/__tests__/MapView.test.js
@@ -3,10 +3,18 @@ import { render } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import MapView from '$components/map/MapView.svelte';
 
-// StopRoutesLayer.svelte and RouteLegend.svelte don't exist yet (later tasks);
-// MapView doesn't import them, so mocking those paths would fail resolution.
 vi.mock('$components/map/RouteMap.svelte', () => ({ default: () => null }));
 vi.mock('$lib/LocationButton/LocationButton.svelte', () => ({ default: () => null }));
+
+// StopRoutesLayer and RouteLegend are unit-tested on their own (their tests
+// cover shape-fetch races, redraw signatures, vehicle polling, i18n). Mocking
+// them here keeps MapView's tests scoped to the wiring it owns: computing the
+// tier map and calling setStopEmphasis/setBasemapDimmed. Rendering the real
+// StopRoutesLayer would also need every method it calls on mapProvider
+// (createPolyline, clearAllPolylines, revealPolylines, ...) added to the stub
+// just to avoid an unhandled rejection unrelated to what these tests assert.
+vi.mock('$components/map/StopRoutesLayer.svelte', () => ({ default: () => null }));
+vi.mock('$components/map/RouteLegend.svelte', () => ({ default: () => null }));
 
 // The global vitest-setup mock omits the region-center coords MapView reads at
 // module init (see MapExperience.test.js for the same override).
@@ -73,5 +81,44 @@ describe('MapView map mode', () => {
 			}
 		});
 		await vi.waitFor(() => expect(mapProvider.clearAllStopMarkers).toHaveBeenCalled());
+	});
+});
+
+describe('stop selection layer', () => {
+	test('tiers markers when routes are drawn: route stops ring, everything else muted', async () => {
+		const mapProvider = makeProvider();
+		render(MapView, {
+			props: {
+				handleStopMarkerSelect: vi.fn(),
+				mapProvider,
+				stop: { id: 'stop_sel', lat: 47.6, lon: -122.3 },
+				activeRoutes: [
+					{ id: 'r_c', shortName: 'C Line', type: 3, tripId: 't_c', gtfsColor: 'b02a37' }
+				],
+				routeColors: new Map([['r_c', { line: '#b02a37', badgeBg: 'b02a37', badgeFg: 'ffffff' }]])
+			}
+		});
+
+		await vi.waitFor(() => expect(mapProvider.setStopEmphasis).toHaveBeenCalled());
+		const [, defaultEmphasis, selectedStopId] = mapProvider.setStopEmphasis.mock.calls.at(-1);
+		expect(defaultEmphasis).toBe('muted');
+		expect(selectedStopId).toBe('stop_sel');
+	});
+
+	test('does not tier or dim when there are no active routes', async () => {
+		const mapProvider = makeProvider();
+		render(MapView, {
+			props: {
+				handleStopMarkerSelect: vi.fn(),
+				mapProvider,
+				stop: { id: 'stop_sel', lat: 47.6, lon: -122.3 },
+				activeRoutes: [],
+				routeColors: new Map()
+			}
+		});
+
+		await vi.waitFor(() => expect(mapProvider.initMap).toHaveBeenCalled());
+		expect(mapProvider.setStopEmphasis).not.toHaveBeenCalled();
+		expect(mapProvider.setBasemapDimmed).not.toHaveBeenCalledWith(true);
 	});
 });

--- a/src/components/containers/SingleSelectAccordion.svelte
+++ b/src/components/containers/SingleSelectAccordion.svelte
@@ -38,8 +38,11 @@
 	});
 </script>
 
+<!-- border-b only (not border-y): the first item sits directly under a header
+     that already draws its own bottom rule, and a top border here would double
+     it up. Combined with divide-y, every item ends with exactly one rule. -->
 <div
-	class="divide-y divide-gray-200 border-y border-gray-200 dark:divide-gray-700 dark:border-gray-700"
+	class="divide-y divide-gray-200 border-b border-gray-200 dark:divide-gray-700 dark:border-gray-700"
 >
 	{@render children?.()}
 </div>

--- a/src/components/map/MapView.svelte
+++ b/src/components/map/MapView.svelte
@@ -146,13 +146,10 @@
 
 			mapInstance = mapProvider;
 
-			// If we have initial coordinates from URL, update the user location store
-			// and add a user location marker
-			if (initialCoords) {
-				const coords = { lat: mapCenterLat, lng: mapCenterLng };
-				userLocation.set(coords);
-				mapInstance.addUserLocationMarker(coords);
-			}
+			// `initialCoords` only says where to center the map — it's a deep-linked
+			// stop or ?lat/?lng, never a geolocation fix. Don't drop a "you are here"
+			// dot on it or seed the userLocation store (which feeds the analytics
+			// distance-to-stop bucket) with coordinates that aren't the user's.
 
 			await loadStopsAndAddMarkers(mapCenterLat, mapCenterLng, true);
 

--- a/src/components/map/MapView.svelte
+++ b/src/components/map/MapView.svelte
@@ -281,7 +281,10 @@
 			stop: s,
 			isHighlighted: shouldHighlight,
 			emphasis: shouldHighlight ? 'full' : (tier?.emphasis ?? 'full'),
-			dotColor: tier?.dotColor ?? null,
+			// Gated the same way as emphasis: a selected stop always renders as a full
+			// pin, so a leftover ring color here would be dead data — but leaving it
+			// non-null was an easy trap for a future reader to assume it's live.
+			dotColor: shouldHighlight ? null : (tier?.dotColor ?? null),
 			onClick: () => {
 				handleStopMarkerSelect(s);
 			}
@@ -367,6 +370,9 @@
 		<RouteMap mapProvider={mapInstance} tripId={selectedTrip.tripId} currentSelectedStop={stop} />
 	{/if}
 
+	<!-- The `stop ? … : []` ternary is defensive, not load-bearing: upstream,
+	     MapExperience already gates activeRoutes on arrivalsMatchSelection, so
+	     activeRoutes is guaranteed empty whenever stop is null. -->
 	<RouteLegend routes={stop ? activeRoutes : []} {routeColors} {liveCounts} />
 </div>
 

--- a/src/components/map/MapView.svelte
+++ b/src/components/map/MapView.svelte
@@ -10,6 +10,8 @@
 	import { debounce } from '$lib/utils';
 	import LocationButton from '$lib/LocationButton/LocationButton.svelte';
 	import RouteMap from './RouteMap.svelte';
+	import StopRoutesLayer from './StopRoutesLayer.svelte';
+	import RouteLegend from './RouteLegend.svelte';
 
 	import { isMapLoaded } from '$src/stores/mapStore';
 	import { userLocation } from '$src/stores/userLocationStore';
@@ -33,8 +35,42 @@
 		showRouteMap = false,
 		mapProvider = null,
 		stop = null,
-		initialCoords = null
+		initialCoords = null,
+		activeRoutes = [],
+		routeColors = new Map()
 	} = $props();
+
+	let routeStopIds = $state(new Map());
+	let liveCounts = $state(new Map());
+
+	// The layer only draws once the arrivals belong to this stop, so gate everything
+	// on there actually being routes. A stop with no arrivals in-window keeps
+	// today's map exactly — there's no catchable bus to point at, so dots on a
+	// washed-out basemap would be noise.
+	let routeLayerActive = $derived(!!stop && activeRoutes.length > 0);
+
+	// Ring-dot tier for every stop the drawn routes serve.
+	let emphasisByStopId = $derived(
+		new Map(
+			[...routeStopIds].map(([stopId, color]) => [
+				stopId,
+				{ emphasis: 'routeDot', dotColor: color }
+			])
+		)
+	);
+
+	$effect(() => {
+		if (!mapInstance) return;
+		if (routeLayerActive) {
+			// Non-selected stops collapse to quiet dots so the selected stop and the
+			// drawn routes are the only loud things on the map.
+			mapInstance.setStopEmphasis(emphasisByStopId, 'muted', stop.id);
+			mapInstance.setBasemapDimmed(true);
+		} else {
+			mapInstance.resetStopEmphasis();
+			mapInstance.setBasemapDimmed(false);
+		}
+	});
 
 	let isTripPlanModeActive = $state(false);
 	let mapInstance = $state(null);
@@ -233,10 +269,19 @@
 		// Check if this marker should be highlighted (if it's the currently selected stop)
 		const shouldHighlight = stop && s.id === stop.id;
 
+		// Seeded here rather than patched after batchAddMarkers, which defers creation
+		// into a rAF — a later setStopEmphasis() would iterate a markersMap that doesn't
+		// hold these markers yet, and stops panned in mid-selection would stay full pins.
+		const tier = routeLayerActive
+			? (emphasisByStopId.get(s.id) ?? { emphasis: 'muted', dotColor: null })
+			: null;
+
 		const markerObj = mapInstance.addMarker({
 			position: { lat: s.lat, lng: s.lon },
 			stop: s,
 			isHighlighted: shouldHighlight,
+			emphasis: shouldHighlight ? 'full' : (tier?.emphasis ?? 'full'),
+			dotColor: tier?.dotColor ?? null,
 			onClick: () => {
 				handleStopMarkerSelect(s);
 			}
@@ -303,9 +348,26 @@
 <div class="map-container">
 	<div id="map" bind:this={mapElement}></div>
 
-	{#if selectedTrip && showRouteMap}
+	{#if mapInstance && stop && activeRoutes.length > 0}
+		<StopRoutesLayer
+			mapProvider={mapInstance}
+			{activeRoutes}
+			{routeColors}
+			promotedRouteId={selectedRoute?.id ?? null}
+			highlightedTripId={selectedTrip?.tripId ?? null}
+			bind:routeStopIds
+			bind:liveCounts
+		/>
+	{/if}
+
+	<!-- RouteMap opens with clearAllPolylines() + removeStopMarkers(), which would
+	     wipe the stop-selection layer. While a stop is selected, StopRoutesLayer
+	     owns the map instead and expansion just promotes a route. -->
+	{#if selectedTrip && showRouteMap && !stop}
 		<RouteMap mapProvider={mapInstance} tripId={selectedTrip.tripId} currentSelectedStop={stop} />
 	{/if}
+
+	<RouteLegend routes={stop ? activeRoutes : []} {routeColors} {liveCounts} />
 </div>
 
 <div class="controls">

--- a/src/components/map/MapView.svelte
+++ b/src/components/map/MapView.svelte
@@ -367,7 +367,7 @@
 	     wipe the stop-selection layer. While a stop is selected, StopRoutesLayer
 	     owns the map instead and expansion just promotes a route. -->
 	{#if selectedTrip && showRouteMap && !stop}
-		<RouteMap mapProvider={mapInstance} tripId={selectedTrip.tripId} currentSelectedStop={stop} />
+		<RouteMap mapProvider={mapInstance} tripId={selectedTrip?.tripId} currentSelectedStop={stop} />
 	{/if}
 
 	<!-- The `stop ? … : []` ternary is defensive, not load-bearing: upstream,

--- a/src/components/map/MapView.svelte
+++ b/src/components/map/MapView.svelte
@@ -57,7 +57,11 @@
 		let newMode;
 		if (isTripPlanModeActive) {
 			newMode = Modes.TRIP_PLAN;
-		} else if (selectedRoute || isRouteSelected || showRouteMap || selectedTrip) {
+			// A selected stop owns the map: expanding one of its arrival rows sets
+			// selectedTrip/isRouteSelected/showRouteMap, and without this guard that
+			// would flip us to ROUTE — whose effect clears every stop marker, exactly
+			// when the stop-selection layer needs them tiered and on screen.
+		} else if (!stop && (selectedRoute || isRouteSelected || showRouteMap || selectedTrip)) {
 			newMode = Modes.ROUTE;
 		} else {
 			newMode = Modes.NORMAL;

--- a/src/components/map/RouteLegend.svelte
+++ b/src/components/map/RouteLegend.svelte
@@ -1,0 +1,45 @@
+<!--
+    @component
+    Names the colors on the map. Two routes in a shared corridor are only
+    distinguishable if the rider can map a color back to a route, so this pane
+    makes the badge -> line -> vehicle mapping explicit while a stop is selected.
+
+    Desktop only: at phone width the bottom sheet already owns this space, and
+    the arrival badges carry the same mapping.
+-->
+<script>
+	import '$lib/i18n.js';
+	import { isLoading, t } from 'svelte-i18n';
+
+	let { routes = [], routeColors = new Map(), liveCounts = new Map() } = $props();
+</script>
+
+{#if routes.length > 0}
+	<div
+		class="route-legend pointer-events-auto absolute right-4 top-4 z-30 hidden min-w-44 rounded-lg border border-gray-300 bg-white/95 p-3 shadow-md backdrop-blur-sm dark:border-gray-600 dark:bg-gray-800/95 md:block"
+	>
+		<h2
+			class="mb-2 text-[10.5px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+		>
+			{$isLoading ? '' : $t('map.routes_shown')}
+		</h2>
+		<ul class="flex flex-col gap-2">
+			{#each routes as route (route.id)}
+				<li class="flex items-center gap-2">
+					<span
+						class="legend-swatch h-1.5 w-5 flex-none rounded-full"
+						style="background-color: {routeColors.get(route.id)?.line};"
+					></span>
+					<span class="text-[13px] font-bold text-gray-900 dark:text-white">{route.shortName}</span>
+					{#if liveCounts.get(route.id)}
+						<span class="ml-auto text-[11px] text-gray-500 dark:text-gray-400">
+							{$isLoading
+								? ''
+								: $t('map.live_vehicle_count', { values: { count: liveCounts.get(route.id) } })}
+						</span>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	</div>
+{/if}

--- a/src/components/map/RouteLegend.svelte
+++ b/src/components/map/RouteLegend.svelte
@@ -27,11 +27,12 @@
 			{#each routes as route (route.id)}
 				<li class="flex items-center gap-2">
 					<span
+						aria-hidden="true"
 						class="legend-swatch h-1.5 w-5 flex-none rounded-full"
 						style="background-color: {routeColors.get(route.id)?.line};"
 					></span>
 					<span class="text-[13px] font-bold text-gray-900 dark:text-white">{route.shortName}</span>
-					{#if liveCounts.get(route.id)}
+					{#if liveCounts.has(route.id)}
 						<span class="ml-auto text-[11px] text-gray-500 dark:text-gray-400">
 							{$isLoading
 								? ''

--- a/src/components/map/RouteMap.svelte
+++ b/src/components/map/RouteMap.svelte
@@ -24,6 +24,14 @@
 			await loadRouteDataPromise;
 		}
 
+		// No tripId means loadRouteData bailed before drawing anything (see the
+		// guard below) — a transient mount/unmount like this must not clear
+		// polylines/markers it never created, nor fly to the stop as if a trip
+		// had just finished loading.
+		if (!tripId) {
+			return;
+		}
+
 		await Promise.all([
 			mapProvider.clearAllPolylines(),
 			mapProvider.removeStopMarkers(),
@@ -39,6 +47,13 @@
 	});
 
 	async function loadRouteData() {
+		// A transient mount (e.g. selectedTrip going null while this is briefly
+		// rendered during a stop close) can land here with no tripId. Bail before
+		// touching the map or issuing a `/api/oba/trip-details/null` request.
+		if (!tripId) {
+			return;
+		}
+
 		try {
 			mapProvider.clearAllPolylines();
 			mapProvider.removeStopMarkers();

--- a/src/components/map/StopMarker.svelte
+++ b/src/components/map/StopMarker.svelte
@@ -89,24 +89,21 @@
 	<!-- The button keeps its 32px box in every tier. Collapsing the *icon* to a
 	     dot is the whole point, but collapsing the hit target with it would put
 	     the control under the WCAG 2.5.8 minimum and make it unusable on touch. -->
-	<button
-		class="marker-hit-area {isFullPin ? '' : 'as-dot'}"
-		onclick={onClick}
-		aria-label={stop.name}
-	>
+	<button class="marker-hit-area h-8 w-8" onclick={onClick} aria-label={stop.name}>
 		{#if isFullPin}
 			<span class="custom-marker dark:border-[#5a2c2c] {isHighlighted ? 'highlight' : ''}">
 				<span class="bus-icon dark:text-white">
 					<FontAwesomeIcon {icon} class=" text-black" />
 					{#if stop.direction}
 						<span class="direction-arrow {stop.direction.toLowerCase()} dark:text-white">
-							<FontAwesomeIcon icon={faCaretUp} class="dark:text-white" />
+							<FontAwesomeIcon icon={faCaretUp} />
 						</span>
 					{/if}
 				</span>
 			</span>
 		{:else if resolvedEmphasis === 'routeDot'}
-			<span class="emphasis-dot route-dot" style="border-color: {dotColor};"></span>
+			<span class="emphasis-dot route-dot" style={dotColor ? `border-color: ${dotColor};` : ''}
+			></span>
 		{:else if resolvedEmphasis === 'muted'}
 			<span class="emphasis-dot muted-dot"></span>
 		{/if}
@@ -142,7 +139,6 @@
 	}
 
 	.marker-hit-area {
-		@apply h-8 w-8;
 		display: flex;
 		justify-content: center;
 		align-items: center;
@@ -198,7 +194,9 @@
 	}
 
 	/* The caret is otherwise hard-coded black; tint it to match the selected
-	   marker's brand-accent border. */
+	   marker's brand-accent border. The caret's <svg> must stay classless (no
+	   dark:text-white of its own) so it inherits color from this span instead
+	   of shadowing it — see StopMarker.test.js for the regression this guards. */
 	.highlight .direction-arrow {
 		@apply text-brand-accent;
 	}

--- a/src/components/map/StopMarker.svelte
+++ b/src/components/map/StopMarker.svelte
@@ -9,10 +9,21 @@
 	 * @property {any} icon
 	 * @property {boolean} [isHighlighted]
 	 * @property {boolean} [showRoutesLabel]
+	 * @property {'full'|'routeDot'|'muted'} [emphasis] - Marker prominence,
+	 *   decided by the map layer from the current selection. `full` is today's pin.
+	 * @property {string|null} [dotColor] - Ring color for the `routeDot` tier.
 	 */
 
 	/** @type {Props} */
-	let { stop, onClick, icon, isHighlighted = false, showRoutesLabel = false } = $props();
+	let {
+		stop,
+		onClick,
+		icon,
+		isHighlighted = false,
+		showRoutesLabel = false,
+		emphasis = 'full',
+		dotColor = null
+	} = $props();
 
 	const MAX_ROUTES_TO_SHOW = 3;
 	let isExpanded = $state(false);
@@ -34,6 +45,12 @@
 			? `${displayedRouteNames.join(', ')}${!isExpanded && remainingRoutesCount > 0 ? ' +' + remainingRoutesCount : ''}`
 			: ''
 	);
+
+	// The selected stop is always among the stops served by the drawn routes, so
+	// `emphasis: 'routeDot'` and `isHighlighted` collide by construction. Highlight
+	// wins: the stop the rider picked must never be the quietest thing on screen.
+	const resolvedEmphasis = $derived(isHighlighted ? 'full' : emphasis);
+	const isFullPin = $derived(resolvedEmphasis === 'full');
 
 	const labelPosition = $derived(
 		(() => {
@@ -69,22 +86,33 @@
 </script>
 
 <div class="marker-container">
+	<!-- The button keeps its 32px box in every tier. Collapsing the *icon* to a
+	     dot is the whole point, but collapsing the hit target with it would put
+	     the control under the WCAG 2.5.8 minimum and make it unusable on touch. -->
 	<button
-		class="custom-marker dark:border-[#5a2c2c] {isHighlighted ? 'highlight' : ''}"
+		class="marker-hit-area {isFullPin ? '' : 'as-dot'}"
 		onclick={onClick}
+		aria-label={stop.name}
 	>
-		<span class="sr-only">{stop.name}</span>
-		<span class="bus-icon dark:text-white">
-			<FontAwesomeIcon {icon} class=" text-black" />
-			{#if stop.direction}
-				<span class="direction-arrow {stop.direction.toLowerCase()} dark:text-white">
-					<FontAwesomeIcon icon={faCaretUp} class="dark:text-white" />
+		{#if isFullPin}
+			<span class="custom-marker dark:border-[#5a2c2c] {isHighlighted ? 'highlight' : ''}">
+				<span class="bus-icon dark:text-white">
+					<FontAwesomeIcon {icon} class=" text-black" />
+					{#if stop.direction}
+						<span class="direction-arrow {stop.direction.toLowerCase()} dark:text-white">
+							<FontAwesomeIcon icon={faCaretUp} class="dark:text-white" />
+						</span>
+					{/if}
 				</span>
-			{/if}
-		</span>
+			</span>
+		{:else if resolvedEmphasis === 'routeDot'}
+			<span class="emphasis-dot route-dot" style="border-color: {dotColor};"></span>
+		{:else if resolvedEmphasis === 'muted'}
+			<span class="emphasis-dot muted-dot"></span>
+		{/if}
 	</button>
 
-	{#if showRoutesLabel && routesLabelText}
+	{#if isFullPin && showRoutesLabel && routesLabelText}
 		<div
 			role="button"
 			tabindex="0"
@@ -113,6 +141,21 @@
 		pointer-events: auto;
 	}
 
+	.marker-hit-area {
+		@apply h-8 w-8;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		background: none;
+		border: none;
+		padding: 0;
+		position: relative;
+	}
+
+	.marker-hit-area:hover {
+		cursor: pointer;
+	}
+
 	.custom-marker {
 		@apply h-8 w-8 rounded-md;
 		@apply bg-white/80 dark:bg-neutral-200;
@@ -123,12 +166,45 @@
 		position: relative;
 	}
 
+	.emphasis-dot {
+		border-radius: 50%;
+		display: block;
+		flex: none;
+	}
+
+	/* "Beads on a string" along the drawn route: reads as a stop on a line the
+	   rider cares about, without competing with the line itself. */
+	.route-dot {
+		height: 14px;
+		width: 14px;
+		background: #fff;
+		border-width: 2.5px;
+		border-style: solid;
+		box-shadow: 0 1px 2px rgb(0 0 0 / 0.28);
+	}
+
+	/* Present for spatial context, but recedes. The white halo keeps it legible on
+	   a dark basemap without adding visual weight. */
+	.muted-dot {
+		height: 9px;
+		width: 9px;
+		background: #8b93a1;
+		opacity: 0.6;
+		box-shadow: 0 0 0 2px rgb(255 255 255 / 0.65);
+	}
+
 	.highlight {
 		@apply scale-125 border-brand-accent drop-shadow-md;
 	}
 
-	.custom-marker:hover {
-		cursor: pointer;
+	/* The caret is otherwise hard-coded black; tint it to match the selected
+	   marker's brand-accent border. */
+	.highlight .direction-arrow {
+		@apply text-brand-accent;
+	}
+
+	:global(.dark) .highlight .direction-arrow {
+		@apply text-brand;
 	}
 
 	.bus-icon {

--- a/src/components/map/StopRoutesLayer.svelte
+++ b/src/components/map/StopRoutesLayer.svelte
@@ -63,6 +63,14 @@
 	// bringToFront). Populated as each route's shape resolves in drawRoutes;
 	// cleared in teardown().
 	let polylinesByRouteId = new Map();
+	// routeId -> the index it drew at (see weightFor), so the promotion
+	// effect below can restore LINE-pane paint order after a demote without
+	// re-deriving it from the live activeRoutes prop — which can reorder
+	// (soonest-arrival-first) without a redraw, per the main effect's
+	// signature-dedup comment below, and so would no longer match the order
+	// the polylines were actually drawn/weighted in. Populated alongside
+	// polylinesByRouteId in drawRoutes; cleared in teardown().
+	let routeDrawIndex = new Map();
 	// The route currently sitting in ROUTE_PANE.PROMOTED, so the promotion
 	// effect can demote it before promoting a new one. Reset in teardown()
 	// since a redraw discards every polyline, promoted or not.
@@ -169,6 +177,7 @@
 				// so the promotion effect's own idea of "currently promoted" starts
 				// in sync with what was actually drawn.
 				polylinesByRouteId.set(route.id, polyline);
+				routeDrawIndex.set(route.id, index);
 				if (isPromoted) currentlyPromotedRouteId = route.id;
 
 				// Reveal only this route: its neighbors may already be drawn, and
@@ -233,7 +242,33 @@
 		// promotion effect's own bookkeeping must be reset here too, or it would
 		// try to re-pane a polyline that no longer exists.
 		polylinesByRouteId.clear();
+		routeDrawIndex.clear();
 		currentlyPromotedRouteId = null;
+	}
+
+	// Restores drawRoutes' widest-backmost / narrowest-frontmost LINE-pane
+	// order after a promote/demote pass. setPolylineLayer's OSM
+	// implementation detaches and re-adds the polyline's <path>, which
+	// appends it to the end of the pane's SVG container regardless of index
+	// — so a demoted route (e.g. the widest one in a shared corridor) would
+	// otherwise land frontmost and paint over its narrower neighbor,
+	// hiding the fringe drawRoutes' stacking order exists to keep visible.
+	// Same mechanism drawRoutes itself uses (see its bringToFront comment
+	// above): call bringToFront() ascending by index so the last call —
+	// the highest index, narrowest route — wins and ends up frontmost.
+	// Excludes whichever route currently sits in ROUTE_PANE.PROMOTED: it
+	// lives in a separate pane above LINE and isn't part of this ordering.
+	function reassertLinePaintOrder() {
+		const nonPromoted = [];
+		for (const [routeId, index] of routeDrawIndex) {
+			if (routeId === currentlyPromotedRouteId) continue;
+			const polyline = polylinesByRouteId.get(routeId);
+			if (polyline) nonPromoted.push({ index, polyline });
+		}
+		nonPromoted.sort((a, b) => a.index - b.index);
+		for (const { polyline } of nonPromoted) {
+			polyline.bringToFront?.();
+		}
 	}
 
 	// Tracks only activeRoutes and routeColors: those two are what define which
@@ -373,6 +408,14 @@
 				}
 
 				currentlyPromotedRouteId = promoted;
+
+				// The demote above (setPolylineLayer(..., ROUTE_PANE.LINE)) just
+				// re-added the outgoing route's polyline to the LINE pane, which on
+				// OSM appends it — making it frontmost regardless of its index.
+				// Re-assert index order over the pane now, the same way drawRoutes
+				// does, so the widest-backmost / narrowest-frontmost stacking that
+				// keeps a shared corridor legible survives the pane move.
+				reassertLinePaintOrder();
 			}
 
 			// Force an immediate refresh rather than waiting up to 30s for the

--- a/src/components/map/StopRoutesLayer.svelte
+++ b/src/components/map/StopRoutesLayer.svelte
@@ -44,6 +44,11 @@
 	const MIN_WEIGHT = 4;
 
 	let vehicleIntervalId = null;
+	// Forces an immediate vehicle refresh (see fetchAndUpdateVehiclesForRoutes)
+	// rather than waiting up to 30s for the next scheduled poll. Set once the
+	// poll started by the main redraw effect below resolves; read by the
+	// promotion effect so expanding a trip moves the amber glow right away.
+	let vehicleTick = null;
 	// Incremented per load so a superseded selection's in-flight fetches bail out
 	// instead of drawing over the newer one.
 	let loadToken = 0;
@@ -51,6 +56,17 @@
 	// currently on the map, so a redraw can be skipped when a new
 	// activeRoutes/routeColors identity carries identical content.
 	let lastSignature = null;
+	// routeId -> the polyline drawn for it, so the promotion effect below can
+	// re-pane a route without re-fetching or re-creating anything. Named
+	// distinctly from drawRoutes' local `drawnPolylines` paint-order array
+	// below, which tracks something else (resolution order, for
+	// bringToFront). Populated as each route's shape resolves in drawRoutes;
+	// cleared in teardown().
+	let polylinesByRouteId = new Map();
+	// The route currently sitting in ROUTE_PANE.PROMOTED, so the promotion
+	// effect can demote it before promoting a new one. Reset in teardown()
+	// since a redraw discards every polyline, promoted or not.
+	let currentlyPromotedRouteId = null;
 
 	function weightFor(index) {
 		return Math.max(MIN_WEIGHT, BASE_WEIGHT - index);
@@ -147,6 +163,14 @@
 				}
 				if (!polyline) return;
 
+				// Retained so the promotion effect can re-pane this route later
+				// without redrawing it. isPromoted was already decided above (from
+				// the untracked promotedRouteId read at the top of this callback),
+				// so the promotion effect's own idea of "currently promoted" starts
+				// in sync with what was actually drawn.
+				polylinesByRouteId.set(route.id, polyline);
+				if (isPromoted) currentlyPromotedRouteId = route.id;
+
 				// Reveal only this route: its neighbors may already be drawn, and
 				// re-animating them on every resolution would look like a glitch.
 				mapProvider.revealPolylines({ only: [polyline], duration: 0.8 });
@@ -192,6 +216,7 @@
 			clearInterval(vehicleIntervalId);
 			vehicleIntervalId = null;
 		}
+		vehicleTick = null;
 	}
 
 	function teardown() {
@@ -204,6 +229,11 @@
 		// clearVehicleMarkers only detaches markers; the module-level map would
 		// otherwise hand stale entries to the next selection.
 		clearVehicleMarkersMap();
+		// clearAllPolylines() above only tears down the map layer side; the
+		// promotion effect's own bookkeeping must be reset here too, or it would
+		// try to re-pane a polyline that no longer exists.
+		polylinesByRouteId.clear();
+		currentlyPromotedRouteId = null;
 	}
 
 	// Tracks only activeRoutes and routeColors: those two are what define which
@@ -217,18 +247,19 @@
 	//    first await runs in a later microtask, outside that stack. So this read
 	//    is naturally untracked; it's wrapped in untrack() anyway so that stays
 	//    true even if the code is later reordered above the await.
-	//  - highlightedTripId is read synchronously (while building the options
-	//    object passed to fetchAndUpdateVehiclesForRoutes, before any await), so
-	//    without untrack() it WOULD become a dependency. untrack() is required
-	//    here, not just defensive.
+	//  - highlightedTripId is passed down as a getter closure (see
+	//    fetchAndUpdateVehiclesForRoutes' `highlightedTripId` option), not read
+	//    directly here, so defining the closure doesn't itself read the prop —
+	//    only *calling* it later would. It's still wrapped in untrack() for the
+	//    same defensive reason as promotedRouteId above: so a future refactor
+	//    that calls the getter synchronously, inside this effect, doesn't
+	//    silently start tracking it.
 	// Net effect: expanding a trip (which only changes promotedRouteId /
 	// highlightedTripId) does not re-fire this effect, does not tear down and
 	// redraw every polyline, and does not restart the vehicle poll — exactly the
-	// "no flash on expand" requirement. The tradeoff is that a vehicle's
-	// highlight glow reflects whichever trip was expanded when the current
-	// route set was drawn; expanding a different trip without changing routes
-	// won't move the glow until the next redraw. No interface exists yet to
-	// update just the highlight without restarting the poll.
+	// "no flash on expand" requirement. Moving the promoted pane and the
+	// highlight glow in response to those two props is instead handled by the
+	// second, narrowly-scoped $effect below.
 	$effect(() => {
 		const routes = activeRoutes;
 		const colors = routeColors;
@@ -275,31 +306,81 @@
 			console.error('StopRoutesLayer: drawRoutes failed', error);
 		});
 
-		// untrack(() => highlightedTripId): this options object is built
-		// synchronously — before any await — as part of *calling*
-		// fetchAndUpdateVehiclesForRoutes, so a plain read here would register as
-		// an effect dependency and re-trigger the whole redraw/re-poll on every
-		// trip expansion. untrack keeps the poll itself scoped to
-		// activeRoutes/routeColors while still passing the current
-		// highlightedTripId value into this run's poll.
+		// A getter, not a captured value: highlightedTripId can change (via trip
+		// expansion) without this effect re-running, so the poll must re-read it
+		// on every tick rather than freezing whatever it was when the poll
+		// started. Wrapped in untrack() so that if a future refactor ever calls
+		// this getter synchronously from inside an effect, it still won't
+		// register highlightedTripId as that effect's dependency.
 		fetchAndUpdateVehiclesForRoutes(routes, mapProvider, {
-			highlightedTripId: untrack(() => highlightedTripId),
+			highlightedTripId: () => untrack(() => highlightedTripId),
 			colorsByRouteId: colors,
 			onCounts: (counts) => {
 				if (token === loadToken) liveCounts = counts;
 			}
 		})
-			.then((intervalId) => {
+			.then(({ intervalId, tick }) => {
 				// A newer load took over while this poll was starting; don't leak it.
 				if (token !== loadToken) {
 					clearInterval(intervalId);
 					return;
 				}
 				vehicleIntervalId = intervalId;
+				vehicleTick = tick;
 			})
 			.catch((error) => {
 				console.error('StopRoutesLayer: vehicle poll failed', error);
 			});
+	});
+
+	// Narrowly scoped: tracks only promotedRouteId and highlightedTripId, the
+	// two props the main redraw effect above deliberately excludes. This is
+	// what actually makes trip expansion move the promoted pane and the
+	// highlight glow — every other read in here is wrapped in untrack() so
+	// this effect can never fire a redraw, a shape refetch, or a poll restart;
+	// see the main effect's comment for why that separation exists.
+	$effect(() => {
+		const promoted = promotedRouteId;
+		// Read only to register as a dependency — the value itself is consumed
+		// live, inside vehicleUtils' tick(), via the getter closure passed to
+		// fetchAndUpdateVehiclesForRoutes above.
+		void highlightedTripId;
+
+		untrack(() => {
+			// No-op before the first draw has landed: mapProvider may still be
+			// null (a cold deep-link mounts this layer before initMap()
+			// resolves), and before any route has been drawn there is nothing to
+			// re-pane and no poll yet to nudge.
+			if (!mapProvider) return;
+
+			if (promoted !== currentlyPromotedRouteId) {
+				// Demote the previously promoted route first — if the polyline it
+				// named ever resolved. Tolerated as a no-op otherwise (its shape
+				// fetch may have failed, or nothing was promoted yet).
+				const previousPolyline = currentlyPromotedRouteId
+					? polylinesByRouteId.get(currentlyPromotedRouteId)
+					: null;
+				if (previousPolyline) {
+					mapProvider.setPolylineLayer(previousPolyline, ROUTE_PANE.LINE);
+				}
+
+				// Promote the new one — same tolerance: promotedRouteId may name a
+				// route whose shape fetch failed, in which case there's no
+				// polyline to move and this is a no-op.
+				const nextPolyline = promoted ? polylinesByRouteId.get(promoted) : null;
+				if (nextPolyline) {
+					mapProvider.setPolylineLayer(nextPolyline, ROUTE_PANE.PROMOTED);
+				}
+
+				currentlyPromotedRouteId = promoted;
+			}
+
+			// Force an immediate refresh rather than waiting up to 30s for the
+			// next scheduled poll, so the amber glow moves right away. Guarded
+			// because the poll's setup promise may not have resolved yet (e.g.
+			// this effect's first run, racing the main effect's initial draw).
+			vehicleTick?.();
+		});
 	});
 
 	onDestroy(() => {

--- a/src/components/map/StopRoutesLayer.svelte
+++ b/src/components/map/StopRoutesLayer.svelte
@@ -1,0 +1,215 @@
+<!--
+    @component
+    Draws the routes a rider can actually board from the selected stop, plus the
+    live vehicles feeding those arrivals.
+
+    Deliberately narrower than RouteMap, which draws a single trip's shape and
+    clears the map first. This layer draws one shape per *route* in the arrivals
+    list and owns its own teardown, so a stop selection and a trip expansion can
+    coexist.
+
+    @prop {Object} mapProvider
+    @prop {ActiveRoute[]} activeRoutes - soonest arrival first; drives draw order
+    @prop {Map<string, RouteColors>} routeColors
+    @prop {string|null} promotedRouteId - the expanded arrival's route, drawn on top
+    @prop {string|null} highlightedTripId - the expanded arrival's trip; its vehicle glows
+    @prop {Map<string,string>} routeStopIds - bindable out: stop id -> ring-dot color
+    @prop {Map<string,number>} liveCounts - bindable out: route id -> live vehicle count
+-->
+<script>
+	import { onDestroy, untrack } from 'svelte';
+	import { fetchAndUpdateVehiclesForRoutes, clearVehicleMarkersMap } from '$lib/vehicleUtils.js';
+	// From the provider-neutral module, NOT from a provider: importing either
+	// provider here would pull its whole map stack into the bundle regardless of
+	// which one PUBLIC_OBA_MAP_PROVIDER selects.
+	import { ROUTE_PANE } from '$lib/mapPanes.js';
+
+	let {
+		mapProvider,
+		activeRoutes = [],
+		routeColors = new Map(),
+		promotedRouteId = null,
+		highlightedTripId = null,
+		routeStopIds = $bindable(new Map()),
+		liveCounts = $bindable(new Map())
+	} = $props();
+
+	// Widest route draws first and each subsequent route is a little narrower, so
+	// a route underneath shows as a colored fringe either side of the one above
+	// it. This is what keeps two routes legible in a shared corridor: all casings
+	// live in one pane below all colored strokes, so the fringe isn't covered.
+	// A true perpendicular offset would need a zoom-reactive screen-space
+	// transform and has no cross-provider primitive — see the design spec.
+	const BASE_WEIGHT = 7;
+	const MIN_WEIGHT = 4;
+
+	let vehicleIntervalId = null;
+	// Incremented per load so a superseded selection's in-flight fetches bail out
+	// instead of drawing over the newer one.
+	let loadToken = 0;
+
+	function weightFor(index) {
+		return Math.max(MIN_WEIGHT, BASE_WEIGHT - index);
+	}
+
+	async function fetchRouteShape(route) {
+		// includeStatus=false: the endpoint defaults it to true, and we need only
+		// the shape id and the stop times.
+		const tripResponse = await fetch(`/api/oba/trip-details/${route.tripId}?includeStatus=false`);
+		if (!tripResponse.ok) {
+			throw new Error(`trip-details ${tripResponse.status} for trip ${route.tripId}`);
+		}
+		const tripData = await tripResponse.json();
+
+		const tripRef = tripData?.data?.references?.trips?.find((trip) => trip.id === route.tripId);
+		const shapeId = tripRef?.shapeId;
+		if (!shapeId) {
+			throw new Error(`no shapeId for trip ${route.tripId}`);
+		}
+
+		const shapeResponse = await fetch(`/api/oba/shape/${shapeId}`);
+		if (!shapeResponse.ok) {
+			throw new Error(`shape ${shapeResponse.status} for shape ${shapeId}`);
+		}
+		const shapeData = await shapeResponse.json();
+
+		const stopIds = (tripData?.data?.entry?.schedule?.stopTimes ?? [])
+			.map((stopTime) => stopTime.stopId)
+			.filter(Boolean);
+
+		return { points: shapeData?.data?.entry?.points, stopIds };
+	}
+
+	async function drawRoutes(routes, colors, token) {
+		// Accumulated outside the map closure so concurrent resolutions merge
+		// into one shared map instead of each mapper invocation racing to publish
+		// its own partial snapshot over the others.
+		const nextStopIds = new Map();
+
+		await Promise.all(
+			routes.map(async (route, index) => {
+				const color = colors.get(route.id)?.line;
+				let shape;
+				try {
+					shape = await fetchRouteShape(route);
+				} catch (error) {
+					// One missing shape degrades the map rather than breaking it: the
+					// other routes still draw, and this one is simply absent from the
+					// lines, the legend, and the ring dots.
+					console.error('StopRoutesLayer: could not load shape', route.id, error);
+					return;
+				}
+				if (token !== loadToken || !shape.points) return;
+
+				// untrack: this read happens after an await, so Svelte would not treat
+				// it as an effect dependency anyway — but reading it explicitly through
+				// untrack makes that non-dependency intentional rather than incidental,
+				// so a future refactor that moves this above the await doesn't silently
+				// turn trip-expansion into a full redraw.
+				const promoted = untrack(() => promotedRouteId);
+				const isPromoted = promoted != null && route.id === promoted;
+				const polyline = await mapProvider.createPolyline(shape.points, {
+					color,
+					casing: true,
+					weight: weightFor(index),
+					pane: isPromoted ? ROUTE_PANE.PROMOTED : ROUTE_PANE.LINE,
+					casingPane: ROUTE_PANE.CASING
+				});
+				if (token !== loadToken) return;
+				if (!polyline) return;
+
+				// Reveal only this route: its neighbors may already be drawn, and
+				// re-animating them on every resolution would look like a glitch.
+				mapProvider.revealPolylines({ only: [polyline], duration: 0.8 });
+
+				// First route to claim a stop wins, and routes arrive soonest-first,
+				// so a shared stop takes the color of the route arriving next. Both
+				// the mutation and the publish happen synchronously within this
+				// resolved route's turn, so two routes resolving "at the same time"
+				// (already-resolved microtasks) still apply one at a time rather than
+				// clobbering each other's contribution.
+				for (const stopId of shape.stopIds) {
+					if (!nextStopIds.has(stopId)) nextStopIds.set(stopId, color);
+				}
+				routeStopIds = new Map(nextStopIds);
+			})
+		);
+	}
+
+	function stopVehiclePolling() {
+		if (vehicleIntervalId) {
+			clearInterval(vehicleIntervalId);
+			vehicleIntervalId = null;
+		}
+	}
+
+	function teardown() {
+		stopVehiclePolling();
+		mapProvider.clearAllPolylines();
+		mapProvider.clearVehicleMarkers();
+		// clearVehicleMarkers only detaches markers; the module-level map would
+		// otherwise hand stale entries to the next selection.
+		clearVehicleMarkersMap();
+	}
+
+	// Tracks only activeRoutes and routeColors: those two are what define which
+	// routes and colors need to be on the map, so only they should tear down and
+	// redraw everything. promotedRouteId and highlightedTripId are consumed here
+	// too (to pick the promoted pane and to seed the vehicle poll's highlight),
+	// but neither is allowed to become a dependency:
+	//  - promotedRouteId is read inside drawRoutes' per-route callback, after an
+	//    `await` — Svelte only tracks reads that happen synchronously within the
+	//    effect's own call stack, and an async function's continuation after its
+	//    first await runs in a later microtask, outside that stack. So this read
+	//    is naturally untracked; it's wrapped in untrack() anyway so that stays
+	//    true even if the code is later reordered above the await.
+	//  - highlightedTripId is read synchronously (while building the options
+	//    object passed to fetchAndUpdateVehiclesForRoutes, before any await), so
+	//    without untrack() it WOULD become a dependency. untrack() is required
+	//    here, not just defensive.
+	// Net effect: expanding a trip (which only changes promotedRouteId /
+	// highlightedTripId) does not re-fire this effect, does not tear down and
+	// redraw every polyline, and does not restart the vehicle poll — exactly the
+	// "no flash on expand" requirement. The tradeoff is that a vehicle's
+	// highlight glow reflects whichever trip was expanded when the current
+	// route set was drawn; expanding a different trip without changing routes
+	// won't move the glow until the next redraw. No interface exists yet to
+	// update just the highlight without restarting the poll.
+	$effect(() => {
+		const routes = activeRoutes;
+		const colors = routeColors;
+		const token = ++loadToken;
+
+		if (!mapProvider || routes.length === 0) return;
+
+		teardown();
+		drawRoutes(routes, colors, token);
+
+		// untrack(() => highlightedTripId): this options object is built
+		// synchronously — before any await — as part of *calling*
+		// fetchAndUpdateVehiclesForRoutes, so a plain read here would register as
+		// an effect dependency and re-trigger the whole redraw/re-poll on every
+		// trip expansion. untrack keeps the poll itself scoped to
+		// activeRoutes/routeColors while still passing the current
+		// highlightedTripId value into this run's poll.
+		fetchAndUpdateVehiclesForRoutes(routes, mapProvider, {
+			highlightedTripId: untrack(() => highlightedTripId),
+			colorsByRouteId: colors,
+			onCounts: (counts) => {
+				if (token === loadToken) liveCounts = counts;
+			}
+		}).then((intervalId) => {
+			// A newer load took over while this poll was starting; don't leak it.
+			if (token !== loadToken) {
+				clearInterval(intervalId);
+				return;
+			}
+			vehicleIntervalId = intervalId;
+		});
+	});
+
+	onDestroy(() => {
+		loadToken++;
+		teardown();
+	});
+</script>

--- a/src/components/map/StopRoutesLayer.svelte
+++ b/src/components/map/StopRoutesLayer.svelte
@@ -18,7 +18,10 @@
 -->
 <script>
 	import { onDestroy, untrack } from 'svelte';
-	import { fetchAndUpdateVehiclesForRoutes, clearVehicleMarkersMap } from '$lib/vehicleUtils.js';
+	import {
+		fetchAndUpdateVehiclesForRoutes,
+		removeVehicleMarkersForRoutes
+	} from '$lib/vehicleUtils.js';
 	// From the provider-neutral module, NOT from a provider: importing either
 	// provider here would pull its whole map stack into the bundle regardless of
 	// which one PUBLIC_OBA_MAP_PROVIDER selects.
@@ -233,12 +236,26 @@
 		// mapProvider can be null: a cold deep-link whose arrivals land before
 		// initMap() resolves mounts this layer with no provider yet, and
 		// onDestroy calls teardown() unconditionally.
-		mapProvider?.clearAllPolylines();
-		mapProvider?.clearVehicleMarkers();
-		// clearVehicleMarkers only detaches markers; the module-level map would
-		// otherwise hand stale entries to the next selection.
-		clearVehicleMarkersMap();
-		// clearAllPolylines() above only tears down the map layer side; the
+		//
+		// Self-scoped: this must remove only what THIS layer drew, never the
+		// whole map. A map-wide clearAllPolylines()/clearVehicleMarkers() here
+		// would also wipe a route SearchPane just drew on top of an open stop
+		// sheet (see MapExperience's handleRouteSelected, which closes the
+		// sheet — and therefore unmounts this layer — *after* SearchPane has
+		// already drawn the newly selected route). polylinesByRouteId's keys
+		// are exactly the route ids this layer drew as of the last completed
+		// drawRoutes() call: on a signature-change redraw this runs before the
+		// new drawRoutes() starts, so it still reflects the *previous* draw,
+		// which is what needs clearing.
+		if (mapProvider) {
+			for (const polyline of polylinesByRouteId.values()) {
+				mapProvider.removePolyline(polyline);
+			}
+			// Array.from, not the live Map iterator: polylinesByRouteId.clear()
+			// below would otherwise empty the iterator's backing map out from
+			// under a caller (or a test spy) that reads it after this call returns.
+			removeVehicleMarkersForRoutes(Array.from(polylinesByRouteId.keys()), mapProvider);
+		}
 		// promotion effect's own bookkeeping must be reset here too, or it would
 		// try to re-pane a polyline that no longer exists.
 		polylinesByRouteId.clear();

--- a/src/components/map/StopRoutesLayer.svelte
+++ b/src/components/map/StopRoutesLayer.svelte
@@ -47,6 +47,10 @@
 	// Incremented per load so a superseded selection's in-flight fetches bail out
 	// instead of drawing over the newer one.
 	let loadToken = 0;
+	// The content signature (see the $effect below) that produced the routes
+	// currently on the map, so a redraw can be skipped when a new
+	// activeRoutes/routeColors identity carries identical content.
+	let lastSignature = null;
 
 	function weightFor(index) {
 		return Math.max(MIN_WEIGHT, BASE_WEIGHT - index);
@@ -81,10 +85,28 @@
 	}
 
 	async function drawRoutes(routes, colors, token) {
+		if (token !== loadToken) return;
+
+		// Publish immediately rather than waiting for the first shape to
+		// resolve (or, if every fetch fails, never). Between teardown and the
+		// first resolution this briefly leaves dots un-ringed rather than
+		// still ringed for the *previous* stop's routes — a stale ring lies
+		// about which stop is selected, an absent one just looks momentary.
+		routeStopIds = new Map();
+
 		// Accumulated outside the map closure so concurrent resolutions merge
 		// into one shared map instead of each mapper invocation racing to publish
 		// its own partial snapshot over the others.
 		const nextStopIds = new Map();
+		// Which route index currently claims each stop, so a shared stop is
+		// decided by index priority (soonest-arrival-first) rather than by
+		// whichever shape happens to resolve first over the network.
+		const stopClaimIndex = new Map();
+		// Polylines drawn so far this call, so paint order can be restored to
+		// index order after every resolution — Leaflet/Google paint in the
+		// order createPolyline resolved, which is shape-fetch race order, not
+		// activeRoutes order.
+		const drawnPolylines = [];
 
 		await Promise.all(
 			routes.map(async (route, index) => {
@@ -115,21 +137,50 @@
 					pane: isPromoted ? ROUTE_PANE.PROMOTED : ROUTE_PANE.LINE,
 					casingPane: ROUTE_PANE.CASING
 				});
-				if (token !== loadToken) return;
+				if (token !== loadToken) {
+					// A supersede ran clearAllPolylines() before this create resolved
+					// (Google's createPolyline is async, awaiting importLibrary), so
+					// the polyline this call just attached to the map is an orphan of
+					// the selection that's already gone — take it back off.
+					mapProvider.removePolyline(polyline);
+					return;
+				}
 				if (!polyline) return;
 
 				// Reveal only this route: its neighbors may already be drawn, and
 				// re-animating them on every resolution would look like a glitch.
 				mapProvider.revealPolylines({ only: [polyline], duration: 0.8 });
 
-				// First route to claim a stop wins, and routes arrive soonest-first,
-				// so a shared stop takes the color of the route arriving next. Both
+				// Paint order is shape-fetch resolution order, not index order, so
+				// re-assert index order after every resolution: the widest route
+				// (lowest index) must stay backmost and the narrower ones (higher
+				// index) frontmost, or the widest — if it happens to resolve last —
+				// paints over the narrower ones entirely and the fringe described
+				// above disappears. Calling bringToFront() ascending by index, last
+				// call wins, puts the highest index frontmost. bringToFront is a
+				// Leaflet Path method the OSM provider's polyline exposes directly;
+				// it's a no-op on Google's polyline object, whose paint order already
+				// comes from the pane's zIndex set at creation, so this line is
+				// harmless there.
+				drawnPolylines.push({ index, polyline });
+				drawnPolylines.sort((a, b) => a.index - b.index);
+				for (const drawn of drawnPolylines) {
+					drawn.polyline.bringToFront?.();
+				}
+
+				// A shared stop is claimed by index priority: only a lower index
+				// (sooner-arriving route) may overwrite a stop already claimed by a
+				// higher one, regardless of which of the two resolves first. Both
 				// the mutation and the publish happen synchronously within this
 				// resolved route's turn, so two routes resolving "at the same time"
 				// (already-resolved microtasks) still apply one at a time rather than
 				// clobbering each other's contribution.
 				for (const stopId of shape.stopIds) {
-					if (!nextStopIds.has(stopId)) nextStopIds.set(stopId, color);
+					const claimedIndex = stopClaimIndex.get(stopId);
+					if (claimedIndex === undefined || index < claimedIndex) {
+						nextStopIds.set(stopId, color);
+						stopClaimIndex.set(stopId, index);
+					}
 				}
 				routeStopIds = new Map(nextStopIds);
 			})
@@ -145,8 +196,11 @@
 
 	function teardown() {
 		stopVehiclePolling();
-		mapProvider.clearAllPolylines();
-		mapProvider.clearVehicleMarkers();
+		// mapProvider can be null: a cold deep-link whose arrivals land before
+		// initMap() resolves mounts this layer with no provider yet, and
+		// onDestroy calls teardown() unconditionally.
+		mapProvider?.clearAllPolylines();
+		mapProvider?.clearVehicleMarkers();
 		// clearVehicleMarkers only detaches markers; the module-level map would
 		// otherwise hand stale entries to the next selection.
 		clearVehicleMarkersMap();
@@ -178,12 +232,48 @@
 	$effect(() => {
 		const routes = activeRoutes;
 		const colors = routeColors;
+
+		// Redraw is keyed on a content signature, not on activeRoutes/routeColors
+		// identity. StopPane polls arrivals every ~30s, and MapExperience's
+		// $derived recomputes activeRoutesFromArrivals/assignRouteColors from
+		// scratch on every poll, handing this effect a brand-new array and a
+		// brand-new Map even when nothing actually changed. Keying on identity
+		// tore down and redrew everything — every polyline and casing, every
+		// vehicle marker (restarting animateMarker's position interpolation from
+		// scratch), 2x the shape/vehicle requests, and a replayed 0.8s draw
+		// animation — every 30 seconds. A signature built from route ids and
+		// their resolved line colors catches actual changes while ignoring
+		// re-allocation noise.
+		//
+		// Sorted deliberately: activeRoutes is ordered soonest-arrival-first and
+		// genuinely reshuffles as predictions update, so an order-sensitive
+		// signature would still redraw on every reshuffle even when the route
+		// set and colors are unchanged. The cost is that stroke weights (which
+		// come from index/order — see weightFor) reflect whichever order was
+		// current at the *first* draw of this route set, not the live
+		// soonest-first order; that's a far smaller price than refetching and
+		// re-animating every 30 seconds.
+		const signature = routes
+			.map((route) => `${route.id}:${colors.get(route.id)?.line ?? ''}`)
+			.sort()
+			.join('|');
+
+		if (!mapProvider) return;
+		if (signature === lastSignature) return;
+		lastSignature = signature;
+
 		const token = ++loadToken;
-
-		if (!mapProvider || routes.length === 0) return;
-
 		teardown();
-		drawRoutes(routes, colors, token);
+
+		// An emptied route set must still tear down (polylines, vehicle
+		// markers, the poll interval) rather than leaving the previous
+		// selection on the map indefinitely — teardown() above already
+		// happened; there's just nothing to redraw.
+		if (routes.length === 0) return;
+
+		drawRoutes(routes, colors, token).catch((error) => {
+			console.error('StopRoutesLayer: drawRoutes failed', error);
+		});
 
 		// untrack(() => highlightedTripId): this options object is built
 		// synchronously — before any await — as part of *calling*
@@ -198,14 +288,18 @@
 			onCounts: (counts) => {
 				if (token === loadToken) liveCounts = counts;
 			}
-		}).then((intervalId) => {
-			// A newer load took over while this poll was starting; don't leak it.
-			if (token !== loadToken) {
-				clearInterval(intervalId);
-				return;
-			}
-			vehicleIntervalId = intervalId;
-		});
+		})
+			.then((intervalId) => {
+				// A newer load took over while this poll was starting; don't leak it.
+				if (token !== loadToken) {
+					clearInterval(intervalId);
+					return;
+				}
+				vehicleIntervalId = intervalId;
+			})
+			.catch((error) => {
+				console.error('StopRoutesLayer: vehicle poll failed', error);
+			});
 	});
 
 	onDestroy(() => {

--- a/src/components/map/__tests__/RouteLegend.test.js
+++ b/src/components/map/__tests__/RouteLegend.test.js
@@ -1,5 +1,38 @@
 import { render, screen } from '@testing-library/svelte';
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi } from 'vitest';
+
+// Local i18n mock that interpolates `values`.
+//
+// This appends each interpolated value to the key rather than substituting it
+// into the key string. The key itself (e.g. "map.live_vehicle_count") never
+// contains a literal placeholder to replace -- only a real translation
+// message would -- so a mock that tries a `key.replace(...)` no-op would let
+// an assertion pass even if the component never forwarded `values` to `$t()`
+// at all. Appending the value instead means the test can only pass if the
+// component actually forwards `values: { count }`.
+vi.mock('svelte-i18n', () => ({
+	t: {
+		subscribe: (fn) => {
+			fn((key, options) => {
+				let str = key;
+				if (options?.values) {
+					for (const value of Object.values(options.values)) {
+						str = `${str} ${value}`;
+					}
+				}
+				return str;
+			});
+			return () => {};
+		}
+	},
+	isLoading: {
+		subscribe: (fn) => {
+			fn(false);
+			return () => {};
+		}
+	}
+}));
+
 import RouteLegend from '../RouteLegend.svelte';
 
 const routes = [
@@ -26,12 +59,36 @@ describe('RouteLegend', () => {
 		expect(swatches[0]).toHaveStyle('background-color: #b02a37');
 	});
 
-	test('shows the live vehicle count when there is one', () => {
+	test('the swatch is decorative and hidden from assistive tech', () => {
+		const { container } = render(RouteLegend, {
+			props: { routes, routeColors: colors, liveCounts: new Map() }
+		});
+		const swatches = container.querySelectorAll('.legend-swatch');
+		expect(swatches[0]).toHaveAttribute('aria-hidden', 'true');
+	});
+
+	test('shows the live vehicle count when there is a positive count', () => {
 		render(RouteLegend, {
 			props: { routes, routeColors: colors, liveCounts: new Map([['r_c', 3]]) }
 		});
-		// The i18n mock echoes keys, so we expect to see the i18n key
-		expect(screen.getByText('map.live_vehicle_count')).toBeInTheDocument();
+		expect(screen.getByText('map.live_vehicle_count 3')).toBeInTheDocument();
+	});
+
+	test('shows the live vehicle count when it is explicitly zero', () => {
+		render(RouteLegend, {
+			props: { routes, routeColors: colors, liveCounts: new Map([['r_c', 0]]) }
+		});
+		expect(screen.getByText('map.live_vehicle_count 0')).toBeInTheDocument();
+	});
+
+	test('shows nothing for a route absent from liveCounts (no data yet)', () => {
+		// Only r_22 has polled successfully; r_c's fetch hasn't landed (or failed),
+		// so it must render no count at all -- not even a blank/zero one.
+		render(RouteLegend, {
+			props: { routes, routeColors: colors, liveCounts: new Map([['r_22', 5]]) }
+		});
+		expect(screen.getByText('map.live_vehicle_count 5')).toBeInTheDocument();
+		expect(screen.getAllByText(/map\.live_vehicle_count/)).toHaveLength(1);
 	});
 
 	test('renders nothing when no routes are drawn', () => {

--- a/src/components/map/__tests__/RouteLegend.test.js
+++ b/src/components/map/__tests__/RouteLegend.test.js
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, test, expect } from 'vitest';
+import RouteLegend from '../RouteLegend.svelte';
+
+const routes = [
+	{ id: 'r_c', shortName: 'C Line', type: 3, tripId: 't_c', gtfsColor: 'b02a37' },
+	{ id: 'r_22', shortName: '22', type: 3, tripId: 't_22', gtfsColor: 'e0a021' }
+];
+const colors = new Map([
+	['r_c', { line: '#b02a37', badgeBg: 'b02a37', badgeFg: 'ffffff' }],
+	['r_22', { line: '#e0a021', badgeBg: 'e0a021', badgeFg: '000000' }]
+]);
+
+describe('RouteLegend', () => {
+	test('lists one row per drawn route', () => {
+		render(RouteLegend, { props: { routes, routeColors: colors, liveCounts: new Map() } });
+		expect(screen.getByText('C Line')).toBeInTheDocument();
+		expect(screen.getByText('22')).toBeInTheDocument();
+	});
+
+	test('colors each swatch with its route color', () => {
+		const { container } = render(RouteLegend, {
+			props: { routes, routeColors: colors, liveCounts: new Map() }
+		});
+		const swatches = container.querySelectorAll('.legend-swatch');
+		expect(swatches[0]).toHaveStyle('background-color: #b02a37');
+	});
+
+	test('shows the live vehicle count when there is one', () => {
+		render(RouteLegend, {
+			props: { routes, routeColors: colors, liveCounts: new Map([['r_c', 3]]) }
+		});
+		// The i18n mock echoes keys, so we expect to see the i18n key
+		expect(screen.getByText('map.live_vehicle_count')).toBeInTheDocument();
+	});
+
+	test('renders nothing when no routes are drawn', () => {
+		const { container } = render(RouteLegend, {
+			props: { routes: [], routeColors: new Map(), liveCounts: new Map() }
+		});
+		expect(container.querySelector('.route-legend')).not.toBeInTheDocument();
+	});
+});

--- a/src/components/map/__tests__/RouteMap.test.js
+++ b/src/components/map/__tests__/RouteMap.test.js
@@ -1,0 +1,88 @@
+import { render } from '@testing-library/svelte';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import RouteMap from '../RouteMap.svelte';
+
+vi.mock('$lib/vehicleUtils', () => ({
+	clearVehicleMarkersMap: vi.fn(),
+	fetchAndUpdateVehicles: vi.fn().mockResolvedValue(null)
+}));
+
+function makeProvider() {
+	return {
+		clearAllPolylines: vi.fn(),
+		removeStopMarkers: vi.fn(),
+		cleanupInfoWindow: vi.fn(),
+		clearVehicleMarkers: vi.fn(),
+		createPolyline: vi.fn().mockResolvedValue(undefined),
+		addStopRouteMarker: vi.fn(),
+		fitToPolylines: vi.fn().mockResolvedValue(true),
+		flyTo: vi.fn()
+	};
+}
+
+describe('RouteMap', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		global.fetch = vi.fn();
+	});
+
+	// Regression test for the transient-mount crash: MapExperience's framing
+	// effect nulls selectedTrip one render tick *after* the DOM re-renders, so
+	// on closing a stop after expanding a trip, RouteMap can transiently mount
+	// with tripId already null before its parent unmounts it again. It must be
+	// a no-op in that state, not clear the map or hit the network.
+	test('does nothing when mounted with a null tripId', async () => {
+		const mapProvider = makeProvider();
+		const { unmount } = render(RouteMap, {
+			props: { mapProvider, tripId: null, currentSelectedStop: { lat: 1, lon: 2 } }
+		});
+
+		await vi.waitFor(() => {
+			// give any pending microtasks a chance to run
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(mapProvider.clearAllPolylines).not.toHaveBeenCalled();
+		expect(mapProvider.removeStopMarkers).not.toHaveBeenCalled();
+		expect(global.fetch).not.toHaveBeenCalled();
+
+		unmount();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		// Teardown must also be a no-op: nothing was drawn, so nothing should be
+		// cleared, and it must not flyTo the stop as though a trip had loaded.
+		expect(mapProvider.clearAllPolylines).not.toHaveBeenCalled();
+		expect(mapProvider.removeStopMarkers).not.toHaveBeenCalled();
+		expect(mapProvider.cleanupInfoWindow).not.toHaveBeenCalled();
+		expect(mapProvider.clearVehicleMarkers).not.toHaveBeenCalled();
+		expect(mapProvider.flyTo).not.toHaveBeenCalled();
+	});
+
+	test('still loads and tears down route data normally when tripId is present', async () => {
+		global.fetch = vi.fn(async (url) => {
+			if (url.includes('/trip-details/')) {
+				return {
+					ok: true,
+					json: async () => ({
+						data: {
+							entry: { schedule: { stopTimes: [] } },
+							references: { trips: [{ id: 'trip_1', shapeId: null }], routes: [] }
+						}
+					})
+				};
+			}
+			return { ok: true, json: async () => ({ data: { entry: { points: null } } }) };
+		});
+		const mapProvider = makeProvider();
+		const { unmount } = render(RouteMap, {
+			props: { mapProvider, tripId: 'trip_1', currentSelectedStop: { lat: 1, lon: 2 } }
+		});
+
+		await vi.waitFor(() => expect(mapProvider.clearAllPolylines).toHaveBeenCalled());
+		expect(mapProvider.removeStopMarkers).toHaveBeenCalled();
+		expect(global.fetch).toHaveBeenCalledWith('/api/oba/trip-details/trip_1');
+
+		unmount();
+		await vi.waitFor(() => expect(mapProvider.flyTo).toHaveBeenCalledWith(1, 2, 18));
+	});
+});

--- a/src/components/map/__tests__/StopMarker.test.js
+++ b/src/components/map/__tests__/StopMarker.test.js
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, test, expect, vi } from 'vitest';
+import { faBus } from '@fortawesome/free-solid-svg-icons';
+import StopMarker from '../StopMarker.svelte';
+
+const stop = {
+	id: 'stop_1',
+	name: 'California Ave SW & Fauntleroy Way SW',
+	direction: 'N',
+	routes: []
+};
+
+function renderMarker(props = {}) {
+	return render(StopMarker, {
+		props: { stop, icon: faBus, onClick: vi.fn(), ...props }
+	});
+}
+
+describe('StopMarker emphasis', () => {
+	test('renders the full pin by default', () => {
+		const { container } = renderMarker();
+		expect(container.querySelector('.custom-marker')).toBeInTheDocument();
+		expect(container.querySelector('.emphasis-dot')).not.toBeInTheDocument();
+	});
+
+	test('renders a route-colored ring dot for routeDot', () => {
+		const { container } = renderMarker({ emphasis: 'routeDot', dotColor: '#b02a37' });
+		const dot = container.querySelector('.emphasis-dot.route-dot');
+		expect(dot).toBeInTheDocument();
+		expect(dot).toHaveStyle('border-color: #b02a37');
+		expect(container.querySelector('.bus-icon')).not.toBeInTheDocument();
+	});
+
+	test('renders a quiet gray dot for muted', () => {
+		const { container } = renderMarker({ emphasis: 'muted' });
+		expect(container.querySelector('.emphasis-dot.muted-dot')).toBeInTheDocument();
+		expect(container.querySelector('.bus-icon')).not.toBeInTheDocument();
+	});
+
+	// The selected stop is always in the ring-dot set (those are the trips that
+	// serve it), so these two props WILL collide. isHighlighted has to win, or the
+	// rider's selected stop becomes the least distinguishable thing on the map.
+	test('isHighlighted wins over routeDot', () => {
+		const { container } = renderMarker({
+			emphasis: 'routeDot',
+			dotColor: '#b02a37',
+			isHighlighted: true
+		});
+		expect(container.querySelector('.custom-marker.highlight')).toBeInTheDocument();
+		expect(container.querySelector('.emphasis-dot')).not.toBeInTheDocument();
+	});
+
+	test.each(['full', 'routeDot', 'muted'])(
+		'keeps an accessible 32px button in the %s tier',
+		(emphasis) => {
+			const { container } = renderMarker({ emphasis, dotColor: '#b02a37' });
+			const button = screen.getByRole('button', { name: stop.name });
+			expect(button).toBeInTheDocument();
+			expect(container.querySelector('.marker-hit-area')).toBeInTheDocument();
+		}
+	);
+
+	test.each(['routeDot', 'muted'])('hides the routes label in the %s tier', (emphasis) => {
+		const withRoutes = { ...stop, routes: [{ shortName: 'C' }, { shortName: '22' }] };
+		render(StopMarker, {
+			props: { stop: withRoutes, icon: faBus, onClick: vi.fn(), showRoutesLabel: true, emphasis }
+		});
+		expect(screen.queryByText('C, 22')).not.toBeInTheDocument();
+	});
+
+	test('shows the routes label in the full tier', () => {
+		const withRoutes = { ...stop, routes: [{ shortName: 'C' }, { shortName: '22' }] };
+		render(StopMarker, {
+			props: {
+				stop: withRoutes,
+				icon: faBus,
+				onClick: vi.fn(),
+				showRoutesLabel: true,
+				emphasis: 'full'
+			}
+		});
+		expect(screen.getByText('C, 22')).toBeInTheDocument();
+	});
+});

--- a/src/components/map/__tests__/StopMarker.test.js
+++ b/src/components/map/__tests__/StopMarker.test.js
@@ -50,13 +50,29 @@ describe('StopMarker emphasis', () => {
 		expect(container.querySelector('.emphasis-dot')).not.toBeInTheDocument();
 	});
 
+	// jsdom doesn't load component <style> blocks (no `css: true` in the vitest
+	// config), so @apply-generated Tailwind utilities never resolve here and a
+	// getComputedStyle assertion would be meaningless either way. What actually
+	// makes `:global(.dark) .highlight .direction-arrow { @apply text-brand; }`
+	// win is the caret's <svg> staying classless: an element's own directly
+	// matching class (e.g. a `dark:text-white` FontAwesomeIcon class landing on
+	// the rendered <svg>) always beats a rule inherited from an ancestor,
+	// regardless of the ancestor's specificity. Lock down that markup contract.
+	test('highlighted caret svg has no color class of its own, so it inherits from .direction-arrow', () => {
+		const { container } = renderMarker({ isHighlighted: true });
+		const directionArrow = container.querySelector('.direction-arrow');
+		expect(directionArrow).toHaveClass('dark:text-white');
+		const caretSvg = directionArrow.querySelector('svg');
+		expect(caretSvg).not.toHaveClass('dark:text-white');
+		expect(caretSvg.getAttribute('class') ?? '').not.toMatch(/text-/);
+	});
+
 	test.each(['full', 'routeDot', 'muted'])(
 		'keeps an accessible 32px button in the %s tier',
 		(emphasis) => {
-			const { container } = renderMarker({ emphasis, dotColor: '#b02a37' });
+			renderMarker({ emphasis, dotColor: '#b02a37' });
 			const button = screen.getByRole('button', { name: stop.name });
-			expect(button).toBeInTheDocument();
-			expect(container.querySelector('.marker-hit-area')).toBeInTheDocument();
+			expect(button).toHaveClass('marker-hit-area', 'h-8', 'w-8');
 		}
 	);
 

--- a/src/components/map/__tests__/StopRoutesLayer.test.js
+++ b/src/components/map/__tests__/StopRoutesLayer.test.js
@@ -1,9 +1,10 @@
 import { render } from '@testing-library/svelte';
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import StopRoutesLayer from '../StopRoutesLayer.svelte';
+import { ROUTE_PANE } from '$lib/mapPanes.js';
 
 vi.mock('$lib/vehicleUtils.js', () => ({
-	fetchAndUpdateVehiclesForRoutes: vi.fn().mockResolvedValue(42),
+	fetchAndUpdateVehiclesForRoutes: vi.fn().mockResolvedValue({ intervalId: 42, tick: vi.fn() }),
 	clearVehicleMarkersMap: vi.fn()
 }));
 import { fetchAndUpdateVehiclesForRoutes, clearVehicleMarkersMap } from '$lib/vehicleUtils.js';
@@ -15,7 +16,8 @@ function makeProvider() {
 		revealPolylines: vi.fn(),
 		clearAllPolylines: vi.fn(),
 		clearVehicleMarkers: vi.fn(),
-		removePolyline: vi.fn()
+		removePolyline: vi.fn(),
+		setPolylineLayer: vi.fn()
 	};
 }
 
@@ -463,5 +465,116 @@ describe('StopRoutesLayer', () => {
 		expect(colorGetSpy.mock.calls.length).toBe(colorGetCallsBefore);
 
 		colorGetSpy.mockRestore();
+	});
+});
+
+// Task 10b: expanding an arrival row promotes its route and highlights its
+// vehicle. The main redraw effect above deliberately excludes
+// promotedRouteId/highlightedTripId as dependencies (see the previous test);
+// this second effect is what actually makes expansion do something, without
+// touching the main effect's redraw guarantees.
+describe('StopRoutesLayer — trip expansion (promote route / highlight vehicle)', () => {
+	function makePromotableProvider() {
+		const polyC = { id: 'poly_c' };
+		const poly22 = { id: 'poly_22' };
+		const mapProvider = {
+			createPolyline: vi.fn(async (points, options) =>
+				options.color === '#b02a37' ? polyC : poly22
+			),
+			revealPolylines: vi.fn(),
+			clearAllPolylines: vi.fn(),
+			clearVehicleMarkers: vi.fn(),
+			removePolyline: vi.fn(),
+			setPolylineLayer: vi.fn()
+		};
+		return { mapProvider, polyC, poly22 };
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockShapeFetches();
+	});
+
+	// The deliverable: expansion must re-pane, not redraw. If this regresses to
+	// a full redraw, createPolyline/fetch counts below would climb.
+	test('promotes the newly expanded route and demotes the previous one, without any createPolyline or fetch call', async () => {
+		const { mapProvider, polyC, poly22 } = makePromotableProvider();
+		const { rerender } = render(StopRoutesLayer, {
+			props: {
+				mapProvider,
+				activeRoutes: routes,
+				routeColors: colors,
+				promotedRouteId: null,
+				highlightedTripId: null
+			}
+		});
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
+		const fetchCallsBefore = global.fetch.mock.calls.length;
+		// The very first draw's own teardown() (there's nothing to tear down
+		// yet, but it always runs) already calls clearAllPolylines() once —
+		// baseline off that rather than asserting zero calls.
+		const clearCallsBefore = mapProvider.clearAllPolylines.mock.calls.length;
+
+		await rerender({ promotedRouteId: 'r_c', highlightedTripId: 't_c' });
+		await flush();
+
+		expect(mapProvider.setPolylineLayer).toHaveBeenCalledWith(polyC, ROUTE_PANE.PROMOTED);
+
+		mapProvider.setPolylineLayer.mockClear();
+		await rerender({ promotedRouteId: 'r_22', highlightedTripId: 't_22' });
+		await flush();
+
+		expect(mapProvider.setPolylineLayer).toHaveBeenCalledWith(polyC, ROUTE_PANE.LINE);
+		expect(mapProvider.setPolylineLayer).toHaveBeenCalledWith(poly22, ROUTE_PANE.PROMOTED);
+
+		expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2);
+		expect(global.fetch.mock.calls.length).toBe(fetchCallsBefore);
+		expect(mapProvider.clearAllPolylines.mock.calls.length).toBe(clearCallsBefore);
+	});
+
+	test('changing highlightedTripId forces an immediate vehicle refresh without redrawing', async () => {
+		const mapProvider = makeProvider();
+		const { rerender } = render(StopRoutesLayer, {
+			props: {
+				mapProvider,
+				activeRoutes: routes,
+				routeColors: colors,
+				promotedRouteId: null,
+				highlightedTripId: null
+			}
+		});
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
+		await vi.waitFor(() => expect(fetchAndUpdateVehiclesForRoutes).toHaveBeenCalled());
+		const { tick } = await fetchAndUpdateVehiclesForRoutes.mock.results[0].value;
+		const fetchCallsBefore = global.fetch.mock.calls.length;
+
+		await rerender({ highlightedTripId: 't_22' });
+		await flush();
+
+		expect(tick).toHaveBeenCalled();
+		expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2);
+		expect(global.fetch.mock.calls.length).toBe(fetchCallsBefore);
+	});
+
+	// promotedRouteId can legitimately name a route whose shape fetch failed —
+	// there is nothing drawn for it to re-pane, and that must not throw or call
+	// setPolylineLayer with an undefined polyline.
+	test('a promotedRouteId with no drawn polyline is a no-op', async () => {
+		const mapProvider = makeProvider();
+		const { rerender } = render(StopRoutesLayer, {
+			props: {
+				mapProvider,
+				activeRoutes: routes,
+				routeColors: colors,
+				promotedRouteId: null,
+				highlightedTripId: null
+			}
+		});
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
+
+		await rerender({ promotedRouteId: 'r_never_drawn', highlightedTripId: null });
+		await flush();
+
+		expect(mapProvider.setPolylineLayer).not.toHaveBeenCalled();
 	});
 });

--- a/src/components/map/__tests__/StopRoutesLayer.test.js
+++ b/src/components/map/__tests__/StopRoutesLayer.test.js
@@ -577,4 +577,84 @@ describe('StopRoutesLayer — trip expansion (promote route / highlight vehicle)
 
 		expect(mapProvider.setPolylineLayer).not.toHaveBeenCalled();
 	});
+
+	// IMPORTANT finding: OSM's setPolylineLayer(poly, ROUTE_PANE.LINE) does
+	// remove()+addTo(), which appends the demoted route's <path> to the LINE
+	// pane's SVG container — making it frontmost regardless of its
+	// drawRoutes index. In a 3-route corridor this leaves the widest route
+	// (index 0, drawn backmost on purpose so its casing shows as a fringe
+	// beside its neighbors) painting over a narrower one once it is demoted
+	// back out of the promoted pane. The fix must re-issue drawRoutes'
+	// ascending-index bringToFront pass over the non-promoted routes after
+	// every promote/demote.
+	test('restores LINE-pane paint order (widest backmost) after demoting a route back from promoted', async () => {
+		const threeRoutes = [
+			...routes,
+			{ id: 'r_x', shortName: 'X', type: 3, tripId: 't_x', gtfsColor: '000000' }
+		];
+		const threeColors = new Map(colors);
+		threeColors.set('r_x', { line: '#000000', badgeBg: '000000', badgeFg: 'ffffff' });
+
+		const callOrder = [];
+		const polyC = { id: 'poly_c', bringToFront: vi.fn(() => callOrder.push('poly_c')) };
+		const poly22 = { id: 'poly_22', bringToFront: vi.fn(() => callOrder.push('poly_22')) };
+		const polyX = { id: 'poly_x', bringToFront: vi.fn(() => callOrder.push('poly_x')) };
+		const mapProvider = {
+			createPolyline: vi.fn(async (points, options) => {
+				if (options.color === '#b02a37') return polyC;
+				if (options.color === '#e0a021') return poly22;
+				return polyX;
+			}),
+			revealPolylines: vi.fn(),
+			clearAllPolylines: vi.fn(),
+			clearVehicleMarkers: vi.fn(),
+			removePolyline: vi.fn(),
+			setPolylineLayer: vi.fn()
+		};
+
+		const { rerender } = render(StopRoutesLayer, {
+			props: {
+				mapProvider,
+				activeRoutes: threeRoutes,
+				routeColors: threeColors,
+				promotedRouteId: null,
+				highlightedTripId: null
+			}
+		});
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(3));
+
+		// Promote r_c (index 0, the widest — the shared-corridor route), then
+		// isolate what happens next: reset the bringToFront spies so only the
+		// promotion effect's own calls remain.
+		await rerender({ promotedRouteId: 'r_c', highlightedTripId: 't_c' });
+		await flush();
+		callOrder.length = 0;
+		polyC.bringToFront.mockClear();
+		poly22.bringToFront.mockClear();
+		polyX.bringToFront.mockClear();
+
+		// Now promote r_22 instead: r_c is demoted back to ROUTE_PANE.LINE,
+		// landing frontmost under the unfixed OSM behavior. r_x (index 2) was
+		// never disturbed and stays in LINE throughout.
+		await rerender({ promotedRouteId: 'r_22', highlightedTripId: 't_22' });
+		await flush();
+
+		expect(mapProvider.setPolylineLayer).toHaveBeenCalledWith(polyC, ROUTE_PANE.LINE);
+		expect(mapProvider.setPolylineLayer).toHaveBeenCalledWith(poly22, ROUTE_PANE.PROMOTED);
+
+		// Paint order must be re-asserted in index order over the two routes
+		// now sharing the LINE pane (r_c index 0, r_x index 2), the same way
+		// drawRoutes does: ascending by index, last call wins, so the higher
+		// index ends up frontmost and the demoted widest route (r_c) goes
+		// back to the bottom of the stack rather than staying on top of it.
+		expect(polyC.bringToFront).toHaveBeenCalled();
+		expect(polyX.bringToFront).toHaveBeenCalled();
+		expect(callOrder.indexOf('poly_c')).toBeLessThan(callOrder.lastIndexOf('poly_x'));
+		expect(callOrder[callOrder.length - 1]).toBe('poly_x');
+		// The freshly promoted route lives in its own pane above LINE and is
+		// excluded from this reassert.
+		expect(poly22.bringToFront).not.toHaveBeenCalled();
+
+		expect(mapProvider.createPolyline).toHaveBeenCalledTimes(3);
+	});
 });

--- a/src/components/map/__tests__/StopRoutesLayer.test.js
+++ b/src/components/map/__tests__/StopRoutesLayer.test.js
@@ -5,9 +5,12 @@ import { ROUTE_PANE } from '$lib/mapPanes.js';
 
 vi.mock('$lib/vehicleUtils.js', () => ({
 	fetchAndUpdateVehiclesForRoutes: vi.fn().mockResolvedValue({ intervalId: 42, tick: vi.fn() }),
-	clearVehicleMarkersMap: vi.fn()
+	removeVehicleMarkersForRoutes: vi.fn()
 }));
-import { fetchAndUpdateVehiclesForRoutes, clearVehicleMarkersMap } from '$lib/vehicleUtils.js';
+import {
+	fetchAndUpdateVehiclesForRoutes,
+	removeVehicleMarkersForRoutes
+} from '$lib/vehicleUtils.js';
 import { createLayerBindings } from './support/layerBindings.svelte.js';
 
 function makeProvider() {
@@ -239,6 +242,7 @@ describe('StopRoutesLayer', () => {
 		const { unmount } = render(StopRoutesLayer, {
 			props: { mapProvider, activeRoutes: routes, routeColors: colors }
 		});
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
 		await vi.waitFor(() => expect(fetchAndUpdateVehiclesForRoutes).toHaveBeenCalled());
 		// Flush the resolved fetchAndUpdateVehiclesForRoutes promise so
 		// vehicleIntervalId is actually assigned before we unmount and assert
@@ -248,11 +252,62 @@ describe('StopRoutesLayer', () => {
 		const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
 		unmount();
 
-		expect(mapProvider.clearAllPolylines).toHaveBeenCalled();
-		expect(mapProvider.clearVehicleMarkers).toHaveBeenCalled();
-		expect(clearVehicleMarkersMap).toHaveBeenCalled();
+		// Self-scoped teardown: exactly the two polylines this layer drew, not a
+		// map-wide clear (which would also strip anything a sibling component
+		// drew, e.g. a route SearchPane just drew over an open stop sheet).
+		expect(mapProvider.removePolyline).toHaveBeenCalledTimes(2);
+		expect(removeVehicleMarkersForRoutes).toHaveBeenCalledWith(
+			expect.arrayContaining(['r_c', 'r_22']),
+			mapProvider
+		);
 		expect(clearIntervalSpy).toHaveBeenCalledWith(42);
 		clearIntervalSpy.mockRestore();
+	});
+
+	// The headline regression this diff guards against (strand-route-on-search-
+	// select): teardown used to call the map-wide clearAllPolylines(), which
+	// would also strip a polyline a sibling component drew directly on the
+	// shared provider — e.g. SearchPane drawing a newly selected route while a
+	// stop sheet (and therefore this layer) was still open. This provider fake
+	// models the map's actual polyline set, including a "foreign" polyline
+	// never handed to this layer, so a map-wide clear is distinguishable from a
+	// self-scoped one. Fails against the old `mapProvider.clearAllPolylines()`
+	// teardown, which would empty `onMap` entirely.
+	test('removes only its own polylines on teardown, leaving a foreign one (e.g. one SearchPane just drew) untouched', async () => {
+		const onMap = new Set();
+		let nextId = 0;
+		const mapProvider = {
+			createPolyline: vi.fn(async () => {
+				const polyline = { id: `own-${nextId++}` };
+				onMap.add(polyline);
+				return polyline;
+			}),
+			revealPolylines: vi.fn(),
+			clearAllPolylines: vi.fn(() => onMap.clear()),
+			clearVehicleMarkers: vi.fn(),
+			removePolyline: vi.fn((polyline) => onMap.delete(polyline)),
+			setPolylineLayer: vi.fn()
+		};
+
+		const { unmount } = render(StopRoutesLayer, {
+			props: { mapProvider, activeRoutes: routes, routeColors: colors }
+		});
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
+		const ownPolylines = [...onMap];
+		expect(ownPolylines).toHaveLength(2);
+
+		// A route SearchPane drew directly on the shared provider — this layer
+		// never created it and has no reference to it.
+		const foreignPolyline = { id: 'searchpane-route' };
+		onMap.add(foreignPolyline);
+
+		unmount();
+
+		expect(onMap.has(foreignPolyline)).toBe(true);
+		for (const polyline of ownPolylines) {
+			expect(onMap.has(polyline)).toBe(false);
+		}
+		expect(mapProvider.clearAllPolylines).not.toHaveBeenCalled();
 	});
 
 	// Finding 1 (CRITICAL): StopPane polls arrivals every 30s, and
@@ -267,7 +322,7 @@ describe('StopRoutesLayer', () => {
 		});
 		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
 		const fetchCallsAfterFirstDraw = global.fetch.mock.calls.length;
-		const clearCallsAfterFirstDraw = mapProvider.clearAllPolylines.mock.calls.length;
+		const removeCallsAfterFirstDraw = mapProvider.removePolyline.mock.calls.length;
 
 		const sameRoutes = routes.map((route) => ({ ...route }));
 		const sameColors = new Map(Array.from(colors, ([id, value]) => [id, { ...value }]));
@@ -276,7 +331,7 @@ describe('StopRoutesLayer', () => {
 
 		expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2);
 		expect(global.fetch.mock.calls.length).toBe(fetchCallsAfterFirstDraw);
-		expect(mapProvider.clearAllPolylines.mock.calls.length).toBe(clearCallsAfterFirstDraw);
+		expect(mapProvider.removePolyline.mock.calls.length).toBe(removeCallsAfterFirstDraw);
 	});
 
 	test('does redraw when the route set actually changes', async () => {
@@ -291,7 +346,14 @@ describe('StopRoutesLayer', () => {
 		await rerender({ mapProvider, activeRoutes: routes, routeColors: changedColors });
 
 		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(4));
-		expect(mapProvider.clearAllPolylines).toHaveBeenCalledTimes(2);
+		// The redraw's own teardown removes exactly the two polylines the
+		// previous draw produced (the first mount's teardown had nothing to
+		// remove yet).
+		expect(mapProvider.removePolyline).toHaveBeenCalledTimes(2);
+		expect(removeVehicleMarkersForRoutes).toHaveBeenCalledWith(
+			expect.arrayContaining(['r_c', 'r_22']),
+			mapProvider
+		);
 	});
 
 	// Finding 2 (CRITICAL): a cold deep-link whose arrivals land before
@@ -315,14 +377,18 @@ describe('StopRoutesLayer', () => {
 		const { rerender } = render(StopRoutesLayer, {
 			props: { mapProvider, activeRoutes: routes, routeColors: colors }
 		});
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
 		await vi.waitFor(() => expect(fetchAndUpdateVehiclesForRoutes).toHaveBeenCalled());
 		await flush();
 
 		const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
 		await rerender({ mapProvider, activeRoutes: [], routeColors: new Map() });
 
-		expect(mapProvider.clearAllPolylines).toHaveBeenCalled();
-		expect(mapProvider.clearVehicleMarkers).toHaveBeenCalled();
+		expect(mapProvider.removePolyline).toHaveBeenCalledTimes(2);
+		expect(removeVehicleMarkersForRoutes).toHaveBeenCalledWith(
+			expect.arrayContaining(['r_c', 'r_22']),
+			mapProvider
+		);
 		expect(clearIntervalSpy).toHaveBeenCalledWith(42);
 		clearIntervalSpy.mockRestore();
 	});
@@ -510,10 +576,7 @@ describe('StopRoutesLayer — trip expansion (promote route / highlight vehicle)
 		});
 		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
 		const fetchCallsBefore = global.fetch.mock.calls.length;
-		// The very first draw's own teardown() (there's nothing to tear down
-		// yet, but it always runs) already calls clearAllPolylines() once —
-		// baseline off that rather than asserting zero calls.
-		const clearCallsBefore = mapProvider.clearAllPolylines.mock.calls.length;
+		const removeCallsBefore = mapProvider.removePolyline.mock.calls.length;
 
 		await rerender({ promotedRouteId: 'r_c', highlightedTripId: 't_c' });
 		await flush();
@@ -529,7 +592,8 @@ describe('StopRoutesLayer — trip expansion (promote route / highlight vehicle)
 
 		expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2);
 		expect(global.fetch.mock.calls.length).toBe(fetchCallsBefore);
-		expect(mapProvider.clearAllPolylines.mock.calls.length).toBe(clearCallsBefore);
+		// Promoting/demoting must not tear down and redraw anything.
+		expect(mapProvider.removePolyline.mock.calls.length).toBe(removeCallsBefore);
 	});
 
 	test('changing highlightedTripId forces an immediate vehicle refresh without redrawing', async () => {

--- a/src/components/map/__tests__/StopRoutesLayer.test.js
+++ b/src/components/map/__tests__/StopRoutesLayer.test.js
@@ -14,8 +14,17 @@ function makeProvider() {
 		createPolyline: vi.fn(async () => ({ id: 'polyline' })),
 		revealPolylines: vi.fn(),
 		clearAllPolylines: vi.fn(),
-		clearVehicleMarkers: vi.fn()
+		clearVehicleMarkers: vi.fn(),
+		removePolyline: vi.fn()
 	};
+}
+
+// Give a microtask-flushing macrotask a chance to run: e.g. so a resolved
+// mock promise's .then() continuation (which sets vehicleIntervalId, or a
+// guarded redraw's early return) has actually executed before we assert on
+// its effects.
+function flush(ms = 0) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 const routes = [
@@ -79,9 +88,45 @@ describe('StopRoutesLayer', () => {
 	// macro that only compiles in a .svelte/.svelte.js module — so a plain
 	// .test.js can't create the proxy to read back. Use a support harness, the
 	// same pattern as the existing support/reactiveStop.svelte.js.
-	test('reports the ring-dot stops from the drawn trips', async () => {
-		const mapProvider = makeProvider();
+	test('reports the ring-dot stops from the drawn trips, with a shared stop won by the lower-index (sooner-arriving) route', async () => {
 		const bindings = createLayerBindings();
+		const mapProvider = makeProvider();
+
+		// r_c is index 0 (soonest arrival, top priority) but its trip-details
+		// response is delayed so it resolves *after* r_22 (index 1) — proving a
+		// shared stop is claimed by index priority, not by whichever shape
+		// happens to resolve first over the network.
+		global.fetch = vi.fn(async (url) => {
+			if (url.includes('/trip-details/t_c')) {
+				await flush(20);
+				return {
+					ok: true,
+					json: async () => ({
+						data: {
+							entry: {
+								schedule: { stopTimes: [{ stopId: 'shared_stop' }, { stopId: 'stop_c_only' }] }
+							},
+							references: { trips: [{ id: 't_c', shapeId: 'shape_t_c' }] }
+						}
+					})
+				};
+			}
+			if (url.includes('/trip-details/t_22')) {
+				return {
+					ok: true,
+					json: async () => ({
+						data: {
+							entry: {
+								schedule: { stopTimes: [{ stopId: 'shared_stop' }, { stopId: 'stop_22_only' }] }
+							},
+							references: { trips: [{ id: 't_22', shapeId: 'shape_t_22' }] }
+						}
+					})
+				};
+			}
+			return { ok: true, json: async () => ({ data: { entry: { points: 'encoded' } } }) };
+		});
+
 		render(StopRoutesLayer, {
 			props: {
 				mapProvider,
@@ -96,17 +141,87 @@ describe('StopRoutesLayer', () => {
 			}
 		});
 
-		await vi.waitFor(() => expect(bindings.routeStopIds.size).toBe(2));
-		expect(bindings.routeStopIds.get('stop_t_c')).toBe('#b02a37');
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
+		expect(bindings.routeStopIds.get('shared_stop')).toBe('#b02a37');
+		expect(bindings.routeStopIds.get('stop_c_only')).toBe('#b02a37');
+		expect(bindings.routeStopIds.get('stop_22_only')).toBe('#e0a021');
+	});
+
+	test('restores paint order to index priority after every resolution, regardless of arrival order', async () => {
+		const callOrder = [];
+		const polyC = { id: 'poly_c', bringToFront: vi.fn(() => callOrder.push('poly_c')) };
+		const poly22 = { id: 'poly_22', bringToFront: vi.fn(() => callOrder.push('poly_22')) };
+
+		// r_22 (index 1, narrower) resolves first; r_c (index 0, wider) resolves
+		// later. If paint order just followed resolution order, the wider route
+		// would end up on top last and cover the narrower one entirely.
+		global.fetch = vi.fn(async (url) => {
+			if (url.includes('/trip-details/t_c')) {
+				await flush(20);
+				return {
+					ok: true,
+					json: async () => ({
+						data: {
+							entry: { schedule: { stopTimes: [] } },
+							references: { trips: [{ id: 't_c', shapeId: 'shape_t_c' }] }
+						}
+					})
+				};
+			}
+			if (url.includes('/trip-details/t_22')) {
+				return {
+					ok: true,
+					json: async () => ({
+						data: {
+							entry: { schedule: { stopTimes: [] } },
+							references: { trips: [{ id: 't_22', shapeId: 'shape_t_22' }] }
+						}
+					})
+				};
+			}
+			return { ok: true, json: async () => ({ data: { entry: { points: 'encoded' } } }) };
+		});
+
+		const mapProvider = {
+			createPolyline: vi.fn(async (points, options) =>
+				options.color === '#b02a37' ? polyC : poly22
+			),
+			revealPolylines: vi.fn(),
+			clearAllPolylines: vi.fn(),
+			clearVehicleMarkers: vi.fn(),
+			removePolyline: vi.fn()
+		};
+
+		render(StopRoutesLayer, { props: { mapProvider, activeRoutes: routes, routeColors: colors } });
+
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
+		// The narrower route (higher index) must be the last one brought to
+		// front, so it ends up frontmost regardless of arrival order.
+		expect(callOrder[callOrder.length - 1]).toBe('poly_22');
 	});
 
 	test('drops a route whose shape fetch fails without losing the others', async () => {
+		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 		mockShapeFetches({ failRouteId: 'r_22' });
 		const mapProvider = makeProvider();
 		render(StopRoutesLayer, { props: { mapProvider, activeRoutes: routes, routeColors: colors } });
 
 		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(1));
 		expect(mapProvider.createPolyline.mock.calls[0][1].color).toBe('#b02a37');
+
+		// Prove the second route actually failed rather than just being slow:
+		// give its (already-settled) rejected fetch time to reach drawRoutes,
+		// then assert createPolyline never gets a second call and the failure
+		// was logged for the right route.
+		await flush(20);
+		expect(mapProvider.createPolyline).toHaveBeenCalledTimes(1);
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			'StopRoutesLayer: could not load shape',
+			'r_22',
+			expect.any(Error)
+		);
+
+		consoleErrorSpy.mockRestore();
 	});
 
 	test('starts one vehicle poll for all routes', async () => {
@@ -123,11 +238,230 @@ describe('StopRoutesLayer', () => {
 			props: { mapProvider, activeRoutes: routes, routeColors: colors }
 		});
 		await vi.waitFor(() => expect(fetchAndUpdateVehiclesForRoutes).toHaveBeenCalled());
+		// Flush the resolved fetchAndUpdateVehiclesForRoutes promise so
+		// vehicleIntervalId is actually assigned before we unmount and assert
+		// clearInterval ran on it — not just that the interval was requested.
+		await flush();
 
+		const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
 		unmount();
 
 		expect(mapProvider.clearAllPolylines).toHaveBeenCalled();
 		expect(mapProvider.clearVehicleMarkers).toHaveBeenCalled();
 		expect(clearVehicleMarkersMap).toHaveBeenCalled();
+		expect(clearIntervalSpy).toHaveBeenCalledWith(42);
+		clearIntervalSpy.mockRestore();
+	});
+
+	// Finding 1 (CRITICAL): StopPane polls arrivals every 30s, and
+	// MapExperience's $derived recomputes activeRoutes/routeColors from
+	// scratch every poll, handing this layer a fresh array/Map with identical
+	// content. Keying the redraw on identity tore everything down and redrew
+	// it on every poll.
+	test('does not redraw when activeRoutes/routeColors are new but structurally identical', async () => {
+		const mapProvider = makeProvider();
+		const { rerender } = render(StopRoutesLayer, {
+			props: { mapProvider, activeRoutes: routes, routeColors: colors }
+		});
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
+		const fetchCallsAfterFirstDraw = global.fetch.mock.calls.length;
+		const clearCallsAfterFirstDraw = mapProvider.clearAllPolylines.mock.calls.length;
+
+		const sameRoutes = routes.map((route) => ({ ...route }));
+		const sameColors = new Map(Array.from(colors, ([id, value]) => [id, { ...value }]));
+		await rerender({ mapProvider, activeRoutes: sameRoutes, routeColors: sameColors });
+		await flush();
+
+		expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2);
+		expect(global.fetch.mock.calls.length).toBe(fetchCallsAfterFirstDraw);
+		expect(mapProvider.clearAllPolylines.mock.calls.length).toBe(clearCallsAfterFirstDraw);
+	});
+
+	test('does redraw when the route set actually changes', async () => {
+		const mapProvider = makeProvider();
+		const { rerender } = render(StopRoutesLayer, {
+			props: { mapProvider, activeRoutes: routes, routeColors: colors }
+		});
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
+
+		const changedColors = new Map(colors);
+		changedColors.set('r_c', { ...colors.get('r_c'), line: '#000000' });
+		await rerender({ mapProvider, activeRoutes: routes, routeColors: changedColors });
+
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(4));
+		expect(mapProvider.clearAllPolylines).toHaveBeenCalledTimes(2);
+	});
+
+	// Finding 2 (CRITICAL): a cold deep-link whose arrivals land before
+	// initMap() resolves mounts this layer with mapProvider still null;
+	// closing the sheet before the map finishes initializing must not throw
+	// out of the destroy chain and abort sibling teardowns.
+	test('does not throw on destroy when mapProvider is null', async () => {
+		const { unmount } = render(StopRoutesLayer, {
+			props: { mapProvider: null, activeRoutes: routes, routeColors: colors }
+		});
+		await flush();
+
+		expect(() => unmount()).not.toThrow();
+	});
+
+	// Finding 3 (IMPORTANT): the route set going empty must tear everything
+	// down (polylines, vehicle markers, the poll interval), not leave the
+	// previous selection live on the map indefinitely.
+	test('tears down and stops polling when the route set goes empty', async () => {
+		const mapProvider = makeProvider();
+		const { rerender } = render(StopRoutesLayer, {
+			props: { mapProvider, activeRoutes: routes, routeColors: colors }
+		});
+		await vi.waitFor(() => expect(fetchAndUpdateVehiclesForRoutes).toHaveBeenCalled());
+		await flush();
+
+		const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+		await rerender({ mapProvider, activeRoutes: [], routeColors: new Map() });
+
+		expect(mapProvider.clearAllPolylines).toHaveBeenCalled();
+		expect(mapProvider.clearVehicleMarkers).toHaveBeenCalled();
+		expect(clearIntervalSpy).toHaveBeenCalledWith(42);
+		clearIntervalSpy.mockRestore();
+	});
+
+	// Finding 5 (IMPORTANT): Google's createPolyline is async (it awaits
+	// importLibrary), so a supersede's clearAllPolylines() can run before a
+	// stale create resolves. The stale create must not orphan its polyline on
+	// the map.
+	test('removes a polyline that resolves after a newer selection has superseded it', async () => {
+		let resolveStaleCreate;
+		const staleCreatePromise = new Promise((resolve) => {
+			resolveStaleCreate = resolve;
+		});
+		const stalePolyline = { id: 'stale' };
+		const freshPolyline = { id: 'fresh' };
+		let createCalls = 0;
+
+		const mapProvider = {
+			createPolyline: vi.fn(async () => {
+				createCalls++;
+				if (createCalls === 1) {
+					return staleCreatePromise.then(() => stalePolyline);
+				}
+				return freshPolyline;
+			}),
+			revealPolylines: vi.fn(),
+			clearAllPolylines: vi.fn(),
+			clearVehicleMarkers: vi.fn(),
+			removePolyline: vi.fn()
+		};
+
+		const { rerender } = render(StopRoutesLayer, {
+			props: { mapProvider, activeRoutes: [routes[0]], routeColors: colors }
+		});
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(1));
+
+		// Supersede before the first create resolves.
+		await rerender({ mapProvider, activeRoutes: [routes[1]], routeColors: colors });
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
+
+		resolveStaleCreate();
+		await vi.waitFor(() => expect(mapProvider.removePolyline).toHaveBeenCalledWith(stalePolyline));
+	});
+
+	// Finding 6 (IMPORTANT): drawRoutes(...) and the vehicle-poll .then(...)
+	// chain both run detached from the effect, with no .catch — a throw from
+	// createPolyline (outside fetchRouteShape's own try/catch) must not
+	// produce an unhandled promise rejection.
+	test('does not produce an unhandled rejection when createPolyline throws', async () => {
+		const unhandled = [];
+		const onUnhandledRejection = (reason) => unhandled.push(reason);
+		process.on('unhandledRejection', onUnhandledRejection);
+		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		const mapProvider = {
+			createPolyline: vi.fn(async () => {
+				throw new Error('boom');
+			}),
+			revealPolylines: vi.fn(),
+			clearAllPolylines: vi.fn(),
+			clearVehicleMarkers: vi.fn(),
+			removePolyline: vi.fn()
+		};
+
+		render(StopRoutesLayer, { props: { mapProvider, activeRoutes: routes, routeColors: colors } });
+
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalled());
+		await flush(20);
+
+		process.off('unhandledRejection', onUnhandledRejection);
+		consoleErrorSpy.mockRestore();
+		expect(unhandled).toHaveLength(0);
+	});
+
+	// Finding 7 (IMPORTANT): routeStopIds must not go stale across a stop
+	// switch — it's cleared at the top of drawRoutes rather than only once a
+	// (possibly failing) shape resolves.
+	test('clears routeStopIds immediately on a redraw, before any shape resolves', async () => {
+		const bindings = createLayerBindings();
+		const mapProvider = makeProvider();
+		const { rerender } = render(StopRoutesLayer, {
+			props: {
+				mapProvider,
+				activeRoutes: routes,
+				routeColors: colors,
+				get routeStopIds() {
+					return bindings.routeStopIds;
+				},
+				set routeStopIds(value) {
+					bindings.routeStopIds = value;
+				}
+			}
+		});
+		await vi.waitFor(() => expect(bindings.routeStopIds.size).toBe(2));
+
+		// A new stop's routes, all of whose shapes will fail to fetch — the
+		// previous stop's ring dots must not linger.
+		global.fetch = vi.fn(async () => ({ ok: false, status: 500 }));
+		const otherRoutes = [
+			{ id: 'r_x', shortName: 'X', type: 3, tripId: 't_x', gtfsColor: '000000' }
+		];
+		const otherColors = new Map([['r_x', { line: '#000000', badgeBg: '000000', badgeFg: 'fff' }]]);
+		await rerender({ mapProvider, activeRoutes: otherRoutes, routeColors: otherColors });
+
+		expect(bindings.routeStopIds.size).toBe(0);
+	});
+
+	// The headline regression this diff guards against: deleting both
+	// untrack() calls currently leaves every other test passing, because
+	// promotedRouteId/highlightedTripId only affect trip-expansion styling
+	// that these tests don't otherwise observe.
+	test('does not re-run the redraw effect when promotedRouteId or highlightedTripId change', async () => {
+		const mapProvider = makeProvider();
+		const colorGetSpy = vi.spyOn(colors, 'get');
+		const { rerender } = render(StopRoutesLayer, {
+			props: {
+				mapProvider,
+				activeRoutes: routes,
+				routeColors: colors,
+				promotedRouteId: null,
+				highlightedTripId: null
+			}
+		});
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
+		const fetchCallsBefore = global.fetch.mock.calls.length;
+		const colorGetCallsBefore = colorGetSpy.mock.calls.length;
+
+		// Partial props only: reassigning activeRoutes/routeColors themselves
+		// (even to the same reference) makes the test harness's $state props
+		// wrapper treat them as changed, which would mask what we're testing.
+		// Changing only promotedRouteId/highlightedTripId isolates it.
+		await rerender({ promotedRouteId: 'r_c', highlightedTripId: 't_c' });
+		await flush();
+
+		expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2);
+		expect(global.fetch.mock.calls.length).toBe(fetchCallsBefore);
+		// If the effect re-ran at all (even if guarded from redrawing by the
+		// content signature), it would recompute the signature and read
+		// colors.get() again for every route.
+		expect(colorGetSpy.mock.calls.length).toBe(colorGetCallsBefore);
+
+		colorGetSpy.mockRestore();
 	});
 });

--- a/src/components/map/__tests__/StopRoutesLayer.test.js
+++ b/src/components/map/__tests__/StopRoutesLayer.test.js
@@ -1,0 +1,133 @@
+import { render } from '@testing-library/svelte';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import StopRoutesLayer from '../StopRoutesLayer.svelte';
+
+vi.mock('$lib/vehicleUtils.js', () => ({
+	fetchAndUpdateVehiclesForRoutes: vi.fn().mockResolvedValue(42),
+	clearVehicleMarkersMap: vi.fn()
+}));
+import { fetchAndUpdateVehiclesForRoutes, clearVehicleMarkersMap } from '$lib/vehicleUtils.js';
+import { createLayerBindings } from './support/layerBindings.svelte.js';
+
+function makeProvider() {
+	return {
+		createPolyline: vi.fn(async () => ({ id: 'polyline' })),
+		revealPolylines: vi.fn(),
+		clearAllPolylines: vi.fn(),
+		clearVehicleMarkers: vi.fn()
+	};
+}
+
+const routes = [
+	{ id: 'r_c', shortName: 'C Line', type: 3, tripId: 't_c', gtfsColor: 'b02a37' },
+	{ id: 'r_22', shortName: '22', type: 3, tripId: 't_22', gtfsColor: 'e0a021' }
+];
+const colors = new Map([
+	['r_c', { line: '#b02a37', badgeBg: 'b02a37', badgeFg: 'ffffff' }],
+	['r_22', { line: '#e0a021', badgeBg: 'e0a021', badgeFg: '000000' }]
+]);
+
+function mockShapeFetches({ failRouteId = null } = {}) {
+	global.fetch = vi.fn(async (url) => {
+		if (url.includes('/trip-details/')) {
+			const tripId = url.split('/trip-details/')[1].split('?')[0];
+			if (failRouteId && tripId === `t_${failRouteId.replace('r_', '')}`) {
+				return { ok: false, status: 500 };
+			}
+			return {
+				ok: true,
+				json: async () => ({
+					data: {
+						entry: { schedule: { stopTimes: [{ stopId: `stop_${tripId}` }] } },
+						references: { trips: [{ id: tripId, shapeId: `shape_${tripId}` }] }
+					}
+				})
+			};
+		}
+		return { ok: true, json: async () => ({ data: { entry: { points: 'encoded' } } }) };
+	});
+}
+
+describe('StopRoutesLayer', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockShapeFetches();
+	});
+
+	test('draws one polyline per active route, in its resolved color', async () => {
+		const mapProvider = makeProvider();
+		render(StopRoutesLayer, { props: { mapProvider, activeRoutes: routes, routeColors: colors } });
+
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
+		const usedColors = mapProvider.createPolyline.mock.calls.map(([, options]) => options.color);
+		expect(usedColors).toEqual(expect.arrayContaining(['#b02a37', '#e0a021']));
+	});
+
+	test('requests casings and skips the status payload it does not need', async () => {
+		const mapProvider = makeProvider();
+		render(StopRoutesLayer, { props: { mapProvider, activeRoutes: routes, routeColors: colors } });
+
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalled());
+		expect(mapProvider.createPolyline.mock.calls[0][1].casing).toBe(true);
+		const tripDetailsUrl = global.fetch.mock.calls
+			.map(([url]) => url)
+			.find((u) => u.includes('/trip-details/'));
+		expect(tripDetailsUrl).toContain('includeStatus=false');
+	});
+
+	// $bindable writes land on the parent's reactive state, and $state is a runes
+	// macro that only compiles in a .svelte/.svelte.js module — so a plain
+	// .test.js can't create the proxy to read back. Use a support harness, the
+	// same pattern as the existing support/reactiveStop.svelte.js.
+	test('reports the ring-dot stops from the drawn trips', async () => {
+		const mapProvider = makeProvider();
+		const bindings = createLayerBindings();
+		render(StopRoutesLayer, {
+			props: {
+				mapProvider,
+				activeRoutes: routes,
+				routeColors: colors,
+				get routeStopIds() {
+					return bindings.routeStopIds;
+				},
+				set routeStopIds(value) {
+					bindings.routeStopIds = value;
+				}
+			}
+		});
+
+		await vi.waitFor(() => expect(bindings.routeStopIds.size).toBe(2));
+		expect(bindings.routeStopIds.get('stop_t_c')).toBe('#b02a37');
+	});
+
+	test('drops a route whose shape fetch fails without losing the others', async () => {
+		mockShapeFetches({ failRouteId: 'r_22' });
+		const mapProvider = makeProvider();
+		render(StopRoutesLayer, { props: { mapProvider, activeRoutes: routes, routeColors: colors } });
+
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(1));
+		expect(mapProvider.createPolyline.mock.calls[0][1].color).toBe('#b02a37');
+	});
+
+	test('starts one vehicle poll for all routes', async () => {
+		const mapProvider = makeProvider();
+		render(StopRoutesLayer, { props: { mapProvider, activeRoutes: routes, routeColors: colors } });
+
+		await vi.waitFor(() => expect(fetchAndUpdateVehiclesForRoutes).toHaveBeenCalledTimes(1));
+		expect(fetchAndUpdateVehiclesForRoutes.mock.calls[0][0]).toHaveLength(2);
+	});
+
+	test('tears down polylines, vehicles, and the interval on destroy', async () => {
+		const mapProvider = makeProvider();
+		const { unmount } = render(StopRoutesLayer, {
+			props: { mapProvider, activeRoutes: routes, routeColors: colors }
+		});
+		await vi.waitFor(() => expect(fetchAndUpdateVehiclesForRoutes).toHaveBeenCalled());
+
+		unmount();
+
+		expect(mapProvider.clearAllPolylines).toHaveBeenCalled();
+		expect(mapProvider.clearVehicleMarkers).toHaveBeenCalled();
+		expect(clearVehicleMarkersMap).toHaveBeenCalled();
+	});
+});

--- a/src/components/map/__tests__/support/layerBindings.svelte.js
+++ b/src/components/map/__tests__/support/layerBindings.svelte.js
@@ -1,0 +1,21 @@
+// Test-only helper: $state is a runes macro, so it only compiles inside a
+// .svelte/.svelte.js module — a plain .test.js can't create the reactive proxy
+// a $bindable prop writes back into. Mirrors support/reactiveStop.svelte.js.
+export function createLayerBindings() {
+	let routeStopIds = $state(new Map());
+	let liveCounts = $state(new Map());
+	return {
+		get routeStopIds() {
+			return routeStopIds;
+		},
+		set routeStopIds(value) {
+			routeStopIds = value;
+		},
+		get liveCounts() {
+			return liveCounts;
+		},
+		set liveCounts(value) {
+			liveCounts = value;
+		}
+	};
+}

--- a/src/components/stops/StopBottomSheet.svelte
+++ b/src/components/stops/StopBottomSheet.svelte
@@ -11,6 +11,8 @@
     @prop {Function} closePane - Called when the close button is tapped (or Escape is pressed)
     @prop {Function} tripSelected - Forwarded to StopPane; called when a trip is selected
     @prop {Function} handleUpdateRouteMap - Forwarded to StopPane; called when the route map needs updating
+    @prop {any} arrivalsAndDeparturesResponse - Bindable; the latest arrivals response, bound up to MapExperience so the map can draw the routes behind it
+    @prop {Map<string, any>} [routeColors] - Resolved by MapExperience; one color per route, forwarded to the arrival badges
 -->
 
 <script>
@@ -23,9 +25,18 @@
 	import { isLoading, t } from 'svelte-i18n';
 	import { removeAgencyPrefix, routeShortNamesForStop } from '$lib/utils';
 
-	let { stop, closePane, tripSelected, handleUpdateRouteMap, snap = $bindable('half') } = $props();
+	let {
+		stop,
+		closePane,
+		tripSelected,
+		handleUpdateRouteMap,
+		snap = $bindable('half'),
+		// Bound up to MapExperience so the map layer can draw the routes behind
+		// these arrivals without issuing a second fetch.
+		arrivalsAndDeparturesResponse = $bindable(null),
+		routeColors = null
+	} = $props();
 
-	let arrivalsAndDeparturesResponse = $state(null);
 	// Bound from StopPane so the toolbar refresh button can spin while any fetch
 	// (initial, manual, or the 30s poll) is in flight, and trigger a manual one.
 	let stopPane = $state(null);
@@ -101,5 +112,6 @@
 		showHeroCard={false}
 		bind:arrivalsAndDeparturesResponse
 		bind:loading={stopPaneLoading}
+		{routeColors}
 	/>
 </BottomSheet>

--- a/src/components/stops/StopBottomSheet.svelte
+++ b/src/components/stops/StopBottomSheet.svelte
@@ -2,8 +2,9 @@
     @component
     Shows a stop's arrivals and departures in a draggable bottom sheet so the map
     stays visible behind it, at every viewport width. The tall hero card is
-    replaced by a condensed header (stop name, stop number, routes) with circular
-    View Details / View Schedule / Close actions inside the drag-handle row.
+    replaced by a condensed header (stop name; stop number, direction and routes)
+    with a Close button, plus a Refresh / Stop Info action row, inside the
+    drag-handle row.
 
     @prop {Object} stop - Stop object containing stop details
     @prop {('peek'|'half'|'full')} snap - Bindable current snap point of the sheet
@@ -16,12 +17,7 @@
 	import BottomSheet from '$components/navigation/BottomSheet.svelte';
 	import StopPane from '$components/stops/StopPane.svelte';
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
-	import {
-		faCircleInfo,
-		faCalendarDays,
-		faX,
-		faArrowsRotate
-	} from '@fortawesome/free-solid-svg-icons';
+	import { faCircleInfo, faX, faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 	import { keybinding } from '$lib/keybinding';
 	import '$lib/i18n.js';
 	import { isLoading, t } from 'svelte-i18n';
@@ -35,30 +31,44 @@
 	let stopPane = $state(null);
 	let stopPaneLoading = $state(false);
 
-	let actions = $derived([
-		{ href: `/stops/${stop.id}`, icon: faCircleInfo, labelKey: 'stop_details.view_details' },
-		{
-			href: `/stops/${stop.id}/schedule`,
-			icon: faCalendarDays,
-			labelKey: 'schedule_for_stop.view_schedule'
-		}
-	]);
-
 	let routeShortNames = $derived(routeShortNamesForStop(arrivalsAndDeparturesResponse, stop));
+	// "Stop #20170 · SW bound · C, 21, 116, 125" — direction and routes are both
+	// optional, so build the parts list and join only what's present.
 	let subtitle = $derived(
-		`${$isLoading ? '' : $t('stop')} #${removeAgencyPrefix(stop.id)}` +
-			(routeShortNames?.length ? ` · ${routeShortNames.join(', ')}` : '')
+		[
+			`${$isLoading ? '' : $t('stop')} #${removeAgencyPrefix(stop.id)}`,
+			stop.direction && !$isLoading
+				? $t('direction_bound', { values: { direction: stop.direction } })
+				: null,
+			routeShortNames?.length ? routeShortNames.join(', ') : null
+		]
+			.filter(Boolean)
+			.join(' · ')
 	);
 </script>
 
 <BottomSheet bind:snap>
 	{#snippet header()}
-		<div class="flex items-center gap-2.5">
-			<div class="min-w-0 flex-1">
-				<p class="truncate text-base font-semibold text-black dark:text-white">{stop.name}</p>
-				<p class="truncate text-xs text-gray-600 dark:text-gray-400">{subtitle}</p>
+		<!-- Bled out to the sheet's edges (-mx-3.5 undoes the drag row's padding) so
+		     the rule under the header spans its full width, as in the design. -->
+		<div class="-mx-3.5 border-b border-gray-200 px-3.5 pb-3 dark:border-gray-700">
+			<div class="flex items-start gap-2.5">
+				<div class="min-w-0 flex-1">
+					<p class="truncate text-xl font-bold text-black dark:text-white">{stop.name}</p>
+					<p class="truncate text-sm text-gray-600 dark:text-gray-400">{subtitle}</p>
+				</div>
+				<button
+					type="button"
+					onclick={closePane}
+					use:keybinding={{ code: 'Escape' }}
+					class="flex h-9 w-9 flex-none items-center justify-center rounded-full bg-gray-200 text-sm text-black hover:bg-gray-300 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600"
+				>
+					<FontAwesomeIcon icon={faX} />
+					<span class="sr-only">{$isLoading ? '' : $t('sheet.close')}</span>
+				</button>
 			</div>
-			<div class="flex flex-none gap-1.5">
+
+			<div class="mt-3 flex items-center gap-2">
 				<button
 					type="button"
 					onclick={() => stopPane?.refresh()}
@@ -66,31 +76,19 @@
 					title={$isLoading ? '' : $t('refresh')}
 					aria-label={$isLoading ? '' : $t('refresh')}
 					aria-busy={stopPaneLoading}
-					class="flex h-8 w-8 items-center justify-center rounded-full bg-brand-accent text-sm text-white hover:bg-brand-accent-dark disabled:cursor-not-allowed disabled:opacity-60"
+					class="flex h-10 w-12 items-center justify-center rounded-xl border border-gray-300 text-black hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:text-white dark:hover:bg-gray-700"
 				>
 					<span class="flex" class:animate-spin={stopPaneLoading}>
 						<FontAwesomeIcon icon={faArrowsRotate} />
 					</span>
 				</button>
-				{#each actions as action (action.href)}
-					<a
-						href={action.href}
-						title={$isLoading ? '' : $t(action.labelKey)}
-						aria-label={$isLoading ? '' : $t(action.labelKey)}
-						class="flex h-8 w-8 items-center justify-center rounded-full bg-brand-accent text-sm text-white hover:bg-brand-accent-dark"
-					>
-						<FontAwesomeIcon icon={action.icon} />
-					</a>
-				{/each}
-				<button
-					type="button"
-					onclick={closePane}
-					use:keybinding={{ code: 'Escape' }}
-					class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-200 text-sm text-black hover:bg-gray-300 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600"
+				<a
+					href={`/stops/${stop.id}`}
+					class="flex h-10 items-center gap-2 rounded-xl border border-gray-300 px-4 text-base font-semibold text-black hover:bg-gray-100 dark:border-gray-600 dark:text-white dark:hover:bg-gray-700"
 				>
-					<FontAwesomeIcon icon={faX} />
-					<span class="sr-only">{$isLoading ? '' : $t('sheet.close')}</span>
-				</button>
+					<FontAwesomeIcon icon={faCircleInfo} />
+					{$isLoading ? '' : $t('stop_details.stop_info')}
+				</a>
 			</div>
 		</div>
 	{/snippet}

--- a/src/components/stops/StopPane.svelte
+++ b/src/components/stops/StopPane.svelte
@@ -345,11 +345,6 @@
 						{@render loadMoreButton(true)}
 					</div>
 				{:else}
-					<h2
-						class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
-					>
-						{$isLoading ? '' : $t('arrivals_and_departures')}
-					</h2>
 					{#key arrivalsAndDepartures.stopId}
 						<Accordion {handleAccordionSelectionChanged}>
 							{#each arrivalsAndDepartures.arrivalsAndDepartures as arrival}

--- a/src/components/stops/StopPane.svelte
+++ b/src/components/stops/StopPane.svelte
@@ -23,6 +23,7 @@
 	 * @property {Function} [tripSelected]
 	 * @property {boolean} [showHeroCard] - Render the brand-accent hero card above the arrivals list
 	 * @property {any} [arrivalsAndDeparturesResponse]
+	 * @property {Map<string, any>} [routeColors]
 	 */
 
 	/** @type {Props} */
@@ -34,7 +35,8 @@
 		arrivalsAndDeparturesResponse = $bindable(null),
 		// Exposed so a parent (e.g. the bottom-sheet toolbar refresh button) can
 		// reflect whether a fetch — initial, manual, or the 30s poll — is in flight.
-		loading = $bindable(false)
+		loading = $bindable(false),
+		routeColors = null
 	} = $props();
 
 	// Time window (in minutes) for upcoming arrivals. Defaults to the OBA
@@ -358,6 +360,7 @@
 											<ArrivalDeparture
 												arrivalDeparture={arrival}
 												route={routeById.get(arrival.routeId)}
+												routeColors={routeColors?.get(arrival.routeId) ?? null}
 												expanded={isActive}
 											/>
 										</span>

--- a/src/components/stops/__tests__/StopBottomSheet.test.js
+++ b/src/components/stops/__tests__/StopBottomSheet.test.js
@@ -41,27 +41,32 @@ describe('StopBottomSheet', () => {
 		});
 	});
 
-	test('renders the condensed stop header with stop number and routes', async () => {
+	test('renders the condensed stop header with stop number, direction and routes', async () => {
 		render(StopBottomSheet, { props: defaultProps });
 
 		expect(screen.getByText(mockStopData.name)).toBeInTheDocument();
 
 		await waitFor(() => {
-			expect(screen.getByText('stop #75403 · 10, 11')).toBeInTheDocument();
+			// The i18n mock echoes keys, so the direction segment renders as its key.
+			expect(screen.getByText('stop #75403 · direction_bound · 10, 11')).toBeInTheDocument();
 		});
 	});
 
-	test('renders View Details and View Schedule links to the standalone stop pages', () => {
+	test('renders a Stop Info link to the standalone stop page', () => {
 		render(StopBottomSheet, { props: defaultProps });
 
-		expect(screen.getByRole('link', { name: 'stop_details.view_details' })).toHaveAttribute(
+		expect(screen.getByRole('link', { name: 'stop_details.stop_info' })).toHaveAttribute(
 			'href',
 			`/stops/${mockStopData.id}`
 		);
-		expect(screen.getByRole('link', { name: 'schedule_for_stop.view_schedule' })).toHaveAttribute(
-			'href',
-			`/stops/${mockStopData.id}/schedule`
-		);
+	});
+
+	test('does not render a schedule link', () => {
+		render(StopBottomSheet, { props: defaultProps });
+
+		expect(
+			screen.queryByRole('link', { name: 'schedule_for_stop.view_schedule' })
+		).not.toBeInTheDocument();
 	});
 
 	test('close button calls closePane', async () => {

--- a/src/components/stops/__tests__/StopPane.test.js
+++ b/src/components/stops/__tests__/StopPane.test.js
@@ -271,7 +271,7 @@ describe('StopPane', () => {
 		});
 	});
 
-	test('renders the ARRIVALS & DEPARTURES section header when arrivals exist', async () => {
+	test('does not render an "Arrivals and departures" section header', async () => {
 		global.fetch.mockResolvedValueOnce({
 			ok: true,
 			status: 200,
@@ -280,8 +280,10 @@ describe('StopPane', () => {
 
 		render(StopPane, { props: { stop: mockStopData } });
 		await waitFor(() => {
-			expect(screen.getByText('Arrivals and departures')).toBeInTheDocument();
+			expect(global.fetch).toHaveBeenCalled();
 		});
+
+		expect(screen.queryByText('Arrivals and departures')).not.toBeInTheDocument();
 	});
 
 	test('displays route information when available', async () => {
@@ -515,10 +517,9 @@ describe('StopPane', () => {
 			expect(stopNameHeading).toHaveTextContent('Pine St & 3rd Ave');
 
 			const headings = screen.getAllByRole('heading', { level: 2 });
-			expect(headings).toHaveLength(3);
+			expect(headings).toHaveLength(2);
 			expect(headings[0]).toHaveTextContent('Stop #75403');
 			expect(headings[1]).toHaveTextContent('Routes: 10, 11');
-			expect(headings[2]).toHaveTextContent('Arrivals and departures');
 		});
 	});
 

--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -714,6 +714,13 @@ export default class GoogleMapProvider {
 		});
 	}
 
+	/**
+	 * Provider-parity no-op. Google's Polyline has no SVG path, so the
+	 * stroke-dashoffset draw-in used by the OSM provider has no analogue; Google
+	 * routes appear immediately. Kept so callers don't have to branch on provider.
+	 */
+	revealPolylines() {}
+
 	enableContextMenu() {
 		if (!this.map) return;
 		this.map.addListener('rightclick', (e) => {

--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -35,6 +35,11 @@ export default class GoogleMapProvider {
 		this.popupContentComponent = null;
 		this.stopsMap = new Map();
 		this.stopMarkers = [];
+		// Route-drawn stop markers (addStopRouteMarker), keyed by stop id. Kept
+		// separate from markersMap so drawing a route never clobbers the reactive
+		// props handle addMarker put there for the same stop — see openStopMarker
+		// for the anchor-resolution fallback this implies.
+		this.routeStopMarkers = new Map();
 		this.vehicleMarkers = [];
 		this.markersMap = new Map();
 		this.handleStopMarkerSelect = handleStopMarkerSelect;
@@ -227,7 +232,11 @@ export default class GoogleMapProvider {
 
 		marker.addListener('click', () => this.openStopMarker(stop, stopTime));
 
-		this.markersMap.set(stop.id, marker);
+		// Deliberately not markersMap: a stop drawn as part of a route can already
+		// have a StopMarker entry there (with a reactive `props` handle used by
+		// setStopEmphasis/highlightMarker/etc.); overwriting it with this bare
+		// google.maps.Marker would silently break emphasis for that stop.
+		this.routeStopMarkers.set(stop.id, marker);
 		this.stopMarkers.push(marker);
 	}
 
@@ -257,7 +266,10 @@ export default class GoogleMapProvider {
 			content: popupContainer
 		});
 
-		this.globalInfoWindow.open(this.map, this.markersMap.get(stop.id));
+		// Route-drawn stops anchor to their routeStopMarkers entry; fall back to
+		// markersMap for stops opened via their own StopMarker overlay.
+		const anchor = this.routeStopMarkers.get(stop.id) ?? this.markersMap.get(stop.id);
+		this.globalInfoWindow.open(this.map, anchor);
 	}
 
 	updatePopupContent(stop, arrivalTime = null) {
@@ -302,8 +314,9 @@ export default class GoogleMapProvider {
 	 */
 	setStopEmphasis(byStopId, defaultEmphasis = 'full', selectedStopId = null) {
 		for (const [stopId, marker] of this.markersMap) {
-			// addStopRouteMarker writes plain google.maps.Marker objects into
-			// markersMap; those have no reactive props to mutate.
+			// Defensive: every markersMap entry should be a StopMarker handle with a
+			// reactive props object (addStopRouteMarker keeps its bare markers in
+			// routeStopMarkers instead), but skip gracefully if that ever changes.
 			if (!marker?.props) continue;
 
 			if (stopId === selectedStopId) {
@@ -331,6 +344,7 @@ export default class GoogleMapProvider {
 			marker.setMap(null);
 		});
 		this.stopMarkers = [];
+		this.routeStopMarkers.clear();
 	}
 
 	addPinMarker(position, text) {
@@ -533,6 +547,14 @@ export default class GoogleMapProvider {
 	/**
 	 * Google replaces the whole `styles` array on setOptions, so theme and dim have
 	 * to be composed in one place — otherwise a theme toggle silently drops the dim.
+	 *
+	 * Caveat (needs manual verification, not testable in jsdom): the dim styler
+	 * below uses `saturation`/`lightness`, which Google's style reference defines
+	 * as *relative* to the base map style. nightModeStyles() sets *absolute*
+	 * `color` on nearly every element instead. Whether a trailing relative styler
+	 * visibly dims already-absolute-colored elements is not guaranteed by the
+	 * API — add this to the manual dark-mode verification list for a
+	 * Google-configured deployment.
 	 */
 	_applyStyles() {
 		const base = this._darkTheme ? nightModeStyles() : [];
@@ -555,6 +577,11 @@ export default class GoogleMapProvider {
 	}
 
 	setBasemapDimmed(dimmed) {
+		// Mirrors OSM's `if (!browser || !this.map) return;` guard: the provider
+		// is constructed with this.map = null, and MapView.initMap swallows init
+		// failures, so a failed Google init must no-op here rather than throw.
+		if (!this.map) return;
+
 		this._dimmed = dimmed;
 		this._applyStyles();
 	}
@@ -638,6 +665,13 @@ export default class GoogleMapProvider {
 		const zIndex = ROUTE_LAYER_Z_INDEX[options.pane];
 		if (zIndex !== undefined) {
 			polylineOptions.zIndex = zIndex;
+		} else if (options.casing) {
+			// The casing below always gets an explicit zIndex (its own default or
+			// ROUTE_LAYER_Z_INDEX[ROUTE_PANE.CASING]). Google documents no default
+			// for PolylineOptions.zIndex, so an explicit casing zIndex beats an
+			// unset line zIndex — without this, an unpaned casing:true call would
+			// paint the white casing over its own colored line.
+			polylineOptions.zIndex = ROUTE_LAYER_Z_INDEX[ROUTE_PANE.LINE];
 		}
 
 		const icons = [];

--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -557,6 +557,13 @@ export default class GoogleMapProvider {
 	 * Google-configured deployment.
 	 */
 	_applyStyles() {
+		// Guard here, at the single choke point both setTheme and setBasemapDimmed
+		// pass through: the provider is constructed with this.map = null, and
+		// MapView.initMap swallows init failures, so a themeChange -> setTheme ->
+		// _applyStyles after a failed Google init must no-op rather than throw on
+		// this.map.setOptions. Mirrors OSM's `if (!browser || !this.map) return;`.
+		if (!this.map) return;
+
 		const base = this._darkTheme ? nightModeStyles() : [];
 		const dim = this._dimmed
 			? [
@@ -577,11 +584,7 @@ export default class GoogleMapProvider {
 	}
 
 	setBasemapDimmed(dimmed) {
-		// Mirrors OSM's `if (!browser || !this.map) return;` guard: the provider
-		// is constructed with this.map = null, and MapView.initMap swallows init
-		// failures, so a failed Google init must no-op here rather than throw.
-		if (!this.map) return;
-
+		// Null-map guard lives in _applyStyles, which both callers pass through.
 		this._dimmed = dimmed;
 		this._applyStyles();
 	}

--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -34,6 +34,7 @@ export default class GoogleMapProvider {
 		this.routeLabelsVisible = false;
 		this.contextMenuInfoWindow = null;
 		this.contextMenuComponent = null;
+		this.userLocationMarker = null;
 	}
 
 	async initMap(element, options) {
@@ -487,8 +488,18 @@ export default class GoogleMapProvider {
 		this.map.setOptions({ styles });
 	}
 
+	/**
+	 * Shows the user's location. There is only ever one such marker: repeat calls
+	 * move the existing one, so successive location fixes can't leave a trail of
+	 * stale blue dots behind.
+	 */
 	addUserLocationMarker(latLng) {
-		new google.maps.Marker({
+		if (this.userLocationMarker) {
+			this.userLocationMarker.setPosition(latLng);
+			return this.userLocationMarker;
+		}
+
+		this.userLocationMarker = new google.maps.Marker({
 			map: this.map,
 			position: latLng,
 			title: 'Your Location',
@@ -501,6 +512,14 @@ export default class GoogleMapProvider {
 				strokeColor: '#FFFFFF'
 			}
 		});
+
+		return this.userLocationMarker;
+	}
+
+	removeUserLocationMarker() {
+		if (!this.userLocationMarker) return;
+		this.userLocationMarker.setMap(null);
+		this.userLocationMarker = null;
 	}
 
 	/**

--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -737,6 +737,18 @@ export default class GoogleMapProvider {
 		return polyline;
 	}
 
+	/**
+	 * Moves an already-drawn polyline to a different stacking layer — used to
+	 * promote the expanded arrival's route above its peers. Uniform in intent
+	 * with OpenStreetMapProvider.setPolylineLayer, but Google's Polyline
+	 * orders purely by `zIndex`, so re-paning is a single option update rather
+	 * than a detach/reattach.
+	 */
+	setPolylineLayer(polyline, pane) {
+		if (!this.map || !polyline) return;
+		polyline.setOptions({ zIndex: ROUTE_LAYER_Z_INDEX[pane] });
+	}
+
 	async removePolyline(polyline) {
 		if (polyline && polyline.setMap) {
 			polyline.setMap(null);

--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -17,6 +17,15 @@ import { animateMarkerTo, cancelMarkerAnimation } from '$lib/MapHelpers/animateM
 import TripPlanPinMarker from '$components/trip-planner/tripPlanPinMarker.svelte';
 import { mount, unmount } from 'svelte';
 import { buildVehiclePopupData } from '$lib/vehicleUtils';
+import { ROUTE_PANE } from '$lib/mapPanes.js';
+
+// Google orders polylines by zIndex rather than by pane. Same contract as the
+// OSM panes: every casing below every colored stroke, promoted above its peers.
+const ROUTE_LAYER_Z_INDEX = {
+	[ROUTE_PANE.CASING]: 10,
+	[ROUTE_PANE.LINE]: 20,
+	[ROUTE_PANE.PROMOTED]: 30
+};
 
 export default class GoogleMapProvider {
 	constructor(apiKey, handleStopMarkerSelect) {
@@ -35,6 +44,8 @@ export default class GoogleMapProvider {
 		this.contextMenuInfoWindow = null;
 		this.contextMenuComponent = null;
 		this.userLocationMarker = null;
+		this._darkTheme = false;
+		this._dimmed = false;
 	}
 
 	async initMap(element, options) {
@@ -102,7 +113,9 @@ export default class GoogleMapProvider {
 				icon: icon,
 				onClick: options.onClick,
 				isHighlighted: options.isHighlighted ?? false,
-				showRoutesLabel: this.map.getZoom() >= this.showStopsRoutesAtZoom
+				showRoutesLabel: this.map.getZoom() >= this.showStopsRoutesAtZoom,
+				emphasis: options.emphasis ?? 'full',
+				dotColor: options.dotColor ?? null
 			});
 
 			const marker = mount(StopMarker, {
@@ -277,6 +290,40 @@ export default class GoogleMapProvider {
 		if (!marker) return;
 
 		marker.props.isHighlighted = false;
+	}
+
+	/**
+	 * Applies marker prominence across the map. Called by the map layer whenever the
+	 * selection or the drawn route set changes.
+	 *
+	 * @param {Map<string, {emphasis: string, dotColor: string|null}>} byStopId
+	 * @param {'full'|'muted'} defaultEmphasis - for stops not in byStopId
+	 * @param {string|null} selectedStopId - always rendered as the full pin
+	 */
+	setStopEmphasis(byStopId, defaultEmphasis = 'full', selectedStopId = null) {
+		for (const [stopId, marker] of this.markersMap) {
+			// addStopRouteMarker writes plain google.maps.Marker objects into
+			// markersMap; those have no reactive props to mutate.
+			if (!marker?.props) continue;
+
+			if (stopId === selectedStopId) {
+				marker.props.emphasis = 'full';
+				marker.props.dotColor = null;
+				continue;
+			}
+
+			const tier = byStopId.get(stopId);
+			marker.props.emphasis = tier?.emphasis ?? defaultEmphasis;
+			marker.props.dotColor = tier?.dotColor ?? null;
+		}
+	}
+
+	resetStopEmphasis() {
+		for (const marker of this.markersMap.values()) {
+			if (!marker?.props) continue;
+			marker.props.emphasis = 'full';
+			marker.props.dotColor = null;
+		}
 	}
 
 	removeStopMarkers() {
@@ -483,9 +530,33 @@ export default class GoogleMapProvider {
 		this.map.addListener(event, callback);
 	}
 
+	/**
+	 * Google replaces the whole `styles` array on setOptions, so theme and dim have
+	 * to be composed in one place — otherwise a theme toggle silently drops the dim.
+	 */
+	_applyStyles() {
+		const base = this._darkTheme ? nightModeStyles() : [];
+		const dim = this._dimmed
+			? [
+					{
+						featureType: 'all',
+						elementType: 'all',
+						stylers: [{ saturation: -45 }, { lightness: 25 }]
+					}
+				]
+			: [];
+		const styles = [...base, ...dim];
+		this.map.setOptions({ styles: styles.length ? styles : null });
+	}
+
 	setTheme(theme) {
-		const styles = theme === 'dark' ? nightModeStyles() : null;
-		this.map.setOptions({ styles });
+		this._darkTheme = theme === 'dark';
+		this._applyStyles();
+	}
+
+	setBasemapDimmed(dimmed) {
+		this._dimmed = dimmed;
+		this._applyStyles();
 	}
 
 	/**
@@ -554,14 +625,20 @@ export default class GoogleMapProvider {
 			return null;
 		}
 		const path = decodedPath.map((point) => ({ lat: point.lat(), lng: point.lng() }));
+		const weight = options.weight || 5;
 
 		const polylineOptions = {
 			path,
 			geodesic: true,
 			strokeColor: options.color || COLORS.POLYLINE,
 			strokeOpacity: options.dashArray ? 0 : (options.opacity ?? 1.0),
-			strokeWeight: options.weight || 5
+			strokeWeight: weight
 		};
+
+		const zIndex = ROUTE_LAYER_Z_INDEX[options.pane];
+		if (zIndex !== undefined) {
+			polylineOptions.zIndex = zIndex;
+		}
 
 		const icons = [];
 
@@ -605,6 +682,22 @@ export default class GoogleMapProvider {
 
 		polyline.setMap(this.map);
 
+		// White casing underneath, so the route reads on any basemap tile without a
+		// halo hack. Kept off this.polylines (same shape as OSM) so
+		// fitToPolylines/getPolylinesCount/_getRoutePaths don't double-count it,
+		// and torn down alongside its polyline.
+		if (options.casing) {
+			polyline._casing = new window.google.maps.Polyline({
+				path,
+				geodesic: true,
+				strokeColor: '#ffffff',
+				strokeOpacity: 0.95,
+				strokeWeight: weight + 5,
+				zIndex: ROUTE_LAYER_Z_INDEX[options.casingPane] ?? ROUTE_LAYER_Z_INDEX[ROUTE_PANE.CASING],
+				map: this.map
+			});
+		}
+
 		this.polylines.push(polyline);
 
 		return polyline;
@@ -613,6 +706,11 @@ export default class GoogleMapProvider {
 	async removePolyline(polyline) {
 		if (polyline && polyline.setMap) {
 			polyline.setMap(null);
+		}
+
+		if (polyline?._casing) {
+			polyline._casing.setMap(null);
+			polyline._casing = null;
 		}
 
 		// Remove from tracking array
@@ -633,6 +731,10 @@ export default class GoogleMapProvider {
 		this.polylines.forEach((polyline) => {
 			if (polyline && polyline.setMap) {
 				polyline.setMap(null);
+			}
+			if (polyline?._casing) {
+				polyline._casing.setMap(null);
+				polyline._casing = null;
 			}
 		});
 

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -143,7 +143,7 @@ export default class OpenStreetMapProvider {
 		// tabindex="0" + role="button" on the wrapper <div> whenever keyboard is
 		// truthy (its default), regardless of interactive. That wrapper holds the
 		// mounted StopMarker, which already has its own real <button> with an
-		// sr-only accessible name — so leaving keyboard on would create nested
+		// aria-label accessible name — so leaving keyboard on would create nested
 		// interactive controls plus a second, unlabeled, dead tab stop per stop.
 		const marker = this.L.marker([options.position.lat, options.position.lng], {
 			icon: customIcon,

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -774,13 +774,16 @@ export default class OpenStreetMapProvider {
 	 * stroke-dashoffset technique, without touching the camera. The direction-arrow
 	 * decorators are added once the line has finished drawing.
 	 *
-	 * @param {{ only?: Array, duration?: number }} [options] `only` limits the
-	 *   animation to specific polylines — used by the stop-selection layer, whose
-	 *   routes resolve one at a time and must not re-animate their neighbors.
-	 *   Omit it to reveal every tracked polyline.
+	 * @param {{ only?: Array | null, duration?: number }} [options] `only` limits
+	 *   the animation to specific polylines — used by the stop-selection layer,
+	 *   whose routes resolve one at a time and must not re-animate their
+	 *   neighbors. The sentinel is *absence*, not emptiness: omit `only` (or pass
+	 *   `null`/`undefined`) to reveal every tracked polyline, but an explicit
+	 *   array — including an empty one — is taken literally, so `only: []`
+	 *   animates nothing.
 	 */
-	revealPolylines({ only = [], duration = 1.2 } = {}) {
-		const targets = only.length ? only : this.polylines;
+	revealPolylines({ only = null, duration = 1.2 } = {}) {
+		const targets = only ?? this.polylines;
 
 		targets.forEach((polyline) => {
 			if (!polyline) return;
@@ -817,6 +820,16 @@ export default class OpenStreetMapProvider {
 				layerPath.style.transition = `stroke-dashoffset ${duration}s ease-in-out`;
 				layerPath.style.strokeDashoffset = '0';
 			});
+
+			// Clear any prior pending reveal for this polyline before scheduling a
+			// new one — otherwise a second call within `duration` overwrites the
+			// stored id, orphaning the first timer so it later fires against a
+			// removed or reused DOM node (removePolyline/clearAllPolylines only
+			// ever clear the single stored id).
+			if (polyline._drawTimeoutId) {
+				clearTimeout(polyline._drawTimeoutId);
+				polyline._drawTimeoutId = null;
+			}
 
 			polyline._drawTimeoutId = setTimeout(() => {
 				polyline._drawTimeoutId = null;

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -244,8 +244,8 @@ export default class OpenStreetMapProvider {
 	 */
 	setStopEmphasis(byStopId, defaultEmphasis = 'full', selectedStopId = null) {
 		for (const [stopId, marker] of this.markersMap) {
-			// addStopRouteMarker writes plain markers into markersMap on the Google
-			// provider; those have no reactive props to mutate.
+			// Defensive: every markersMap entry should be a StopMarker handle with a
+			// reactive props object, but skip gracefully if that ever changes.
 			if (!marker?.props) continue;
 
 			if (stopId === selectedStopId) {

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -23,6 +23,7 @@ import { env } from '$env/dynamic/public';
 import { buildVehiclePopupData } from '$lib/vehicleUtils';
 import { get } from 'svelte/store';
 import { t } from 'svelte-i18n';
+import { ROUTE_PANE_Z_INDEX } from '$lib/mapPanes.js';
 
 // activeTrip is always truthy here: the sole caller (vehicleUtils.js) guards on
 // it, and buildVehiclePopupData reads activeTrip.tripHeadsign without optional
@@ -86,6 +87,16 @@ export default class OpenStreetMapProvider {
 		this.map.on('zoomend', () => {
 			this.updateMarkersRouteLabelVisibility();
 		});
+
+		// Custom panes give the route layer explicit stacking: every casing below
+		// every colored stroke, and the promoted route above its peers.
+		// createPane does not assign a z-index — .leaflet-pane sets 400 for all of
+		// them — so it must be set here, or the panes tie with overlayPane and
+		// order only by DOM insertion.
+		for (const [name, zIndex] of Object.entries(ROUTE_PANE_Z_INDEX)) {
+			this.map.createPane(name);
+			this.map.getPane(name).style.zIndex = String(zIndex);
+		}
 	}
 
 	eventListeners(mapInstance, debouncedLoadMarkers) {
@@ -125,7 +136,9 @@ export default class OpenStreetMapProvider {
 			icon: icon,
 			onClick: options.onClick,
 			isHighlighted: options.isHighlighted ?? false,
-			showRoutesLabel: this.map.getZoom() >= this.showStopsRoutesAtZoom
+			showRoutesLabel: this.map.getZoom() >= this.showStopsRoutesAtZoom,
+			emphasis: options.emphasis ?? 'full',
+			dotColor: options.dotColor ?? null
 		});
 
 		mount(StopMarker, {
@@ -219,6 +232,53 @@ export default class OpenStreetMapProvider {
 		if (!marker) return;
 
 		marker.props.isHighlighted = false;
+	}
+
+	/**
+	 * Applies marker prominence across the map. Called by the map layer whenever the
+	 * selection or the drawn route set changes.
+	 *
+	 * @param {Map<string, {emphasis: string, dotColor: string|null}>} byStopId
+	 * @param {'full'|'muted'} defaultEmphasis - for stops not in byStopId
+	 * @param {string|null} selectedStopId - always rendered as the full pin
+	 */
+	setStopEmphasis(byStopId, defaultEmphasis = 'full', selectedStopId = null) {
+		for (const [stopId, marker] of this.markersMap) {
+			// addStopRouteMarker writes plain markers into markersMap on the Google
+			// provider; those have no reactive props to mutate.
+			if (!marker?.props) continue;
+
+			if (stopId === selectedStopId) {
+				marker.props.emphasis = 'full';
+				marker.props.dotColor = null;
+				continue;
+			}
+
+			const tier = byStopId.get(stopId);
+			marker.props.emphasis = tier?.emphasis ?? defaultEmphasis;
+			marker.props.dotColor = tier?.dotColor ?? null;
+		}
+	}
+
+	resetStopEmphasis() {
+		for (const marker of this.markersMap.values()) {
+			if (!marker?.props) continue;
+			marker.props.emphasis = 'full';
+			marker.props.dotColor = null;
+		}
+	}
+
+	/**
+	 * Fades the basemap so the colored routes and vehicles carry the map.
+	 *
+	 * The MapLibre GL canvas is the only thing in Leaflet's tilePane, so a CSS
+	 * filter scoped there dims the basemap and nothing else — routes and markers
+	 * live in overlayPane/markerPane and keep full contrast. The class goes on the
+	 * container rather than the layer so it survives setTheme's layer rebuild.
+	 */
+	setBasemapDimmed(dimmed) {
+		if (!browser || !this.map) return;
+		this.map.getContainer().classList.toggle('oba-dim-basemap', dimmed);
 	}
 
 	// Leaflet only activates markers on Enter, so we add Space for ARIA button parity.
@@ -633,16 +693,38 @@ export default class OpenStreetMapProvider {
 		}
 
 		const withArrow = options.withArrow ?? true;
+		const weight = options.weight || 4;
+		const pane = options.pane;
+
+		// White casing underneath, so the route reads on any basemap tile without a
+		// halo hack. Created first so it renders below; kept off this.polylines (like
+		// arrowDecorator) so fitToPolylines/getPolylinesCount/_getRoutePaths don't
+		// double-count it, and torn down with its polyline.
+		let casing = null;
+		if (options.casing) {
+			casing = new this.L.Polyline(decodedPolyline, {
+				color: '#ffffff',
+				weight: weight + 5,
+				opacity: 0.95,
+				lineCap: 'round',
+				lineJoin: 'round',
+				...(options.casingPane ? { pane: options.casingPane } : {})
+			}).addTo(this.map);
+		}
 
 		const polylineOpts = {
 			color: options.color || COLORS.POLYLINE,
-			weight: options.weight || 4,
-			opacity: options.opacity ?? 1
+			weight,
+			opacity: options.opacity ?? 1,
+			lineCap: 'round',
+			lineJoin: 'round'
 		};
+		if (pane) polylineOpts.pane = pane;
 		if (options.dashArray) {
 			polylineOpts.dashArray = options.dashArray;
 		}
 		const polyline = new this.L.Polyline(decodedPolyline, polylineOpts).addTo(this.map);
+		polyline._casing = casing;
 
 		this.polylines.push(polyline);
 
@@ -660,7 +742,8 @@ export default class OpenStreetMapProvider {
 							color: arrowColor,
 							fill: true,
 							fillColor: arrowColor,
-							fillOpacity: 0.85
+							fillOpacity: 0.85,
+							...(pane ? { pane } : {})
 						}
 					})
 				}
@@ -683,6 +766,11 @@ export default class OpenStreetMapProvider {
 		if (polyline.arrowDecorator) {
 			polyline.arrowDecorator.remove();
 			polyline.arrowDecorator = null;
+		}
+
+		if (polyline._casing) {
+			polyline._casing.remove();
+			polyline._casing = null;
 		}
 
 		polyline.remove();
@@ -709,6 +797,10 @@ export default class OpenStreetMapProvider {
 				if (polyline.arrowDecorator) {
 					polyline.arrowDecorator.remove();
 					polyline.arrowDecorator = null;
+				}
+				if (polyline._casing) {
+					polyline._casing.remove();
+					polyline._casing = null;
 				}
 				polyline.remove();
 			}

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -51,6 +51,7 @@ export default class OpenStreetMapProvider {
 		this.routeLabelsVisible = false;
 		this.contextMenuPopup = null;
 		this.contextMenuComponent = null;
+		this.userLocationMarker = null;
 		// Incremented on each fitToPolylines() so a superseded route load's
 		// pending reveal can detect it's stale and bail out.
 		this._fitToken = 0;
@@ -515,15 +516,34 @@ export default class OpenStreetMapProvider {
 		this.map.on(event, callback);
 	}
 
+	/**
+	 * Shows the user's location. There is only ever one such marker: repeat calls
+	 * move the existing one, so successive location fixes can't leave a trail of
+	 * stale blue dots behind.
+	 */
 	addUserLocationMarker(latLng) {
-		if (!browser || !this.map) return;
-		this.L.circleMarker([latLng.lat, latLng.lng], {
+		if (!browser || !this.map) return null;
+
+		if (this.userLocationMarker) {
+			this.userLocationMarker.setLatLng([latLng.lat, latLng.lng]);
+			return this.userLocationMarker;
+		}
+
+		this.userLocationMarker = this.L.circleMarker([latLng.lat, latLng.lng], {
 			radius: 8,
 			fillColor: '#007BFF',
 			fillOpacity: 1,
 			color: '#FFFFFF',
 			weight: 2
 		}).addTo(this.map);
+
+		return this.userLocationMarker;
+	}
+
+	removeUserLocationMarker() {
+		if (!browser || !this.map || !this.userLocationMarker) return;
+		this.map.removeLayer(this.userLocationMarker);
+		this.userLocationMarker = null;
 	}
 
 	setCenter(latLng) {

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -758,7 +758,7 @@ export default class OpenStreetMapProvider {
 	 */
 	_setPolylinesVisible(visible) {
 		this.polylines.forEach((polyline) => {
-			[polyline, polyline.arrowDecorator].forEach((layer) => {
+			[polyline, polyline._casing, polyline.arrowDecorator].forEach((layer) => {
 				if (!layer) return;
 				if (visible) {
 					if (!this.map.hasLayer(layer)) layer.addTo(this.map);
@@ -770,14 +770,27 @@ export default class OpenStreetMapProvider {
 	}
 
 	/**
-	 * Reveals the route polylines with a "draw from start to end" animation
-	 * using the SVG stroke-dashoffset technique. The direction-arrow decorators
-	 * are added once the line has finished drawing.
-	 * @param {number} duration animation length in seconds
+	 * Reveals polylines with a "draw from start to end" animation using the SVG
+	 * stroke-dashoffset technique, without touching the camera. The direction-arrow
+	 * decorators are added once the line has finished drawing.
+	 *
+	 * @param {{ only?: Array, duration?: number }} [options] `only` limits the
+	 *   animation to specific polylines — used by the stop-selection layer, whose
+	 *   routes resolve one at a time and must not re-animate their neighbors.
+	 *   Omit it to reveal every tracked polyline.
 	 */
-	_revealPolylinesWithDraw(duration = 1.2) {
-		this.polylines.forEach((polyline) => {
-			if (!this.map.hasLayer(polyline)) polyline.addTo(this.map);
+	revealPolylines({ only = [], duration = 1.2 } = {}) {
+		const targets = only.length ? only : this.polylines;
+
+		targets.forEach((polyline) => {
+			if (!polyline) return;
+			// The casing is a second, wider stroke drawn underneath. It is deliberately
+			// absent from this.polylines (like arrowDecorator) so it can't double-count
+			// in fitToPolylines/_getRoutePaths, so reveal it explicitly here.
+			[polyline._casing, polyline].forEach((layer) => {
+				if (!layer) return;
+				if (!this.map.hasLayer(layer)) layer.addTo(this.map);
+			});
 
 			const path = polyline._path;
 			const addDecorator = () => {
@@ -792,14 +805,18 @@ export default class OpenStreetMapProvider {
 				return;
 			}
 
-			const length = path.getTotalLength();
-			path.style.transition = 'none';
-			path.style.strokeDasharray = `${length} ${length}`;
-			path.style.strokeDashoffset = `${length}`;
-			// Force a reflow so the starting offset is applied before transitioning.
-			path.getBoundingClientRect();
-			path.style.transition = `stroke-dashoffset ${duration}s ease-in-out`;
-			path.style.strokeDashoffset = '0';
+			[polyline._casing, polyline].forEach((layer) => {
+				const layerPath = layer?._path;
+				if (!layerPath || typeof layerPath.getTotalLength !== 'function') return;
+				const length = layerPath.getTotalLength();
+				layerPath.style.transition = 'none';
+				layerPath.style.strokeDasharray = `${length} ${length}`;
+				layerPath.style.strokeDashoffset = `${length}`;
+				// Force a reflow so the starting offset is applied before transitioning.
+				layerPath.getBoundingClientRect();
+				layerPath.style.transition = `stroke-dashoffset ${duration}s ease-in-out`;
+				layerPath.style.strokeDashoffset = '0';
+			});
 
 			polyline._drawTimeoutId = setTimeout(() => {
 				polyline._drawTimeoutId = null;
@@ -807,9 +824,13 @@ export default class OpenStreetMapProvider {
 				if (!this.map.hasLayer(polyline)) return;
 				// Clear the inline styles so the original stroke (e.g. the dashed
 				// pattern used for walking legs) is restored once drawing is done.
-				path.style.transition = '';
-				path.style.strokeDasharray = '';
-				path.style.strokeDashoffset = '';
+				[polyline._casing, polyline].forEach((layer) => {
+					const layerPath = layer?._path;
+					if (!layerPath) return;
+					layerPath.style.transition = '';
+					layerPath.style.strokeDasharray = '';
+					layerPath.style.strokeDashoffset = '';
+				});
 				addDecorator();
 			}, duration * 1000);
 		});
@@ -855,7 +876,7 @@ export default class OpenStreetMapProvider {
 					resolve(false);
 					return;
 				}
-				this._revealPolylinesWithDraw(options.drawDuration ?? 1.2);
+				this.revealPolylines({ duration: options.drawDuration ?? 1.2 });
 				// Resolve as the route starts drawing so callers can reveal stop
 				// markers in sync, rather than before the camera has settled.
 				resolve(true);

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -755,6 +755,69 @@ export default class OpenStreetMapProvider {
 		return polyline;
 	}
 
+	/**
+	 * Moves an already-drawn polyline to a different stacking pane — used to
+	 * promote the expanded arrival's route above its peers.
+	 *
+	 * Not a property set: Leaflet's Path.beforeAdd resolves
+	 * `this._renderer = map.getRenderer(this)` once, at add time, from
+	 * `layer.options.pane`. Assigning `polyline.options.pane` on an
+	 * already-added layer does nothing on its own — the layer must be
+	 * detached and reattached for the new pane to take effect.
+	 *
+	 * SVG._initPath creates a brand-new `<path>` DOM element on every onAdd,
+	 * discarding any in-flight reveal transition, so a pending
+	 * `_drawTimeoutId` is cleared first — left alone, it would later fire its
+	 * "clear the inline dash styles" step against the dead node.
+	 *
+	 * The arrow decorator bakes `pane` into its `Symbol.arrowHead`
+	 * `pathOptions` at construction time, so it has to be recreated, not just
+	 * re-added, to follow the line into its new pane.
+	 *
+	 * Uses `layer.remove()`, not `this.removePolyline()`: that helper also
+	 * splices the layer out of `this.polylines`, and `addTo()` doesn't push it
+	 * back in, so a later `clearAllPolylines()` would leak this layer.
+	 *
+	 * The casing is left untouched in its own pane — only the colored line
+	 * (and its arrows) move.
+	 */
+	setPolylineLayer(polyline, pane) {
+		if (!this.map || !polyline) return;
+
+		if (polyline._drawTimeoutId) {
+			clearTimeout(polyline._drawTimeoutId);
+			polyline._drawTimeoutId = null;
+		}
+
+		polyline.remove();
+		polyline.options.pane = pane;
+		polyline.addTo(this.map);
+
+		if (polyline.arrowDecorator) {
+			polyline.arrowDecorator.remove();
+
+			const arrowColor = polylineArrowColor(polyline.options.color);
+			polyline.arrowDecorator = this.L.polylineDecorator(polyline, {
+				patterns: [
+					{
+						offset: 0,
+						repeat: 125,
+						symbol: this.L.Symbol.arrowHead({
+							pixelSize: 12,
+							pathOptions: {
+								color: arrowColor,
+								fill: true,
+								fillColor: arrowColor,
+								fillOpacity: 0.85,
+								pane
+							}
+						})
+					}
+				]
+			}).addTo(this.map);
+		}
+	}
+
 	removePolyline(polyline) {
 		if (!polyline) return;
 

--- a/src/lib/__tests__/activeRoutes.test.js
+++ b/src/lib/__tests__/activeRoutes.test.js
@@ -1,0 +1,167 @@
+import { describe, test, expect } from 'vitest';
+import { activeRoutesFromArrivals } from '$lib/activeRoutes.js';
+
+function makeResponse(arrivals, routes = []) {
+	return {
+		data: {
+			entry: { stopId: 'stop_1', arrivalsAndDepartures: arrivals },
+			references: { routes }
+		}
+	};
+}
+
+describe('activeRoutesFromArrivals', () => {
+	test('returns one entry per distinct route, soonest first', () => {
+		const result = activeRoutesFromArrivals(
+			makeResponse(
+				[
+					{
+						routeId: 'r_22',
+						tripId: 't_b',
+						predicted: true,
+						predictedArrivalTime: 2000,
+						scheduledArrivalTime: 2000
+					},
+					{
+						routeId: 'r_c',
+						tripId: 't_a',
+						predicted: true,
+						predictedArrivalTime: 1000,
+						scheduledArrivalTime: 1000
+					}
+				],
+				[
+					{ id: 'r_c', shortName: 'C Line', type: 3, color: 'b02a37' },
+					{ id: 'r_22', shortName: '22', type: 3, color: 'e0a021' }
+				]
+			)
+		);
+		expect(result.map((r) => r.id)).toEqual(['r_c', 'r_22']);
+		expect(result[0]).toEqual({
+			id: 'r_c',
+			shortName: 'C Line',
+			type: 3,
+			tripId: 't_a',
+			gtfsColor: 'b02a37'
+		});
+	});
+
+	test('keeps the soonest trip when a route has several arrivals', () => {
+		const result = activeRoutesFromArrivals(
+			makeResponse(
+				[
+					{
+						routeId: 'r_c',
+						tripId: 't_late',
+						predicted: true,
+						predictedArrivalTime: 5000,
+						scheduledArrivalTime: 5000
+					},
+					{
+						routeId: 'r_c',
+						tripId: 't_soon',
+						predicted: true,
+						predictedArrivalTime: 1000,
+						scheduledArrivalTime: 1000
+					}
+				],
+				[{ id: 'r_c', shortName: 'C Line', type: 3, color: 'b02a37' }]
+			)
+		);
+		expect(result).toHaveLength(1);
+		expect(result[0].tripId).toBe('t_soon');
+	});
+
+	// OBA sends predictedArrivalTime: 0 (not null) when there is no real-time
+	// prediction. A naive `predictedArrivalTime ?? scheduledArrivalTime` reads
+	// that as "arriving at epoch" and sorts it first. This test is the point.
+	test('treats predictedArrivalTime 0 as absent rather than as time zero', () => {
+		const result = activeRoutesFromArrivals(
+			makeResponse(
+				[
+					{
+						routeId: 'r_c',
+						tripId: 't_unpredicted',
+						predicted: false,
+						predictedArrivalTime: 0,
+						scheduledArrivalTime: 9000
+					},
+					{
+						routeId: 'r_22',
+						tripId: 't_predicted',
+						predicted: true,
+						predictedArrivalTime: 3000,
+						scheduledArrivalTime: 3200
+					}
+				],
+				[
+					{ id: 'r_c', shortName: 'C Line', type: 3, color: 'b02a37' },
+					{ id: 'r_22', shortName: '22', type: 3, color: 'e0a021' }
+				]
+			)
+		);
+		expect(result.map((r) => r.id)).toEqual(['r_22', 'r_c']);
+	});
+
+	test('picks the soonest trip by scheduled time when nothing is predicted', () => {
+		const result = activeRoutesFromArrivals(
+			makeResponse(
+				[
+					{
+						routeId: 'r_c',
+						tripId: 't_late',
+						predicted: false,
+						predictedArrivalTime: 0,
+						scheduledArrivalTime: 9000
+					},
+					{
+						routeId: 'r_c',
+						tripId: 't_soon',
+						predicted: false,
+						predictedArrivalTime: 0,
+						scheduledArrivalTime: 4000
+					}
+				],
+				[{ id: 'r_c', shortName: 'C Line', type: 3, color: 'b02a37' }]
+			)
+		);
+		expect(result[0].tripId).toBe('t_soon');
+	});
+
+	test('falls back to the arrival routeShortName when the route reference is missing', () => {
+		const result = activeRoutesFromArrivals(
+			makeResponse(
+				[
+					{
+						routeId: 'r_x',
+						tripId: 't_x',
+						routeShortName: '773',
+						predicted: true,
+						predictedArrivalTime: 1000,
+						scheduledArrivalTime: 1000
+					}
+				],
+				[]
+			)
+		);
+		expect(result[0].shortName).toBe('773');
+		expect(result[0].gtfsColor).toBeNull();
+	});
+
+	test.each([
+		['null', null],
+		['undefined', undefined],
+		['an empty object', {}],
+		['a response with no entry', { data: { references: { routes: [] } } }],
+		['a response with no arrivals array', { data: { entry: {}, references: { routes: [] } } }]
+	])('returns an empty array for %s', (_label, input) => {
+		expect(activeRoutesFromArrivals(input)).toEqual([]);
+	});
+
+	test('skips arrivals with no routeId', () => {
+		const result = activeRoutesFromArrivals(
+			makeResponse([{ tripId: 't_a', predicted: true, predictedArrivalTime: 1000 }], [])
+		);
+		expect(result).toEqual([]);
+	});
+});

--- a/src/lib/__tests__/activeRoutes.test.js
+++ b/src/lib/__tests__/activeRoutes.test.js
@@ -306,6 +306,21 @@ describe('assignRouteColors', () => {
 		}
 	});
 
+	// 'r_a' and 'r_i' both hash to the same palette slot, so they contend for one
+	// color: without sorting the fallback set by id, whichever comes first in the
+	// input claims that slot and the other probes forward — reversing the input
+	// would swap their colors. activeRoutes reshuffles on every 30s poll, so the
+	// assignment must not depend on input order even for a hash collision.
+	test('is stable when two fallback routes collide on the same palette slot', () => {
+		const routes = [route('r_a', null), route('r_i', null)];
+		const forward = assignRouteColors(routes, { dark: false });
+		const reversed = assignRouteColors([...routes].reverse(), { dark: false });
+		for (const { id } of routes) {
+			expect(reversed.get(id).line).toBe(forward.get(id).line);
+		}
+		expect(forward.get('r_a').line).not.toBe(forward.get('r_i').line);
+	});
+
 	// Two routes sharing one real, valid GTFS color is the exact scenario the
 	// fallback palette exists for. Routes are drawn soonest-arrival-first, so a
 	// naive "whichever comes first in the array wins the shared color" rule

--- a/src/lib/__tests__/activeRoutes.test.js
+++ b/src/lib/__tests__/activeRoutes.test.js
@@ -146,6 +146,94 @@ describe('activeRoutesFromArrivals', () => {
 		);
 		expect(result[0].shortName).toBe('773');
 		expect(result[0].gtfsColor).toBeNull();
+		expect(result[0].type).toBe(3);
+	});
+
+	test('uses type 3 default when route reference is missing, but uses the reference type when present', () => {
+		const result = activeRoutesFromArrivals(
+			makeResponse(
+				[
+					{
+						routeId: 'r_no_ref',
+						tripId: 't_a',
+						routeShortName: 'NoRef',
+						predicted: true,
+						predictedArrivalTime: 1000,
+						scheduledArrivalTime: 1000
+					},
+					{
+						routeId: 'r_with_ref',
+						tripId: 't_b',
+						routeShortName: 'WithRef',
+						predicted: true,
+						predictedArrivalTime: 2000,
+						scheduledArrivalTime: 2000
+					}
+				],
+				[{ id: 'r_with_ref', shortName: 'WithRef', type: 2, color: 'abc123' }]
+			)
+		);
+		const noRefRoute = result.find((r) => r.id === 'r_no_ref');
+		const withRefRoute = result.find((r) => r.id === 'r_with_ref');
+		expect(noRefRoute.type).toBe(3);
+		expect(withRefRoute.type).toBe(2);
+	});
+
+	test('maintains input order when routes have identical effective arrival times', () => {
+		const result = activeRoutesFromArrivals(
+			makeResponse(
+				[
+					{
+						routeId: 'r_first',
+						tripId: 't_first',
+						predicted: true,
+						predictedArrivalTime: 1000,
+						scheduledArrivalTime: 1000
+					},
+					{
+						routeId: 'r_second',
+						tripId: 't_second',
+						predicted: true,
+						predictedArrivalTime: 1000,
+						scheduledArrivalTime: 1000
+					},
+					{
+						routeId: 'r_third',
+						tripId: 't_third',
+						predicted: true,
+						predictedArrivalTime: 1000,
+						scheduledArrivalTime: 1000
+					}
+				],
+				[
+					{ id: 'r_first', shortName: 'First', type: 3, color: 'aaa' },
+					{ id: 'r_second', shortName: 'Second', type: 3, color: 'bbb' },
+					{ id: 'r_third', shortName: 'Third', type: 3, color: 'ccc' }
+				]
+			)
+		);
+		expect(result.map((r) => r.id)).toEqual(['r_first', 'r_second', 'r_third']);
+	});
+
+	test('handles null entries in arrivalsAndDepartures array', () => {
+		const result = activeRoutesFromArrivals(
+			makeResponse(
+				[
+					null,
+					{
+						routeId: 'r_valid',
+						tripId: 't_valid',
+						predicted: true,
+						predictedArrivalTime: 1000,
+						scheduledArrivalTime: 1000
+					},
+					null
+				],
+				[{ id: 'r_valid', shortName: 'Valid', type: 3, color: 'ddd' }]
+			)
+		);
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe('r_valid');
 	});
 
 	test.each([

--- a/src/lib/__tests__/activeRoutes.test.js
+++ b/src/lib/__tests__/activeRoutes.test.js
@@ -253,3 +253,113 @@ describe('activeRoutesFromArrivals', () => {
 		expect(result).toEqual([]);
 	});
 });
+
+import { assignRouteColors } from '$lib/activeRoutes.js';
+import { ROUTE_FALLBACK_PALETTE } from '$lib/colors.js';
+
+const route = (id, gtfsColor) => ({ id, shortName: id, type: 3, tripId: `t_${id}`, gtfsColor });
+
+function contrast(hexA, hexB) {
+	const lum = (hex) => {
+		const channels = [1, 3, 5]
+			.map((i) => parseInt(hex.slice(i, i + 2), 16) / 255)
+			.map((v) => (v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4));
+		return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+	};
+	const [hi, lo] = [lum(hexA), lum(hexB)].sort((a, b) => b - a);
+	return (hi + 0.05) / (lo + 0.05);
+}
+
+describe('assignRouteColors', () => {
+	test('keeps a unique GTFS color, contrast-adjusted for the basemap', () => {
+		const colors = assignRouteColors([route('r_c', 'b02a37')], { dark: false });
+		expect(colors.get('r_c').line).toBe('#b02a37');
+		expect(colors.get('r_c').badgeBg).toBe('b02a37');
+	});
+
+	test('badgeBg is always the line color without the hash', () => {
+		const colors = assignRouteColors([route('r_c', 'b02a37'), route('r_22', 'e0a021')], {
+			dark: true
+		});
+		for (const value of colors.values()) {
+			expect(value.badgeBg).toBe(value.line.slice(1));
+		}
+	});
+
+	test('gives colliding routes distinct colors', () => {
+		const colors = assignRouteColors([route('r_22', '4a4a4a'), route('r_128', '4a4a4a')], {
+			dark: false
+		});
+		expect(colors.get('r_22').line).not.toBe(colors.get('r_128').line);
+	});
+
+	test('assigns a palette color when the GTFS color is missing or invalid', () => {
+		const palette = ROUTE_FALLBACK_PALETTE.map((entry) => entry.light);
+		const colors = assignRouteColors([route('r_a', null), route('r_b', 'nonsense')], {
+			dark: false
+		});
+		expect(palette).toContain(colors.get('r_a').line);
+		expect(palette).toContain(colors.get('r_b').line);
+		expect(colors.get('r_a').line).not.toBe(colors.get('r_b').line);
+	});
+
+	test('is stable when the input order changes', () => {
+		const routes = [route('r_a', null), route('r_b', null), route('r_c', null)];
+		const forward = assignRouteColors(routes, { dark: false });
+		const reversed = assignRouteColors([...routes].reverse(), { dark: false });
+		for (const { id } of routes) {
+			expect(reversed.get(id).line).toBe(forward.get(id).line);
+		}
+	});
+
+	test('uses the dark palette variant in dark mode', () => {
+		const light = assignRouteColors([route('r_a', null)], { dark: false });
+		const dark = assignRouteColors([route('r_a', null)], { dark: true });
+		expect(dark.get('r_a').line).not.toBe(light.get('r_a').line);
+		expect(ROUTE_FALLBACK_PALETTE.map((e) => e.dark)).toContain(dark.get('r_a').line);
+	});
+
+	test('picks a readable badge foreground for light backgrounds', () => {
+		// #DCE775 (the Olive dark variant) is far too light for white text.
+		const colors = assignRouteColors([route('r_a', 'DCE775')], { dark: true });
+		const { badgeBg, badgeFg } = colors.get('r_a');
+		expect(contrast(`#${badgeBg}`, `#${badgeFg}`)).toBeGreaterThanOrEqual(4.5);
+	});
+
+	test('returns an empty map for an empty route list', () => {
+		expect(assignRouteColors([], { dark: false }).size).toBe(0);
+	});
+});
+
+describe('ROUTE_FALLBACK_PALETTE', () => {
+	// These guarantees are asserted in the design spec; enforce them here so a
+	// future palette edit can't quietly break legibility.
+	test('every entry clears 3:1 against its basemap and 4.5:1 against its text', () => {
+		for (const { light, dark } of ROUTE_FALLBACK_PALETTE) {
+			expect(contrast(light, '#F2F2F0')).toBeGreaterThanOrEqual(3);
+			expect(contrast(dark, '#1B1B1B')).toBeGreaterThanOrEqual(3);
+			expect(
+				Math.max(contrast(light, '#FFFFFF'), contrast(light, '#000000'))
+			).toBeGreaterThanOrEqual(4.5);
+			expect(Math.max(contrast(dark, '#FFFFFF'), contrast(dark, '#000000'))).toBeGreaterThanOrEqual(
+				4.5
+			);
+		}
+	});
+
+	test('entries stay visually distinct within each mode', () => {
+		const distance = (a, b) => {
+			const parse = (hex) => [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16));
+			const [x, y] = [parse(a), parse(b)];
+			return Math.hypot(x[0] - y[0], x[1] - y[1], x[2] - y[2]);
+		};
+		for (const key of ['light', 'dark']) {
+			const values = ROUTE_FALLBACK_PALETTE.map((entry) => entry[key]);
+			for (let i = 0; i < values.length; i++) {
+				for (let j = i + 1; j < values.length; j++) {
+					expect(distance(values[i], values[j])).toBeGreaterThan(60);
+				}
+			}
+		}
+	});
+});

--- a/src/lib/__tests__/activeRoutes.test.js
+++ b/src/lib/__tests__/activeRoutes.test.js
@@ -256,19 +256,13 @@ describe('activeRoutesFromArrivals', () => {
 
 import { assignRouteColors } from '$lib/activeRoutes.js';
 import { ROUTE_FALLBACK_PALETTE } from '$lib/colors.js';
+import { contrastRatio, rgbToHex } from '$lib/colorUtils.js';
 
 const route = (id, gtfsColor) => ({ id, shortName: id, type: 3, tripId: `t_${id}`, gtfsColor });
 
-function contrast(hexA, hexB) {
-	const lum = (hex) => {
-		const channels = [1, 3, 5]
-			.map((i) => parseInt(hex.slice(i, i + 2), 16) / 255)
-			.map((v) => (v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4));
-		return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
-	};
-	const [hi, lo] = [lum(hexA), lum(hexB)].sort((a, b) => b - a);
-	return (hi + 0.05) / (lo + 0.05);
-}
+// Thin wrapper kept so the palette/badge assertions below read as "hex, hex"
+// rather than "#hex, #hex" — contrastRatio itself tolerates either form.
+const contrast = (hexA, hexB) => contrastRatio(hexA, hexB);
 
 describe('assignRouteColors', () => {
 	test('keeps a unique GTFS color, contrast-adjusted for the basemap', () => {
@@ -312,6 +306,43 @@ describe('assignRouteColors', () => {
 		}
 	});
 
+	// Two routes sharing one real, valid GTFS color is the exact scenario the
+	// fallback palette exists for. Routes are drawn soonest-arrival-first, so a
+	// naive "whichever comes first in the array wins the shared color" rule
+	// means two routes with close arrival times would swap the winner — and
+	// therefore both routes' colors — between 30s polls, with no underlying
+	// data change. Every permutation of the same three routes must produce
+	// identical colors for every route, not just the keeper.
+	test('resolves a shared GTFS color collision identically regardless of input order', () => {
+		const alpha = route('r_alpha', '4a4a4a');
+		const beta = route('r_beta', '4a4a4a');
+		const gamma = route('r_gamma', null);
+		const all = [alpha, beta, gamma];
+
+		const permutations = [
+			[alpha, beta, gamma],
+			[alpha, gamma, beta],
+			[beta, alpha, gamma],
+			[beta, gamma, alpha],
+			[gamma, alpha, beta],
+			[gamma, beta, alpha]
+		];
+
+		const results = permutations.map((order) => assignRouteColors(order, { dark: false }));
+		const reference = results[0];
+
+		for (const result of results) {
+			for (const { id } of all) {
+				expect(result.get(id)).toEqual(reference.get(id));
+			}
+		}
+
+		// 'r_alpha' sorts before 'r_beta' lexicographically, so it is the
+		// deterministic keeper of the shared color; 'r_beta' must fall back.
+		expect(reference.get('r_alpha').line).toBe('#4a4a4a');
+		expect(reference.get('r_beta').line).not.toBe('#4a4a4a');
+	});
+
 	test('uses the dark palette variant in dark mode', () => {
 		const light = assignRouteColors([route('r_a', null)], { dark: false });
 		const dark = assignRouteColors([route('r_a', null)], { dark: true });
@@ -324,6 +355,45 @@ describe('assignRouteColors', () => {
 		const colors = assignRouteColors([route('r_a', 'DCE775')], { dark: true });
 		const { badgeBg, badgeFg } = colors.get('r_a');
 		expect(contrast(`#${badgeBg}`, `#${badgeFg}`)).toBeGreaterThanOrEqual(4.5);
+	});
+
+	// Property test, not an example: the old NTSC-brightness heuristic
+	// (getBrightness(rgb) > 140) mis-picked badge text color on 14.4% of a
+	// dense RGB sweep run through this same pipeline — including ordinary GTFS
+	// colors like forest green and saturated red that keep their own color and
+	// so aren't covered by any palette test. Sweep a coarse-but-broad grid of
+	// backgrounds through the real pipeline in both themes and require every
+	// single one to clear the 4.5:1 WCAG AA minimum.
+	test('badge foreground clears 4.5:1 WCAG contrast for every color the pipeline can produce', () => {
+		const step = 51; // 0,51,102,153,204,255: 6^3 = 216 combos
+		const swept = [];
+		for (let r = 0; r <= 255; r += step) {
+			for (let g = 0; g <= 255; g += step) {
+				for (let b = 0; b <= 255; b += step) {
+					swept.push(rgbToHex(r, g, b).slice(1));
+				}
+			}
+		}
+
+		// Colors called out by name as failures under the old heuristic (worst
+		// case 1.63:1 for #00eb0f). Kept explicit so a regression on any one of
+		// them fails with an obvious message rather than being one hit among 216.
+		const knownFailures = ['00eb0f', '009900', 'ff0000', 'ff6600', 'ff00ff'];
+
+		const palette = [...new Set([...swept, ...knownFailures])];
+
+		for (const dark of [false, true]) {
+			for (const hex of palette) {
+				const routeId = `r_${hex}`;
+				const colors = assignRouteColors([route(routeId, hex)], { dark });
+				const { badgeBg, badgeFg } = colors.get(routeId);
+				const ratio = contrast(`#${badgeBg}`, `#${badgeFg}`);
+				expect(
+					ratio,
+					`#${hex} (dark=${dark}): badgeFg #${badgeFg} vs badgeBg #${badgeBg} = ${ratio.toFixed(2)}:1`
+				).toBeGreaterThanOrEqual(4.5);
+			}
+		}
 	});
 
 	test('returns an empty map for an empty route list', () => {

--- a/src/lib/__tests__/vehicleUtils.test.js
+++ b/src/lib/__tests__/vehicleUtils.test.js
@@ -1,9 +1,28 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
 	buildVehiclePopupData,
 	updateVehicleMarkers,
-	clearVehicleMarkersMap
+	clearVehicleMarkersMap,
+	fetchVehicles,
+	fetchAndUpdateVehiclesForRoutes
 } from '$lib/vehicleUtils.js';
+
+function tripsResponse(routeId, vehicles) {
+	return {
+		data: {
+			references: { trips: vehicles.map((v) => ({ id: v.tripId, routeId })) },
+			list: vehicles.map((v) => ({
+				status: {
+					activeTripId: v.tripId,
+					vehicleId: v.vehicleId,
+					position: { lat: 47.6, lon: -122.3 },
+					predicted: true,
+					orientation: 0
+				}
+			}))
+		}
+	};
+}
 
 describe('buildVehiclePopupData', () => {
 	it('returns popup data with stop name when stopsMap has the nextStop', () => {
@@ -230,5 +249,148 @@ describe('updateVehicleMarkers', () => {
 		for (const call of provider.updateVehicleMarker.mock.calls) {
 			expect(call[5]).toBe('#0a4ea2');
 		}
+	});
+});
+
+function makeMultiRouteProvider() {
+	return {
+		addVehicleMarker: vi.fn((status) => ({ id: status.vehicleId })),
+		updateVehicleMarker: vi.fn(),
+		removeVehicleMarker: vi.fn()
+	};
+}
+
+describe('fetchVehicles failure contract', () => {
+	test('returns null when the request fails', async () => {
+		global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+		expect(await fetchVehicles('route_1')).toBeNull();
+	});
+
+	test('returns null for a malformed body', async () => {
+		global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: {} }) });
+		expect(await fetchVehicles('route_1')).toBeNull();
+	});
+
+	test('returns the data for a well-formed empty response', async () => {
+		global.fetch = vi
+			.fn()
+			.mockResolvedValue({ ok: true, json: async () => tripsResponse('route_1', []) });
+		expect(await fetchVehicles('route_1')).toEqual({ references: { trips: [] }, list: [] });
+	});
+});
+
+describe('fetchAndUpdateVehiclesForRoutes', () => {
+	beforeEach(() => {
+		clearVehicleMarkersMap();
+		vi.useFakeTimers();
+	});
+	afterEach(() => vi.useRealTimers());
+
+	// The old per-route sweep deleted every marker absent from the single polled
+	// route's active set, so three concurrent route polls each wiped the other two.
+	test('polling three routes keeps all three routes markers', async () => {
+		const provider = makeMultiRouteProvider();
+		global.fetch = vi.fn(async (url) => {
+			const routeId = url.split('/').pop();
+			return {
+				ok: true,
+				json: async () =>
+					tripsResponse(routeId, [{ tripId: `t_${routeId}`, vehicleId: `v_${routeId}` }])
+			};
+		});
+
+		const intervalId = await fetchAndUpdateVehiclesForRoutes(
+			[
+				{ id: 'r_a', type: 3 },
+				{ id: 'r_b', type: 3 },
+				{ id: 'r_c', type: 3 }
+			],
+			provider
+		);
+		clearInterval(intervalId);
+
+		expect(provider.addVehicleMarker).toHaveBeenCalledTimes(3);
+		expect(provider.removeVehicleMarker).not.toHaveBeenCalled();
+	});
+
+	test('removes only the vehicle a route stopped reporting', async () => {
+		const provider = makeMultiRouteProvider();
+		let secondTick = false;
+		global.fetch = vi.fn(async (url) => {
+			const routeId = url.split('/').pop();
+			const vehicles =
+				routeId === 'r_a' && secondTick
+					? []
+					: [{ tripId: `t_${routeId}`, vehicleId: `v_${routeId}` }];
+			return { ok: true, json: async () => tripsResponse(routeId, vehicles) };
+		});
+
+		const routes = [
+			{ id: 'r_a', type: 3 },
+			{ id: 'r_b', type: 3 }
+		];
+		const intervalId = await fetchAndUpdateVehiclesForRoutes(routes, provider);
+		secondTick = true;
+		await vi.advanceTimersByTimeAsync(30000);
+		clearInterval(intervalId);
+
+		expect(provider.removeVehicleMarker).toHaveBeenCalledTimes(1);
+	});
+
+	// fetchVehicles used to return an empty list for a failed request, which a
+	// scoped sweep would read as "this route has no vehicles" and clear them all.
+	test('a failed fetch for one route leaves that routes markers alone', async () => {
+		const provider = makeMultiRouteProvider();
+		let failSecond = false;
+		global.fetch = vi.fn(async (url) => {
+			const routeId = url.split('/').pop();
+			if (routeId === 'r_a' && failSecond) return { ok: false, status: 503 };
+			return {
+				ok: true,
+				json: async () =>
+					tripsResponse(routeId, [{ tripId: `t_${routeId}`, vehicleId: `v_${routeId}` }])
+			};
+		});
+
+		const intervalId = await fetchAndUpdateVehiclesForRoutes(
+			[
+				{ id: 'r_a', type: 3 },
+				{ id: 'r_b', type: 3 }
+			],
+			provider
+		);
+		failSecond = true;
+		await vi.advanceTimersByTimeAsync(30000);
+		clearInterval(intervalId);
+
+		expect(provider.removeVehicleMarker).not.toHaveBeenCalled();
+	});
+
+	test('reports a live vehicle count per route', async () => {
+		const provider = makeMultiRouteProvider();
+		global.fetch = vi.fn(async (url) => {
+			const routeId = url.split('/').pop();
+			const count = routeId === 'r_a' ? 2 : 1;
+			const vehicles = Array.from({ length: count }, (_, i) => ({
+				tripId: `t_${routeId}_${i}`,
+				vehicleId: `v_${routeId}_${i}`
+			}));
+			return { ok: true, json: async () => tripsResponse(routeId, vehicles) };
+		});
+		const onCounts = vi.fn();
+
+		const intervalId = await fetchAndUpdateVehiclesForRoutes(
+			[
+				{ id: 'r_a', type: 3 },
+				{ id: 'r_b', type: 3 }
+			],
+			provider,
+			{ onCounts }
+		);
+		clearInterval(intervalId);
+
+		const counts = onCounts.mock.calls.at(-1)[0];
+		expect(counts.get('r_a')).toBe(2);
+		expect(counts.get('r_b')).toBe(1);
 	});
 });

--- a/src/lib/__tests__/vehicleUtils.test.js
+++ b/src/lib/__tests__/vehicleUtils.test.js
@@ -4,7 +4,8 @@ import {
 	clearVehicleMarkersMap,
 	fetchVehicles,
 	fetchAndUpdateVehicles,
-	fetchAndUpdateVehiclesForRoutes
+	fetchAndUpdateVehiclesForRoutes,
+	removeVehicleMarkersForRoutes
 } from '$lib/vehicleUtils.js';
 
 function tripsResponse(routeId, vehicles) {
@@ -504,6 +505,60 @@ describe('fetchAndUpdateVehiclesForRoutes', () => {
 
 		const counts = onCounts.mock.calls.at(-1)[0];
 		expect(counts.get('r_b')).toBe(1);
+	});
+});
+
+// Self-scoped teardown for a caller (StopRoutesLayer) that owns a subset of
+// routes and must remove exactly its own markers on unmount/redraw, without
+// disturbing markers a sibling component (e.g. SearchPane, drawing a route
+// selected from search) is polling concurrently.
+describe('removeVehicleMarkersForRoutes', () => {
+	beforeEach(() => {
+		clearVehicleMarkersMap();
+		vi.useFakeTimers();
+	});
+	afterEach(() => vi.useRealTimers());
+
+	test('removes only the given routes markers, leaving others intact', async () => {
+		const provider = makeMultiRouteProvider();
+		global.fetch = vi.fn(async (url) => {
+			const routeId = url.split('/').pop();
+			return {
+				ok: true,
+				json: async () =>
+					tripsResponse(routeId, [{ tripId: `t_${routeId}`, vehicleId: `v_${routeId}` }])
+			};
+		});
+
+		const { intervalId } = await fetchAndUpdateVehiclesForRoutes(
+			[
+				{ id: 'r_a', type: 3 },
+				{ id: 'r_b', type: 3 }
+			],
+			provider
+		);
+		clearInterval(intervalId);
+		expect(provider.addVehicleMarker).toHaveBeenCalledTimes(2);
+
+		removeVehicleMarkersForRoutes(['r_a'], provider);
+
+		expect(provider.removeVehicleMarker).toHaveBeenCalledTimes(1);
+		expect(provider.removeVehicleMarker).toHaveBeenCalledWith({ id: 'v_r_a' });
+
+		// r_b's marker must survive: re-polling only r_b (simulating a sibling
+		// layer that still owns it) must update the existing marker rather than
+		// add a new one, proving it's still tracked in the module map rather than
+		// only detached visually.
+		provider.addVehicleMarker.mockClear();
+		provider.updateVehicleMarker.mockClear();
+		const { intervalId: secondIntervalId } = await fetchAndUpdateVehiclesForRoutes(
+			[{ id: 'r_b', type: 3 }],
+			provider
+		);
+		clearInterval(secondIntervalId);
+
+		expect(provider.updateVehicleMarker).toHaveBeenCalledTimes(1);
+		expect(provider.addVehicleMarker).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/lib/__tests__/vehicleUtils.test.js
+++ b/src/lib/__tests__/vehicleUtils.test.js
@@ -96,7 +96,7 @@ describe('applyRouteVehicles behavior via fetchAndUpdateVehiclesForRoutes (singl
 	}
 
 	async function updateRoute1(provider, { highlightedTripId = null, routeColor } = {}) {
-		const intervalId = await fetchAndUpdateVehiclesForRoutes(
+		const { intervalId } = await fetchAndUpdateVehiclesForRoutes(
 			[{ id: 'route-1', type: undefined }],
 			provider,
 			{
@@ -320,7 +320,7 @@ describe('fetchAndUpdateVehiclesForRoutes', () => {
 			};
 		});
 
-		const intervalId = await fetchAndUpdateVehiclesForRoutes(
+		const { intervalId } = await fetchAndUpdateVehiclesForRoutes(
 			[
 				{ id: 'r_a', type: 3 },
 				{ id: 'r_b', type: 3 },
@@ -350,7 +350,7 @@ describe('fetchAndUpdateVehiclesForRoutes', () => {
 			{ id: 'r_a', type: 3 },
 			{ id: 'r_b', type: 3 }
 		];
-		const intervalId = await fetchAndUpdateVehiclesForRoutes(routes, provider);
+		const { intervalId } = await fetchAndUpdateVehiclesForRoutes(routes, provider);
 		secondTick = true;
 		await vi.advanceTimersByTimeAsync(30000);
 		clearInterval(intervalId);
@@ -373,7 +373,7 @@ describe('fetchAndUpdateVehiclesForRoutes', () => {
 			};
 		});
 
-		const intervalId = await fetchAndUpdateVehiclesForRoutes(
+		const { intervalId } = await fetchAndUpdateVehiclesForRoutes(
 			[
 				{ id: 'r_a', type: 3 },
 				{ id: 'r_b', type: 3 }
@@ -400,7 +400,7 @@ describe('fetchAndUpdateVehiclesForRoutes', () => {
 		});
 		const onCounts = vi.fn();
 
-		const intervalId = await fetchAndUpdateVehiclesForRoutes(
+		const { intervalId } = await fetchAndUpdateVehiclesForRoutes(
 			[
 				{ id: 'r_a', type: 3 },
 				{ id: 'r_b', type: 3 }
@@ -453,7 +453,7 @@ describe('fetchAndUpdateVehiclesForRoutes', () => {
 			{ id: 'r_a', type: 3 },
 			{ id: 'r_b', type: 3 }
 		];
-		const intervalId = await fetchAndUpdateVehiclesForRoutes(routes, provider);
+		const { intervalId } = await fetchAndUpdateVehiclesForRoutes(routes, provider);
 
 		tick = 2;
 		await vi.advanceTimersByTimeAsync(30000);
@@ -487,7 +487,7 @@ describe('fetchAndUpdateVehiclesForRoutes', () => {
 		});
 		const onCounts = vi.fn();
 
-		const intervalId = await fetchAndUpdateVehiclesForRoutes(
+		const { intervalId } = await fetchAndUpdateVehiclesForRoutes(
 			[
 				{ id: 'r_a', type: 3 },
 				{ id: 'r_b', type: 3 }
@@ -504,6 +504,98 @@ describe('fetchAndUpdateVehiclesForRoutes', () => {
 
 		const counts = onCounts.mock.calls.at(-1)[0];
 		expect(counts.get('r_b')).toBe(1);
+	});
+});
+
+// Task 10b: highlightedTripId used to be captured once, by value, at poll
+// start — so it could never change without restarting the whole poll. It can
+// now also be a getter, re-resolved on every tick, so a trip expansion can
+// move the highlight glow onto a live poll instead of waiting for the next
+// route redraw.
+describe('fetchAndUpdateVehiclesForRoutes — live highlight', () => {
+	beforeEach(() => {
+		clearVehicleMarkersMap();
+		vi.useFakeTimers();
+	});
+	afterEach(() => vi.useRealTimers());
+
+	function mockTwoRoutesOneVehicleEach() {
+		global.fetch = vi.fn(async (url) => {
+			const routeId = url.split('/').pop();
+			return {
+				ok: true,
+				json: async () =>
+					tripsResponse(routeId, [{ tripId: `t_${routeId}`, vehicleId: `v_${routeId}` }])
+			};
+		});
+	}
+
+	test('re-reads the highlight via a getter, so it can change between ticks', async () => {
+		const provider = makeMultiRouteProvider();
+		mockTwoRoutesOneVehicleEach();
+		let highlighted = 't_r_a';
+
+		const { intervalId, tick } = await fetchAndUpdateVehiclesForRoutes(
+			[
+				{ id: 'r_a', type: 3 },
+				{ id: 'r_b', type: 3 }
+			],
+			provider,
+			{ highlightedTripId: () => highlighted }
+		);
+
+		const firstPassCalls = provider.addVehicleMarker.mock.calls;
+		expect(firstPassCalls.find((c) => c[1].id === 't_r_a')[3]).toBe(true);
+		expect(firstPassCalls.find((c) => c[1].id === 't_r_b')[3]).toBe(false);
+
+		// Change which trip is highlighted, then force a tick — a value
+		// captured once at poll start could never observe this change.
+		highlighted = 't_r_b';
+		provider.updateVehicleMarker.mockClear();
+		await tick();
+
+		const secondPassCalls = provider.updateVehicleMarker.mock.calls;
+		expect(secondPassCalls.find((c) => c[2].id === 't_r_a')[4]).toBe(false);
+		expect(secondPassCalls.find((c) => c[2].id === 't_r_b')[4]).toBe(true);
+
+		clearInterval(intervalId);
+	});
+
+	test('tick() forces an immediate refresh instead of waiting for the poll interval', async () => {
+		const provider = makeMultiRouteProvider();
+		let vehicleId = 'v1';
+		global.fetch = vi.fn(async () => ({
+			ok: true,
+			json: async () => tripsResponse('r_a', [{ tripId: 't1', vehicleId }])
+		}));
+
+		const { intervalId, tick } = await fetchAndUpdateVehiclesForRoutes(
+			[{ id: 'r_a', type: 3 }],
+			provider
+		);
+		expect(provider.addVehicleMarker).toHaveBeenCalledTimes(1);
+
+		// A second, distinct vehicle appears — proves this ran a real extra
+		// fetch/apply cycle, not just a no-op re-invocation.
+		vehicleId = 'v2';
+		await tick();
+
+		expect(provider.addVehicleMarker).toHaveBeenCalledTimes(2);
+		clearInterval(intervalId);
+	});
+
+	test('still accepts a plain value for highlightedTripId, not just a getter', async () => {
+		const provider = makeMultiRouteProvider();
+		mockTwoRoutesOneVehicleEach();
+
+		const { intervalId } = await fetchAndUpdateVehiclesForRoutes(
+			[{ id: 'r_a', type: 3 }],
+			provider,
+			{ highlightedTripId: 't_r_a' }
+		);
+
+		expect(provider.addVehicleMarker.mock.calls[0][3]).toBe(true);
+		clearInterval(intervalId);
 	});
 });
 
@@ -579,5 +671,24 @@ describe('fetchAndUpdateVehicles (wrapper)', () => {
 		clearInterval(intervalId);
 
 		expect(provider.addVehicleMarker.mock.calls[0][4]).toBeUndefined();
+	});
+
+	// SearchPane.svelte:174 and RouteMap.svelte:100 both do
+	// `currentIntervalId = await fetchAndUpdateVehicles(...)` and later
+	// `clearInterval(currentIntervalId)` — unlike
+	// fetchAndUpdateVehiclesForRoutes, this wrapper must keep resolving to a
+	// bare interval id, not `{ intervalId, tick }`, or both call sites break.
+	test('resolves to a bare interval id, not an { intervalId, tick } object', async () => {
+		mockFetch(ONE_VEHICLE_RESPONSE);
+		const provider = makeProvider();
+
+		const result = await fetchAndUpdateVehicles('route-1', provider, 3);
+
+		// Node's setInterval returns an opaque Timeout, not a plain number, so
+		// assert on shape rather than typeof: the wrapper must hand back
+		// whatever setInterval itself returned, not { intervalId, tick }.
+		expect(result).not.toHaveProperty('intervalId');
+		expect(result).not.toHaveProperty('tick');
+		expect(() => clearInterval(result)).not.toThrow();
 	});
 });

--- a/src/lib/__tests__/vehicleUtils.test.js
+++ b/src/lib/__tests__/vehicleUtils.test.js
@@ -1,9 +1,9 @@
 import { describe, it, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
 	buildVehiclePopupData,
-	updateVehicleMarkers,
 	clearVehicleMarkersMap,
 	fetchVehicles,
+	fetchAndUpdateVehicles,
 	fetchAndUpdateVehiclesForRoutes
 } from '$lib/vehicleUtils.js';
 
@@ -73,7 +73,16 @@ describe('buildVehiclePopupData', () => {
 	});
 });
 
-describe('updateVehicleMarkers', () => {
+// This suite used to drive the now-deleted single-route `updateVehicleMarkers`
+// wrapper directly. That wrapper had zero production callers (SearchPane and
+// RouteMap both go through `fetchAndUpdateVehicles`) and only duplicated what
+// `fetchAndUpdateVehiclesForRoutes` already does for a single-route array, so
+// it was removed. The behavior under test here — highlighting, marker-keying
+// by vehicleId, routeColor forwarding — lives in the shared
+// `applyRouteVehicles` helper, which the production path also exercises, so
+// driving it through `fetchAndUpdateVehiclesForRoutes([{ id: 'route-1' }], ...)`
+// preserves the same coverage.
+describe('applyRouteVehicles behavior via fetchAndUpdateVehiclesForRoutes (single route)', () => {
 	function makeProvider() {
 		return {
 			addVehicleMarker: vi.fn(() => ({})),
@@ -84,6 +93,18 @@ describe('updateVehicleMarkers', () => {
 
 	function mockFetch(data) {
 		global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data }) });
+	}
+
+	async function updateRoute1(provider, { highlightedTripId = null, routeColor } = {}) {
+		const intervalId = await fetchAndUpdateVehiclesForRoutes(
+			[{ id: 'route-1', type: undefined }],
+			provider,
+			{
+				highlightedTripId,
+				colorsByRouteId: routeColor ? new Map([['route-1', { line: routeColor }]]) : new Map()
+			}
+		);
+		clearInterval(intervalId);
 	}
 
 	const TWO_VEHICLE_RESPONSE = {
@@ -125,7 +146,7 @@ describe('updateVehicleMarkers', () => {
 		it('marks only the matching trip as highlighted', async () => {
 			const provider = makeProvider();
 
-			await updateVehicleMarkers('route-1', provider, undefined, 'trip-1');
+			await updateRoute1(provider, { highlightedTripId: 'trip-1' });
 
 			const calls = provider.addVehicleMarker.mock.calls;
 			expect(highlightArg(calls.find((c) => tripOf(c) === 'trip-1'))).toBe(true);
@@ -135,7 +156,7 @@ describe('updateVehicleMarkers', () => {
 		it('highlights no vehicle when highlightedTripId is null', async () => {
 			const provider = makeProvider();
 
-			await updateVehicleMarkers('route-1', provider, undefined, null);
+			await updateRoute1(provider, { highlightedTripId: null });
 
 			for (const call of provider.addVehicleMarker.mock.calls) {
 				expect(highlightArg(call)).toBe(false);
@@ -145,8 +166,8 @@ describe('updateVehicleMarkers', () => {
 		it('passes the highlight flag through to updates on subsequent refreshes', async () => {
 			const provider = makeProvider();
 
-			await updateVehicleMarkers('route-1', provider, undefined, 'trip-2');
-			await updateVehicleMarkers('route-1', provider, undefined, 'trip-2');
+			await updateRoute1(provider, { highlightedTripId: 'trip-2' });
+			await updateRoute1(provider, { highlightedTripId: 'trip-2' });
 
 			const calls = provider.updateVehicleMarker.mock.calls;
 			const trip2 = calls.find((c) => c[2].id === 'trip-2');
@@ -181,7 +202,7 @@ describe('updateVehicleMarkers', () => {
 			});
 
 			const provider = makeProvider();
-			await updateVehicleMarkers('route-1', provider);
+			await updateRoute1(provider);
 
 			expect(provider.addVehicleMarker).toHaveBeenCalledTimes(2);
 			expect(provider.updateVehicleMarker).not.toHaveBeenCalled();
@@ -201,8 +222,8 @@ describe('updateVehicleMarkers', () => {
 			mockFetch({ references: { trips: [{ id: 'trip-1', routeId: 'route-1' }] }, list });
 
 			const provider = makeProvider();
-			await updateVehicleMarkers('route-1', provider);
-			await updateVehicleMarkers('route-1', provider);
+			await updateRoute1(provider);
+			await updateRoute1(provider);
 
 			expect(provider.addVehicleMarker).toHaveBeenCalledTimes(1);
 			expect(provider.updateVehicleMarker).toHaveBeenCalledTimes(1);
@@ -223,7 +244,7 @@ describe('updateVehicleMarkers', () => {
 			});
 
 			const provider = makeProvider();
-			await updateVehicleMarkers('route-1', provider);
+			await updateRoute1(provider);
 
 			expect(provider.addVehicleMarker).toHaveBeenCalledTimes(1);
 		});
@@ -233,7 +254,7 @@ describe('updateVehicleMarkers', () => {
 		mockFetch(TWO_VEHICLE_RESPONSE);
 		const provider = makeProvider();
 
-		await updateVehicleMarkers('route-1', provider, undefined, 'trip-1', '#0a4ea2');
+		await updateRoute1(provider, { highlightedTripId: 'trip-1', routeColor: '#0a4ea2' });
 		for (const call of provider.addVehicleMarker.mock.calls) {
 			expect(call[4]).toBe('#0a4ea2');
 		}
@@ -243,8 +264,8 @@ describe('updateVehicleMarkers', () => {
 		mockFetch(TWO_VEHICLE_RESPONSE);
 		// First pass creates markers, second pass updates them.
 		const provider = makeProvider();
-		await updateVehicleMarkers('route-1', provider, undefined, 'trip-1', '#0a4ea2');
-		await updateVehicleMarkers('route-1', provider, undefined, 'trip-1', '#0a4ea2');
+		await updateRoute1(provider, { highlightedTripId: 'trip-1', routeColor: '#0a4ea2' });
+		await updateRoute1(provider, { highlightedTripId: 'trip-1', routeColor: '#0a4ea2' });
 		expect(provider.updateVehicleMarker).toHaveBeenCalled();
 		for (const call of provider.updateVehicleMarker.mock.calls) {
 			expect(call[5]).toBe('#0a4ea2');
@@ -392,5 +413,171 @@ describe('fetchAndUpdateVehiclesForRoutes', () => {
 		const counts = onCounts.mock.calls.at(-1)[0];
 		expect(counts.get('r_a')).toBe(2);
 		expect(counts.get('r_b')).toBe(1);
+	});
+
+	// A physical vehicle can move between routes across a shift (e.g. a driver
+	// swap). `applyRouteVehicles` re-stamps `existing.routeId` on marker reuse
+	// specifically so ownership transfers to whichever route reports the
+	// vehicle now.
+	//
+	// The re-stamp only becomes observable once the *old* owning route later
+	// fails to fetch (dropping out of `polledRouteIds` for that tick): if
+	// ownership were still (wrongly) attributed to it, the marker would be
+	// skipped by the scoped sweep and never cleaned up even though its *new*
+	// owner has stopped reporting it. If both routes always fetch
+	// successfully, `polledRouteIds` contains both regardless of which one
+	// owns the marker, so removal wouldn't depend on the re-stamp at all.
+	test('a vehicle that moves to a different route transfers ownership instead of being orphaned', async () => {
+		const provider = makeMultiRouteProvider();
+		let tick = 1;
+		global.fetch = vi.fn(async (url) => {
+			const routeId = url.split('/').pop();
+			if (tick === 1) {
+				const vehicles = routeId === 'r_a' ? [{ tripId: 't1_a', vehicleId: 'v1' }] : [];
+				return { ok: true, json: async () => tripsResponse(routeId, vehicles) };
+			}
+			if (tick === 2) {
+				// v1 now reported by r_b instead of r_a.
+				const vehicles = routeId === 'r_b' ? [{ tripId: 't1_b', vehicleId: 'v1' }] : [];
+				return { ok: true, json: async () => tripsResponse(routeId, vehicles) };
+			}
+			// tick 3: r_a (the *old* owner) fails to fetch entirely, and r_b (the
+			// new owner) drops v1. If ownership hadn't transferred to r_b, the
+			// marker would still be attributed to r_a, which is absent from
+			// polledRouteIds this tick, and would incorrectly survive.
+			if (routeId === 'r_a') return { ok: false, status: 503 };
+			return { ok: true, json: async () => tripsResponse(routeId, []) };
+		});
+
+		const routes = [
+			{ id: 'r_a', type: 3 },
+			{ id: 'r_b', type: 3 }
+		];
+		const intervalId = await fetchAndUpdateVehiclesForRoutes(routes, provider);
+
+		tick = 2;
+		await vi.advanceTimersByTimeAsync(30000);
+		expect(provider.removeVehicleMarker).not.toHaveBeenCalled();
+
+		tick = 3;
+		await vi.advanceTimersByTimeAsync(30000);
+		clearInterval(intervalId);
+
+		expect(provider.removeVehicleMarker).toHaveBeenCalledTimes(1);
+	});
+
+	// Only the fetch is isolated per route inside Promise.all. If
+	// applyRouteVehicles throws synchronously for one route (e.g. a
+	// map-provider bug in addVehicleMarker), that must not skip the routes
+	// ordered after it in the forEach, nor abort removeInactiveMarkers/onCounts
+	// for the tick.
+	test('a route whose applyRouteVehicles throws does not block other routes from updating', async () => {
+		const provider = makeMultiRouteProvider();
+		provider.addVehicleMarker.mockImplementation((status) => {
+			if (status.vehicleId === 'v_r_a') throw new Error('boom');
+			return { id: status.vehicleId };
+		});
+		global.fetch = vi.fn(async (url) => {
+			const routeId = url.split('/').pop();
+			return {
+				ok: true,
+				json: async () =>
+					tripsResponse(routeId, [{ tripId: `t_${routeId}`, vehicleId: `v_${routeId}` }])
+			};
+		});
+		const onCounts = vi.fn();
+
+		const intervalId = await fetchAndUpdateVehiclesForRoutes(
+			[
+				{ id: 'r_a', type: 3 },
+				{ id: 'r_b', type: 3 }
+			],
+			provider,
+			{ onCounts }
+		);
+		clearInterval(intervalId);
+
+		const calledForB = provider.addVehicleMarker.mock.calls.some(
+			(call) => call[0].vehicleId === 'v_r_b'
+		);
+		expect(calledForB).toBe(true);
+
+		const counts = onCounts.mock.calls.at(-1)[0];
+		expect(counts.get('r_b')).toBe(1);
+	});
+});
+
+describe('fetchAndUpdateVehicles (wrapper)', () => {
+	beforeEach(() => clearVehicleMarkersMap());
+	afterEach(() => vi.restoreAllMocks());
+
+	function makeProvider() {
+		return {
+			addVehicleMarker: vi.fn(() => ({})),
+			updateVehicleMarker: vi.fn(),
+			removeVehicleMarker: vi.fn()
+		};
+	}
+
+	function mockFetch(data) {
+		global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data }) });
+	}
+
+	const ONE_VEHICLE_RESPONSE = {
+		references: { trips: [{ id: 'trip-1', routeId: 'route-1' }] },
+		list: [
+			{
+				status: {
+					activeTripId: 'trip-1',
+					status: 'SCHEDULED',
+					vehicleId: 'veh-A',
+					position: { lat: 47.5, lon: -122.3 }
+				}
+			}
+		]
+	};
+
+	// SearchPane calls fetchAndUpdateVehicles(routeId, provider, routeType).
+	test('SearchPane call shape forwards routeType to addVehicleMarker', async () => {
+		mockFetch(ONE_VEHICLE_RESPONSE);
+		const provider = makeProvider();
+
+		const intervalId = await fetchAndUpdateVehicles('route-1', provider, 3);
+		clearInterval(intervalId);
+
+		expect(provider.addVehicleMarker).toHaveBeenCalledTimes(1);
+		// addVehicleMarker(vehicleStatus, activeTrip, routeType, isHighlighted, routeColor)
+		expect(provider.addVehicleMarker.mock.calls[0][2]).toBe(3);
+	});
+
+	// RouteMap calls fetchAndUpdateVehicles(routeId, provider, undefined, tripId, routeColor).
+	test('RouteMap call shape flags the highlighted trip and forwards the route color', async () => {
+		mockFetch(ONE_VEHICLE_RESPONSE);
+		const provider = makeProvider();
+
+		const intervalId = await fetchAndUpdateVehicles(
+			'route-1',
+			provider,
+			undefined,
+			'trip-1',
+			'#0a4ea2'
+		);
+		clearInterval(intervalId);
+
+		const call = provider.addVehicleMarker.mock.calls[0];
+		expect(call[3]).toBe(true);
+		expect(call[4]).toBe('#0a4ea2');
+	});
+
+	// routeColor === undefined must collapse to an empty color map, matching
+	// pre-change behavior: no color forwarded to addVehicleMarker.
+	test('an omitted routeColor forwards no color to addVehicleMarker', async () => {
+		mockFetch(ONE_VEHICLE_RESPONSE);
+		const provider = makeProvider();
+
+		const intervalId = await fetchAndUpdateVehicles('route-1', provider, 3, 'trip-1');
+		clearInterval(intervalId);
+
+		expect(provider.addVehicleMarker.mock.calls[0][4]).toBeUndefined();
 	});
 });

--- a/src/lib/activeRoutes.js
+++ b/src/lib/activeRoutes.js
@@ -163,6 +163,14 @@ export function assignRouteColors(routes, { dark = false } = {}) {
 		needsFallback.push(...rest.map((entry) => entry.route));
 	}
 
+	// Sorted by id before probing so palette allocation is order-independent too:
+	// two ids that hash to the same slot (e.g. `r_a` and `r_i` both land on slot
+	// 4) would otherwise let whichever arrives first claim it and force the other
+	// to probe forward, so reversing the arrivals order would swap their colors.
+	// activeRoutes reshuffles soonest-arrival-first on every 30s poll, so an
+	// input-order-dependent rule would flip both colors with no data change.
+	needsFallback.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
 	for (const route of needsFallback) {
 		const start = paletteIndexFor(route.id);
 		let line = null;

--- a/src/lib/activeRoutes.js
+++ b/src/lib/activeRoutes.js
@@ -72,3 +72,88 @@ export function activeRoutesFromArrivals(response) {
 			};
 		});
 }
+
+import { mapContrastColor, getBrightness, hexToRgb } from '$lib/colorUtils.js';
+import { ROUTE_FALLBACK_PALETTE } from '$lib/colors.js';
+
+/**
+ * @typedef {Object} RouteColors
+ * @property {string} line    - '#rrggbb', for polylines and vehicle markers
+ * @property {string} badgeBg - 'rrggbb' (no '#'), for RouteBadge `color`
+ * @property {string} badgeFg - 'rrggbb' (no '#'), for RouteBadge `textColor`
+ */
+
+// Stable index into the fallback palette. Keyed on the route id rather than the
+// route's position in the list so a 30s refresh that reorders arrivals doesn't
+// change any route's color.
+function paletteIndexFor(routeId) {
+	let hash = 0;
+	for (let i = 0; i < routeId.length; i++) {
+		hash = (hash * 31 + routeId.charCodeAt(i)) | 0;
+	}
+	return Math.abs(hash) % ROUTE_FALLBACK_PALETTE.length;
+}
+
+// Badge text: the background is no longer the agency's own color, so the
+// agency's textColor (chosen for that original hex) may be unreadable against
+// it. Pick from the resolved background instead. 140 is the midpoint of
+// colorUtils' own brightness scale.
+function badgeForeground(hex) {
+	return getBrightness(hexToRgb(hex)) > 140 ? '000000' : 'ffffff';
+}
+
+/**
+ * Resolves one color per route, used identically by the polyline, the vehicle
+ * markers, the legend, and the arrival badge.
+ *
+ * @param {ActiveRoute[]} routes - in draw order (soonest arrival first)
+ * @param {{ dark?: boolean }} options
+ * @returns {Map<string, RouteColors>}
+ */
+export function assignRouteColors(routes, { dark = false } = {}) {
+	/** @type {Map<string, RouteColors>} */
+	const colors = new Map();
+	const taken = new Set();
+
+	const finish = (routeId, line) => {
+		taken.add(line.toLowerCase());
+		const badgeBg = line.slice(1);
+		colors.set(routeId, { line, badgeBg, badgeFg: badgeForeground(line) });
+	};
+
+	// Two passes so palette assignment is order-independent: every route that can
+	// keep its own GTFS color claims it first, and only then do the leftovers pick
+	// from the palette. A single pass would let an early colorless route grab a
+	// palette slot that a later route's GTFS color also maps to.
+	const needsFallback = [];
+	for (const route of routes) {
+		const resolved = mapContrastColor(route.gtfsColor, { dark });
+		if (resolved && !taken.has(resolved.toLowerCase())) {
+			finish(route.id, resolved);
+		} else {
+			needsFallback.push(route);
+		}
+	}
+
+	for (const route of needsFallback) {
+		const start = paletteIndexFor(route.id);
+		let line = null;
+		// Linear-probe from the hashed slot to the next unused palette entry.
+		for (let offset = 0; offset < ROUTE_FALLBACK_PALETTE.length; offset++) {
+			const entry = ROUTE_FALLBACK_PALETTE[(start + offset) % ROUTE_FALLBACK_PALETTE.length];
+			const candidate = dark ? entry.dark : entry.light;
+			if (!taken.has(candidate.toLowerCase())) {
+				line = candidate;
+				break;
+			}
+		}
+		// More routes than palette entries: accept a repeat rather than no color.
+		if (!line) {
+			const entry = ROUTE_FALLBACK_PALETTE[start];
+			line = dark ? entry.dark : entry.light;
+		}
+		finish(route.id, line);
+	}
+
+	return colors;
+}

--- a/src/lib/activeRoutes.js
+++ b/src/lib/activeRoutes.js
@@ -73,7 +73,7 @@ export function activeRoutesFromArrivals(response) {
 		});
 }
 
-import { mapContrastColor, getBrightness, hexToRgb } from '$lib/colorUtils.js';
+import { mapContrastColor, contrastRatio } from '$lib/colorUtils.js';
 import { ROUTE_FALLBACK_PALETTE } from '$lib/colors.js';
 
 /**
@@ -96,10 +96,19 @@ function paletteIndexFor(routeId) {
 
 // Badge text: the background is no longer the agency's own color, so the
 // agency's textColor (chosen for that original hex) may be unreadable against
-// it. Pick from the resolved background instead. 140 is the midpoint of
-// colorUtils' own brightness scale.
+// it. Pick from the resolved background instead.
+//
+// Picking whichever of white/black has the higher *true* WCAG contrast
+// (contrastRatio, not the NTSC-weighted getBrightness) is a structural
+// guarantee, not an empirical one: the worst case is the background luminance
+// L where white and black tie, i.e. (L+0.05)/0.05 == 1.05/(L+0.05), which
+// solves to L ≈ 0.1791 and a ratio of ≈4.58. Since 4.58 > the 4.5:1 WCAG AA
+// text minimum, "better of white/black" clears AA for *any* background hex —
+// no palette-specific tuning required.
 function badgeForeground(hex) {
-	return getBrightness(hexToRgb(hex)) > 140 ? '000000' : 'ffffff';
+	const whiteContrast = contrastRatio(hex, '#ffffff');
+	const blackContrast = contrastRatio(hex, '#000000');
+	return blackContrast >= whiteContrast ? '000000' : 'ffffff';
 }
 
 /**
@@ -125,14 +134,33 @@ export function assignRouteColors(routes, { dark = false } = {}) {
 	// keep its own GTFS color claims it first, and only then do the leftovers pick
 	// from the palette. A single pass would let an early colorless route grab a
 	// palette slot that a later route's GTFS color also maps to.
+	//
+	// Routes are grouped by their *resolved* GTFS color before anyone claims one,
+	// rather than letting whichever route is processed first win. Routes arrive in
+	// draw order (soonest arrival first), which reorders on every 30s poll — if the
+	// winner were "first in the array", two same-colored routes with close arrival
+	// times would flip colors on every poll with no underlying data change, and the
+	// loser's fallback color would flip with it. Picking the keeper by lowest
+	// routeId is a stable, data-only rule: the same two routes always resolve the
+	// same way regardless of what order they're passed in.
 	const needsFallback = [];
+	const byResolvedColor = new Map();
 	for (const route of routes) {
 		const resolved = mapContrastColor(route.gtfsColor, { dark });
-		if (resolved && !taken.has(resolved.toLowerCase())) {
-			finish(route.id, resolved);
-		} else {
+		if (!resolved) {
 			needsFallback.push(route);
+			continue;
 		}
+		const key = resolved.toLowerCase();
+		if (!byResolvedColor.has(key)) byResolvedColor.set(key, []);
+		byResolvedColor.get(key).push({ route, resolved });
+	}
+
+	for (const group of byResolvedColor.values()) {
+		group.sort((a, b) => (a.route.id < b.route.id ? -1 : a.route.id > b.route.id ? 1 : 0));
+		const [keeper, ...rest] = group;
+		finish(keeper.route.id, keeper.resolved);
+		needsFallback.push(...rest.map((entry) => entry.route));
 	}
 
 	for (const route of needsFallback) {

--- a/src/lib/activeRoutes.js
+++ b/src/lib/activeRoutes.js
@@ -1,0 +1,74 @@
+/**
+ * Derives the set of routes a rider can actually board from a stop, from that
+ * stop's arrivals-and-departures response.
+ *
+ * This is deliberately narrower than "routes the stop is signed for": a stop
+ * signed "128, 22, 773, C Line" whose 773 has no arrival in the current window
+ * yields three routes, not four. A line on the map then means "a bus you can
+ * catch from here is running this route now."
+ */
+
+/**
+ * @typedef {Object} ActiveRoute
+ * @property {string} id
+ * @property {string} shortName
+ * @property {number} type
+ * @property {string} tripId
+ * @property {string|null} gtfsColor
+ */
+
+/**
+ * Effective arrival time for ordering.
+ *
+ * OBA sends `predictedArrivalTime: 0` — not null — when there is no real-time
+ * prediction, so `predictedArrivalTime ?? scheduledArrivalTime` would read every
+ * unpredicted arrival as "arriving at the epoch" and sort it to the front. This
+ * mirrors the guard ArrivalDeparture.svelte already uses to pick its display time.
+ * @param {Object} arrival
+ * @returns {number}
+ */
+function effectiveArrivalTime(arrival) {
+	return arrival.predicted && arrival.predictedArrivalTime > 0
+		? arrival.predictedArrivalTime
+		: arrival.scheduledArrivalTime;
+}
+
+/**
+ * @param {Object} response - an /arrivals-and-departures-for-stop response
+ * @returns {ActiveRoute[]} distinct routes, soonest arrival first
+ */
+export function activeRoutesFromArrivals(response) {
+	const arrivals = response?.data?.entry?.arrivalsAndDepartures;
+	if (!Array.isArray(arrivals)) return [];
+
+	const routeRefs = new Map(
+		(response?.data?.references?.routes ?? []).map((route) => [route.id, route])
+	);
+
+	/** @type {Map<string, {arrival: Object, time: number}>} */
+	const soonestByRoute = new Map();
+
+	for (const arrival of arrivals) {
+		const routeId = arrival?.routeId;
+		if (!routeId) continue;
+
+		const time = effectiveArrivalTime(arrival);
+		const existing = soonestByRoute.get(routeId);
+		if (!existing || time < existing.time) {
+			soonestByRoute.set(routeId, { arrival, time });
+		}
+	}
+
+	return [...soonestByRoute.entries()]
+		.sort((a, b) => a[1].time - b[1].time)
+		.map(([routeId, { arrival }]) => {
+			const ref = routeRefs.get(routeId);
+			return {
+				id: routeId,
+				shortName: ref?.shortName ?? arrival.routeShortName ?? '',
+				type: ref?.type ?? 3,
+				tripId: arrival.tripId,
+				gtfsColor: ref?.color || null
+			};
+		});
+}

--- a/src/lib/colorUtils.js
+++ b/src/lib/colorUtils.js
@@ -168,6 +168,51 @@ export function getBrightness(rgb) {
 }
 
 /**
+ * Computes the WCAG 2.x contrast ratio between two colors, per the W3C
+ * formula (https://www.w3.org/TR/WCAG21/#dfn-contrast-ratio): each channel is
+ * gamma-corrected into linear light, combined into a relative luminance, and
+ * the two luminances are compared as (lighter + 0.05) / (darker + 0.05).
+ *
+ * This is a different computation from `getBrightness` above, and the two are
+ * NOT interchangeable — do not reach for `getBrightness` when the question is
+ * "will this text be readable". `getBrightness` uses NTSC luma weights (R
+ * .299 / G .587 / B .114), a formula for perceived brightness on 1950s analog
+ * television, applied to raw (non-gamma-corrected) channel values. WCAG's
+ * relative-luminance weights are different (R .2126 / G .7152 / B .0722,
+ * applied after gamma-correcting each channel) because the eye's contrast
+ * sensitivity is dominated by green and much less by red or blue. The two
+ * formulas disagree often enough to matter: a dense sweep of real route
+ * colors through an NTSC-brightness threshold mis-picked readable text color
+ * on 14.4% of combinations (worst case `#00eb0f`, which reads "bright" under
+ * NTSC luma but clears only 1.63:1 against white — far below the 4.5:1 WCAG
+ * AA minimum for text). Anything deciding whether text is legible against a
+ * background must use `contrastRatio`, not `getBrightness`.
+ *
+ * @param {string} hexA - First hex color, with or without leading '#'
+ * @param {string} hexB - Second hex color, with or without leading '#'
+ * @returns {number} Contrast ratio from 1 (identical luminance) to 21 (black
+ *   vs. white). Returns 1 if either color fails to parse.
+ */
+export function contrastRatio(hexA, hexB) {
+	const relativeLuminance = (hex) => {
+		const rgb = hexToRgb(hex);
+		if (!rgb) return null;
+		const [r, g, b] = [rgb.r, rgb.g, rgb.b].map((channel) => {
+			const c = channel / 255;
+			return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+		});
+		return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+	};
+
+	const lumA = relativeLuminance(hexA);
+	const lumB = relativeLuminance(hexB);
+	if (lumA === null || lumB === null) return 1;
+
+	const [lighter, darker] = lumA >= lumB ? [lumA, lumB] : [lumB, lumA];
+	return (lighter + 0.05) / (darker + 0.05);
+}
+
+/**
  * Adjusts a color for better visibility in dark mode
  * Method: lightens dark colors by mixing with white
  * @param {string} hexColor - Original hex color (e.g., "#ff0000")

--- a/src/lib/colors.js
+++ b/src/lib/colors.js
@@ -3,3 +3,27 @@ export const COLORS = {
 	POLYLINE_ARROW_STROKE: '#21649b',
 	VEHICLE_REAL_TIME_OFF: '#808080'
 };
+
+/**
+ * Fallback colors for routes whose GTFS color is missing, invalid, or collides
+ * with another route drawn at the same time (real agencies routinely give
+ * several routes one generic color, which makes two lines in a shared corridor
+ * indistinguishable).
+ *
+ * Each entry is a light/dark pair because no single hex can clear both a light
+ * and a dark basemap — the same reason mapContrastColor adjusts GTFS colors per
+ * theme. These values were chosen by computation, not by eye; every one clears
+ * 3:1 against its basemap and 4.5:1 against its computed text color, and the
+ * closest pair within a mode is 65 units apart in RGB. See the palette tests in
+ * src/lib/__tests__/activeRoutes.test.js, which enforce all of that.
+ */
+export const ROUTE_FALLBACK_PALETTE = [
+	{ light: '#C2185B', dark: '#F06292' }, // crimson
+	{ light: '#1565C0', dark: '#64B5F6' }, // blue
+	{ light: '#2E7D32', dark: '#81C784' }, // green
+	{ light: '#E65100', dark: '#FFB74D' }, // orange
+	{ light: '#6A1B9A', dark: '#BA68C8' }, // purple
+	{ light: '#00695C', dark: '#4DB6AC' }, // teal
+	{ light: '#5D4037', dark: '#BCAAA4' }, // brown
+	{ light: '#827717', dark: '#DCE775' } // olive
+];

--- a/src/lib/mapPanes.js
+++ b/src/lib/mapPanes.js
@@ -1,0 +1,23 @@
+/**
+ * Stacking layers for the stop-selection route overlay.
+ *
+ * The OSM provider maps these to Leaflet panes (whose z-index it assigns
+ * explicitly — createPane does not). The Google provider maps them to Polyline
+ * zIndex values. Callers pick a layer by name and stay provider-agnostic.
+ *
+ * Every casing must render below every colored stroke, or one route's casing
+ * paints over its neighbor's line. The promoted layer carries the route whose
+ * arrival the rider has expanded.
+ */
+export const ROUTE_PANE = {
+	CASING: 'obaRouteCasing',
+	LINE: 'obaRoute',
+	PROMOTED: 'obaRoutePromoted'
+};
+
+/** Leaflet pane z-indexes. Below markerPane (600) so markers stay on top. */
+export const ROUTE_PANE_Z_INDEX = {
+	[ROUTE_PANE.CASING]: 402,
+	[ROUTE_PANE.LINE]: 403,
+	[ROUTE_PANE.PROMOTED]: 404
+};

--- a/src/lib/vehicleUtils.js
+++ b/src/lib/vehicleUtils.js
@@ -243,6 +243,28 @@ export function clearVehicleMarkersMap() {
 	activeTripMap.clear();
 }
 
+/**
+ * Removes only the vehicle markers owned by the given routes, leaving markers
+ * for any other route (e.g. one a sibling component is polling) untouched.
+ *
+ * Self-scoped counterpart to `removeInactiveMarkers`: that sweep decides which
+ * markers within a set of *polled* routes are stale; this one removes every
+ * marker for a set of routes outright, for a caller (StopRoutesLayer's
+ * teardown) tearing down its own selection rather than reconciling a poll.
+ *
+ * @param {Iterable<string>} routeIds
+ * @param {Object} mapProvider
+ */
+export function removeVehicleMarkersForRoutes(routeIds, mapProvider) {
+	const idsToRemove = routeIds instanceof Set ? routeIds : new Set(routeIds);
+	for (const [markerKey, entry] of vehicleMarkersMap) {
+		if (idsToRemove.has(entry.routeId)) {
+			mapProvider.removeVehicleMarker(entry.marker);
+			vehicleMarkersMap.delete(markerKey);
+		}
+	}
+}
+
 export function buildVehiclePopupData(vehicle, activeTrip, stopsMap) {
 	return {
 		nextDestination: activeTrip.tripHeadsign,

--- a/src/lib/vehicleUtils.js
+++ b/src/lib/vehicleUtils.js
@@ -128,14 +128,26 @@ const VEHICLE_POLL_INTERVAL_MS = 30000;
  *
  * @param {Array<{id: string, type?: number}>} routes
  * @param {Object} mapProvider
- * @param {{highlightedTripId?: string|null, colorsByRouteId?: Map<string,{line:string}>, onCounts?: Function}} [options]
- * @returns {Promise<number>} interval id
+ * @param {{highlightedTripId?: string|null|(() => string|null), colorsByRouteId?: Map<string,{line:string}>, onCounts?: Function}} [options]
+ * `highlightedTripId` may be a plain value (captured once, for callers that
+ * genuinely never change it) or a getter function, resolved fresh on every
+ * tick — the trip-expansion glow needs the latter: the poll is started once
+ * per route-set redraw, but the highlighted trip changes independently of
+ * that redraw (see StopRoutesLayer's second effect), so a value captured at
+ * start time would go stale until the next redraw.
+ * @returns {Promise<{intervalId: number, tick: () => Promise<void>}>} the
+ * poll's interval id, plus `tick` so a caller can force an immediate refresh
+ * (e.g. to move the highlight glow right away) instead of waiting up to
+ * VEHICLE_POLL_INTERVAL_MS for the next scheduled one.
  */
 export async function fetchAndUpdateVehiclesForRoutes(
 	routes,
 	mapProvider,
 	{ highlightedTripId = null, colorsByRouteId = new Map(), onCounts = null } = {}
 ) {
+	const resolveHighlightedTripId = () =>
+		typeof highlightedTripId === 'function' ? highlightedTripId() : highlightedTripId;
+
 	const tick = async () => {
 		const results = await Promise.all(
 			routes.map((route) =>
@@ -165,7 +177,7 @@ export async function fetchAndUpdateVehiclesForRoutes(
 					route.id,
 					mapProvider,
 					route.type,
-					highlightedTripId,
+					resolveHighlightedTripId(),
 					colorsByRouteId.get(route.id)?.line
 				);
 				polledRouteIds.add(route.id);
@@ -190,16 +202,23 @@ export async function fetchAndUpdateVehiclesForRoutes(
 		console.error('fetchAndUpdateVehiclesForRoutes: initial tick failed', error);
 	}
 
-	return setInterval(() => {
+	const intervalId = setInterval(() => {
 		tick().catch((error) => {
 			console.error('fetchAndUpdateVehiclesForRoutes: polling tick failed', error);
 		});
 	}, VEHICLE_POLL_INTERVAL_MS);
+
+	return { intervalId, tick };
 }
 
 /**
  * Single-route wrapper, kept so SearchPane and RouteMap run through the same
- * code path. Signature and behavior are unchanged.
+ * code path. Signature and behavior are unchanged: unlike
+ * `fetchAndUpdateVehiclesForRoutes`, this still resolves to a bare interval
+ * id — SearchPane.svelte and RouteMap.svelte both do
+ * `currentIntervalId = await fetchAndUpdateVehicles(...)` and later
+ * `clearInterval(currentIntervalId)`, so returning `{ intervalId, tick }`
+ * here instead would silently break both.
  */
 export async function fetchAndUpdateVehicles(
 	routeId,
@@ -208,10 +227,15 @@ export async function fetchAndUpdateVehicles(
 	highlightedTripId = null,
 	routeColor = undefined
 ) {
-	return fetchAndUpdateVehiclesForRoutes([{ id: routeId, type: routeType }], mapProvider, {
-		highlightedTripId,
-		colorsByRouteId: routeColor ? new Map([[routeId, { line: routeColor }]]) : new Map()
-	});
+	const { intervalId } = await fetchAndUpdateVehiclesForRoutes(
+		[{ id: routeId, type: routeType }],
+		mapProvider,
+		{
+			highlightedTripId,
+			colorsByRouteId: routeColor ? new Map([[routeId, { line: routeColor }]]) : new Map()
+		}
+	);
+	return intervalId;
 }
 
 export function clearVehicleMarkersMap() {

--- a/src/lib/vehicleUtils.js
+++ b/src/lib/vehicleUtils.js
@@ -6,40 +6,48 @@
 const activeTripMap = new Map();
 
 /**
- * @type {Map<vehicleId, marker>}
+ * @type {Map<vehicleId, {marker, routeId}>}
  * Keyed by the physical vehicle id. The trips-for-route response can report the
  * same activeTripId for two different vehicles (e.g. the vehicle actually serving
  * the trip plus a second one still parked at the base), so keying by trip id
  * collapsed both into one marker that flipped between their positions on every
  * refresh. Falls back to activeTripId only when a status has no vehicleId.
  * see (https://developer.onebusaway.org/api/where/elements/trip-status)
+ *
+ * `routeId` records which route owns each marker, so a sweep across several
+ * concurrently-polled routes only removes markers belonging to routes it
+ * actually fetched.
  */
 const vehicleMarkersMap = new Map();
 
+/**
+ * @returns {Promise<Object|null>} the trips-for-route payload, or `null` when
+ * the request failed or came back malformed.
+ *
+ * Failure and emptiness must be distinguishable: a caller sweeping stale markers
+ * across several routes would otherwise read a 500 as "this route has no
+ * vehicles" and delete every marker the route owns.
+ */
 export async function fetchVehicles(routeId) {
 	const response = await fetch(`/api/oba/trips-for-route/${routeId}`);
 	if (!response.ok) {
 		console.warn('fetchVehicles: request failed', routeId, response.status);
-		return { references: { trips: [] }, list: [] };
+		return null;
 	}
 	const responseBody = await response.json();
 	const data = responseBody.data;
 	if (!data?.references?.trips || !Array.isArray(data.list)) {
 		console.warn('fetchVehicles: unexpected response structure for route', routeId);
-		return { references: { trips: [] }, list: [] };
+		return null;
 	}
 	return data;
 }
 
-export async function updateVehicleMarkers(
-	routeId,
-	mapProvider,
-	routeType,
-	highlightedTripId = null,
-	routeColor = undefined
-) {
-	const data = await fetchVehicles(routeId);
-
+/**
+ * Draws/updates the vehicles for one route from an already-fetched payload, and
+ * returns the marker keys this route currently owns.
+ */
+function applyRouteVehicles(data, routeId, mapProvider, routeType, highlightedTripId, routeColor) {
 	const activeKeys = new Set();
 
 	for (const trip of data.references.trips) {
@@ -65,17 +73,19 @@ export async function updateVehicleMarkers(
 
 			activeKeys.add(markerKey);
 
-			if (vehicleMarkersMap.has(markerKey)) {
-				const marker = vehicleMarkersMap.get(markerKey);
-
+			const existing = vehicleMarkersMap.get(markerKey);
+			if (existing) {
 				mapProvider.updateVehicleMarker(
-					marker,
+					existing.marker,
 					vehicleStatus,
 					activeTrip,
 					routeType,
 					isHighlighted,
 					routeColor
 				);
+				// A physical vehicle can move between routes across a shift; re-stamp
+				// ownership so the sweep attributes it to the route reporting it now.
+				existing.routeId = routeId;
 			} else {
 				const marker = mapProvider.addVehicleMarker(
 					vehicleStatus,
@@ -84,23 +94,102 @@ export async function updateVehicleMarkers(
 					isHighlighted,
 					routeColor
 				);
-				vehicleMarkersMap.set(markerKey, marker);
+				vehicleMarkersMap.set(markerKey, { marker, routeId });
 			}
 		}
 	}
 
-	removeInactiveMarkers(activeKeys, mapProvider);
+	return activeKeys;
 }
 
-export function removeInactiveMarkers(activeKeys, mapProvider) {
-	for (const [markerKey, marker] of vehicleMarkersMap) {
+/**
+ * Removes markers that are no longer active — but only among routes we actually
+ * polled successfully. A route whose fetch failed keeps its markers.
+ *
+ * @param {Set<string>} activeKeys
+ * @param {Object} mapProvider
+ * @param {Set<string>|null} [polledRouteIds] - when omitted, every marker is in
+ * scope (single-route callers didn't fetch a subset).
+ */
+export function removeInactiveMarkers(activeKeys, mapProvider, polledRouteIds = null) {
+	for (const [markerKey, entry] of vehicleMarkersMap) {
+		if (polledRouteIds && !polledRouteIds.has(entry.routeId)) continue;
 		if (!activeKeys.has(markerKey)) {
-			mapProvider.removeVehicleMarker(marker);
+			mapProvider.removeVehicleMarker(entry.marker);
 			vehicleMarkersMap.delete(markerKey);
 		}
 	}
 }
 
+const VEHICLE_POLL_INTERVAL_MS = 30000;
+
+/**
+ * Polls several routes' vehicles on one interval.
+ *
+ * @param {Array<{id: string, type?: number}>} routes
+ * @param {Object} mapProvider
+ * @param {{highlightedTripId?: string|null, colorsByRouteId?: Map<string,{line:string}>, onCounts?: Function}} [options]
+ * @returns {Promise<number>} interval id
+ */
+export async function fetchAndUpdateVehiclesForRoutes(
+	routes,
+	mapProvider,
+	{ highlightedTripId = null, colorsByRouteId = new Map(), onCounts = null } = {}
+) {
+	const tick = async () => {
+		const results = await Promise.all(
+			routes.map((route) =>
+				fetchVehicles(route.id).catch((error) => {
+					console.error('fetchAndUpdateVehiclesForRoutes: fetch failed', route.id, error);
+					return null;
+				})
+			)
+		);
+
+		const activeKeys = new Set();
+		const polledRouteIds = new Set();
+		const counts = new Map();
+
+		routes.forEach((route, index) => {
+			const data = results[index];
+			// null means the fetch failed, which is NOT the same as "no vehicles".
+			// Leave this route out of the sweep scope so its markers survive.
+			if (!data) return;
+
+			polledRouteIds.add(route.id);
+			const routeKeys = applyRouteVehicles(
+				data,
+				route.id,
+				mapProvider,
+				route.type,
+				highlightedTripId,
+				colorsByRouteId.get(route.id)?.line
+			);
+			routeKeys.forEach((key) => activeKeys.add(key));
+			counts.set(route.id, routeKeys.size);
+		});
+
+		removeInactiveMarkers(activeKeys, mapProvider, polledRouteIds);
+		if (onCounts) onCounts(counts);
+	};
+
+	try {
+		await tick();
+	} catch (error) {
+		console.error('fetchAndUpdateVehiclesForRoutes: initial tick failed', error);
+	}
+
+	return setInterval(() => {
+		tick().catch((error) => {
+			console.error('fetchAndUpdateVehiclesForRoutes: polling tick failed', error);
+		});
+	}, VEHICLE_POLL_INTERVAL_MS);
+}
+
+/**
+ * Single-route wrapper, kept so SearchPane and RouteMap run through the same
+ * code path. Signature and behavior are unchanged.
+ */
 export async function fetchAndUpdateVehicles(
 	routeId,
 	mapProvider,
@@ -108,19 +197,35 @@ export async function fetchAndUpdateVehicles(
 	highlightedTripId = null,
 	routeColor = undefined
 ) {
-	try {
-		await updateVehicleMarkers(routeId, mapProvider, routeType, highlightedTripId, routeColor);
-	} catch (error) {
-		console.error('fetchAndUpdateVehicles: initial fetch failed', routeId, error);
-	}
+	return fetchAndUpdateVehiclesForRoutes([{ id: routeId, type: routeType }], mapProvider, {
+		highlightedTripId,
+		colorsByRouteId: routeColor ? new Map([[routeId, { line: routeColor }]]) : new Map()
+	});
+}
 
-	return setInterval(async () => {
-		try {
-			await updateVehicleMarkers(routeId, mapProvider, routeType, highlightedTripId, routeColor);
-		} catch (error) {
-			console.error('fetchAndUpdateVehicles: polling update failed', routeId, error);
-		}
-	}, 30000);
+/**
+ * Single-route wrapper around applyRouteVehicles + removeInactiveMarkers, kept
+ * for the existing per-route test suite. Not used by the batched entry point.
+ */
+export async function updateVehicleMarkers(
+	routeId,
+	mapProvider,
+	routeType,
+	highlightedTripId = null,
+	routeColor = undefined
+) {
+	const data = await fetchVehicles(routeId);
+	if (!data) return;
+
+	const activeKeys = applyRouteVehicles(
+		data,
+		routeId,
+		mapProvider,
+		routeType,
+		highlightedTripId,
+		routeColor
+	);
+	removeInactiveMarkers(activeKeys, mapProvider, new Set([routeId]));
 }
 
 export function clearVehicleMarkersMap() {

--- a/src/lib/vehicleUtils.js
+++ b/src/lib/vehicleUtils.js
@@ -156,17 +156,28 @@ export async function fetchAndUpdateVehiclesForRoutes(
 			// Leave this route out of the sweep scope so its markers survive.
 			if (!data) return;
 
-			polledRouteIds.add(route.id);
-			const routeKeys = applyRouteVehicles(
-				data,
-				route.id,
-				mapProvider,
-				route.type,
-				highlightedTripId,
-				colorsByRouteId.get(route.id)?.line
-			);
-			routeKeys.forEach((key) => activeKeys.add(key));
-			counts.set(route.id, routeKeys.size);
+			// A synchronous throw here (e.g. a map-provider bug) must not abort the
+			// routes ordered after this one in the forEach, nor skip the sweep below.
+			// Treat it the same as a failed fetch: leave the route's markers alone.
+			try {
+				const routeKeys = applyRouteVehicles(
+					data,
+					route.id,
+					mapProvider,
+					route.type,
+					highlightedTripId,
+					colorsByRouteId.get(route.id)?.line
+				);
+				polledRouteIds.add(route.id);
+				routeKeys.forEach((key) => activeKeys.add(key));
+				counts.set(route.id, routeKeys.size);
+			} catch (error) {
+				console.error(
+					'fetchAndUpdateVehiclesForRoutes: applying route vehicles failed',
+					route.id,
+					error
+				);
+			}
 		});
 
 		removeInactiveMarkers(activeKeys, mapProvider, polledRouteIds);
@@ -201,31 +212,6 @@ export async function fetchAndUpdateVehicles(
 		highlightedTripId,
 		colorsByRouteId: routeColor ? new Map([[routeId, { line: routeColor }]]) : new Map()
 	});
-}
-
-/**
- * Single-route wrapper around applyRouteVehicles + removeInactiveMarkers, kept
- * for the existing per-route test suite. Not used by the batched entry point.
- */
-export async function updateVehicleMarkers(
-	routeId,
-	mapProvider,
-	routeType,
-	highlightedTripId = null,
-	routeColor = undefined
-) {
-	const data = await fetchVehicles(routeId);
-	if (!data) return;
-
-	const activeKeys = applyRouteVehicles(
-		data,
-		routeId,
-		mapProvider,
-		routeType,
-		highlightedTripId,
-		routeColor
-	);
-	removeInactiveMarkers(activeKeys, mapProvider, new Set([routeId]));
 }
 
 export function clearVehicleMarkersMap() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -131,6 +131,7 @@
 	"refresh": "Refresh",
 	"no_arrivals_found_in_next_minutes": "No arrivals found in the next {minutes} minutes",
 	"stop": "Stop",
+	"direction_bound": "{direction} bound",
 	"routes": "Routes",
 	"route": "route",
 	"route_modal_title": "Route {name}",
@@ -197,7 +198,8 @@
 	},
 	"view_stop_information": "View Stop Information",
 	"stop_details": {
-		"view_details": "View Details"
+		"view_details": "View Details",
+		"stop_info": "Stop Info"
 	},
 	"language_switcher": {
 		"select_language": "Select language: {language}",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -206,7 +206,9 @@
 		"available_languages": "Available languages"
 	},
 	"map": {
-		"find_my_location": "Find My Location"
+		"find_my_location": "Find My Location",
+		"routes_shown": "Routes shown",
+		"live_vehicle_count": "{count} live"
 	},
 	"context-menu": {
 		"start_here": "Start Here",

--- a/src/tests/lib/GoogleMapProvider.test.js
+++ b/src/tests/lib/GoogleMapProvider.test.js
@@ -191,3 +191,49 @@ describe('flyTo — vertical offset for the bottom sheet', () => {
 		expect(provider.map.panBy).toHaveBeenCalledWith(0, 200);
 	});
 });
+
+describe('addUserLocationMarker — one marker, repositioned', () => {
+	let provider;
+	let MarkerMock;
+
+	beforeEach(() => {
+		MarkerMock = vi.fn(function GoogleMarker(options) {
+			this.options = options;
+			this.setMap = vi.fn();
+			this.setPosition = vi.fn();
+		});
+		setupGoogleMaps(MarkerMock);
+		provider = new GoogleMapProvider('key', vi.fn());
+		provider.map = {};
+	});
+
+	test('creates the marker on the first call', () => {
+		const marker = provider.addUserLocationMarker({ lat: 47.6, lng: -122.3 });
+
+		expect(MarkerMock).toHaveBeenCalledOnce();
+		expect(marker.options.position).toEqual({ lat: 47.6, lng: -122.3 });
+		expect(provider.userLocationMarker).toBe(marker);
+	});
+
+	test('moves the existing marker instead of stacking a second one', () => {
+		const first = provider.addUserLocationMarker({ lat: 47.6, lng: -122.3 });
+		const second = provider.addUserLocationMarker({ lat: 47.5, lng: -122.4 });
+
+		expect(MarkerMock).toHaveBeenCalledOnce();
+		expect(second).toBe(first);
+		expect(first.setPosition).toHaveBeenCalledWith({ lat: 47.5, lng: -122.4 });
+	});
+
+	test('removeUserLocationMarker detaches the marker and clears the reference', () => {
+		const marker = provider.addUserLocationMarker({ lat: 47.6, lng: -122.3 });
+
+		provider.removeUserLocationMarker();
+
+		expect(marker.setMap).toHaveBeenCalledWith(null);
+		expect(provider.userLocationMarker).toBeNull();
+	});
+
+	test('removeUserLocationMarker is a no-op when no marker exists', () => {
+		expect(() => provider.removeUserLocationMarker()).not.toThrow();
+	});
+});

--- a/src/tests/lib/GoogleMapProvider.test.js
+++ b/src/tests/lib/GoogleMapProvider.test.js
@@ -237,3 +237,217 @@ describe('addUserLocationMarker — one marker, repositioned', () => {
 		expect(() => provider.removeUserLocationMarker()).not.toThrow();
 	});
 });
+
+describe('stop emphasis', () => {
+	function providerWithMarkers(entries) {
+		const provider = new GoogleMapProvider('test-key', vi.fn());
+		provider.markersMap = new Map(entries);
+		return provider;
+	}
+
+	test('applies per-stop emphasis and the default to everything else', () => {
+		const a = { props: { emphasis: 'full', dotColor: null } };
+		const b = { props: { emphasis: 'full', dotColor: null } };
+		const provider = providerWithMarkers([
+			['stop_a', a],
+			['stop_b', b]
+		]);
+
+		provider.setStopEmphasis(
+			new Map([['stop_a', { emphasis: 'routeDot', dotColor: '#b02a37' }]]),
+			'muted',
+			null
+		);
+
+		expect(a.props.emphasis).toBe('routeDot');
+		expect(a.props.dotColor).toBe('#b02a37');
+		expect(b.props.emphasis).toBe('muted');
+		expect(b.props.dotColor).toBeNull();
+	});
+
+	// The selected stop is served by the drawn trips, so it is always in the
+	// ring-dot map. Forcing 'full' here keeps the invariant in one place rather
+	// than at every call site.
+	test('forces the selected stop to full even when it is in the ring-dot map', () => {
+		const selected = { props: { emphasis: 'full', dotColor: null } };
+		const provider = providerWithMarkers([['stop_sel', selected]]);
+
+		provider.setStopEmphasis(
+			new Map([['stop_sel', { emphasis: 'routeDot', dotColor: '#b02a37' }]]),
+			'muted',
+			'stop_sel'
+		);
+
+		expect(selected.props.emphasis).toBe('full');
+	});
+
+	// addStopRouteMarker writes bare google.maps.Marker objects into markersMap;
+	// those have no reactive props to mutate.
+	test('skips markers with no props', () => {
+		const provider = providerWithMarkers([['stop_a', { noProps: true }]]);
+		expect(() => provider.setStopEmphasis(new Map(), 'muted', null)).not.toThrow();
+	});
+
+	test('resetStopEmphasis returns every marker to full', () => {
+		const a = { props: { emphasis: 'muted', dotColor: '#b02a37' } };
+		const provider = providerWithMarkers([['stop_a', a]]);
+		provider.resetStopEmphasis();
+		expect(a.props.emphasis).toBe('full');
+		expect(a.props.dotColor).toBeNull();
+	});
+});
+
+describe('setBasemapDimmed / setTheme composition', () => {
+	function makeProvider() {
+		const provider = new GoogleMapProvider('test-key', vi.fn());
+		return provider;
+	}
+
+	test('setBasemapDimmed applies a desaturating style', () => {
+		const provider = makeProvider();
+		const setOptions = vi.fn();
+		provider.map = { setOptions };
+
+		provider.setBasemapDimmed(true);
+
+		const styles = setOptions.mock.calls.at(-1)[0].styles;
+		expect(styles.some((s) => s.stylers?.some((v) => 'saturation' in v))).toBe(true);
+	});
+
+	test('setBasemapDimmed(false) clears the dim style', () => {
+		const provider = makeProvider();
+		const setOptions = vi.fn();
+		provider.map = { setOptions };
+
+		provider.setBasemapDimmed(true);
+		provider.setBasemapDimmed(false);
+
+		const styles = setOptions.mock.calls.at(-1)[0].styles;
+		expect(styles).toBeNull();
+	});
+
+	// Google replaces the whole `styles` array on setOptions, so theme and dim
+	// must be composed together — otherwise a theme toggle silently drops the dim.
+	test('a theme change preserves the basemap dim', () => {
+		const provider = makeProvider();
+		const setOptions = vi.fn();
+		provider.map = { setOptions };
+
+		provider.setBasemapDimmed(true);
+		provider.setTheme('dark');
+
+		const lastStyles = setOptions.mock.calls.at(-1)[0].styles;
+		expect(lastStyles.some((s) => s.stylers?.some((v) => 'saturation' in v))).toBe(true);
+	});
+
+	test('a dim toggle preserves the current theme', () => {
+		const provider = makeProvider();
+		const setOptions = vi.fn();
+		provider.map = { setOptions };
+
+		provider.setTheme('dark');
+		setOptions.mockClear();
+		provider.setBasemapDimmed(true);
+
+		const lastStyles = setOptions.mock.calls.at(-1)[0].styles;
+		// nightModeStyles() is mocked to [] above, so assert the dim entry landed
+		// alongside whatever the (empty, mocked) dark-theme base produced.
+		expect(lastStyles.some((s) => s.stylers?.some((v) => 'saturation' in v))).toBe(true);
+	});
+});
+
+describe('createPolyline casing', () => {
+	function setupGoogleMapsForPolylines() {
+		const PolylineMock = vi.fn(function GooglePolyline(options) {
+			this.options = options;
+			this.setMap = vi.fn();
+		});
+		global.google = {
+			maps: {
+				geometry: {
+					encoding: {
+						decodePath: vi.fn(() => [
+							{ lat: () => 47.6, lng: () => -122.3 },
+							{ lat: () => 47.61, lng: () => -122.31 }
+						])
+					}
+				},
+				importLibrary: vi.fn(async () => {}),
+				Polyline: PolylineMock,
+				SymbolPath: { FORWARD_CLOSED_ARROW: 1 }
+			}
+		};
+		return { PolylineMock };
+	}
+
+	function makeProvider() {
+		const provider = new GoogleMapProvider('test-key', vi.fn());
+		provider.map = {};
+		return provider;
+	}
+
+	test('draws a wider white casing under the colored stroke', async () => {
+		setupGoogleMapsForPolylines();
+		const provider = makeProvider();
+
+		const line = await provider.createPolyline('encoded', {
+			color: '#b02a37',
+			casing: true,
+			weight: 5
+		});
+
+		expect(line._casing).toBeTruthy();
+		expect(line._casing.options.strokeColor).toBe('#ffffff');
+		expect(line._casing.options.strokeWeight).toBeGreaterThan(line.options.strokeWeight);
+	});
+
+	test('gives the polyline and its casing the zIndex layer it was asked for', async () => {
+		setupGoogleMapsForPolylines();
+		const provider = makeProvider();
+
+		const line = await provider.createPolyline('encoded', {
+			color: '#b02a37',
+			casing: true,
+			pane: 'obaRoute',
+			casingPane: 'obaRouteCasing'
+		});
+
+		expect(line.options.zIndex).toBe(20);
+		expect(line._casing.options.zIndex).toBe(10);
+	});
+
+	// The casing must stay out of this.polylines or fitToPolylines,
+	// getPolylinesCount, and _getRoutePaths all double-count it.
+	test('does not track the casing in this.polylines', async () => {
+		setupGoogleMapsForPolylines();
+		const provider = makeProvider();
+
+		await provider.createPolyline('encoded', { color: '#b02a37', casing: true });
+
+		expect(provider.getPolylinesCount()).toBe(1);
+	});
+
+	test('removes the casing with its polyline', async () => {
+		setupGoogleMapsForPolylines();
+		const provider = makeProvider();
+
+		const line = await provider.createPolyline('encoded', { color: '#b02a37', casing: true });
+		const casing = line._casing;
+
+		await provider.removePolyline(line);
+
+		expect(casing.setMap).toHaveBeenCalledWith(null);
+	});
+
+	test('clearAllPolylines removes casings too', async () => {
+		setupGoogleMapsForPolylines();
+		const provider = makeProvider();
+
+		const line = await provider.createPolyline('encoded', { color: '#b02a37', casing: true });
+		const casing = line._casing;
+
+		provider.clearAllPolylines();
+
+		expect(casing.setMap).toHaveBeenCalledWith(null);
+	});
+});

--- a/src/tests/lib/GoogleMapProvider.test.js
+++ b/src/tests/lib/GoogleMapProvider.test.js
@@ -392,7 +392,10 @@ describe('setBasemapDimmed / setTheme composition', () => {
 		const provider = makeProvider();
 		expect(provider.map).toBeNull();
 
+		// Both callers pass through _applyStyles, whose null-map guard must keep
+		// either one from dereferencing this.map.setOptions after a failed init.
 		expect(() => provider.setBasemapDimmed(true)).not.toThrow();
+		expect(() => provider.setTheme('dark')).not.toThrow();
 	});
 
 	// Google replaces the whole `styles` array on setOptions, so theme and dim

--- a/src/tests/lib/GoogleMapProvider.test.js
+++ b/src/tests/lib/GoogleMapProvider.test.js
@@ -440,30 +440,34 @@ describe('setBasemapDimmed / setTheme composition', () => {
 	});
 });
 
-describe('createPolyline casing', () => {
-	function setupGoogleMapsForPolylines() {
-		const PolylineMock = vi.fn(function GooglePolyline(options) {
-			this.options = options;
-			this.setMap = vi.fn();
-		});
-		global.google = {
-			maps: {
-				geometry: {
-					encoding: {
-						decodePath: vi.fn(() => [
-							{ lat: () => 47.6, lng: () => -122.3 },
-							{ lat: () => 47.61, lng: () => -122.31 }
-						])
-					}
-				},
-				importLibrary: vi.fn(async () => {}),
-				Polyline: PolylineMock,
-				SymbolPath: { FORWARD_CLOSED_ARROW: 1 }
-			}
-		};
-		return { PolylineMock };
-	}
+// Shared by both the createPolyline and setPolylineLayer suites below, since
+// setPolylineLayer's tests also need to createPolyline() first to have
+// something to re-pane.
+function setupGoogleMapsForPolylines() {
+	const PolylineMock = vi.fn(function GooglePolyline(options) {
+		this.options = options;
+		this.setMap = vi.fn();
+		this.setOptions = vi.fn((nextOptions) => Object.assign(this.options, nextOptions));
+	});
+	global.google = {
+		maps: {
+			geometry: {
+				encoding: {
+					decodePath: vi.fn(() => [
+						{ lat: () => 47.6, lng: () => -122.3 },
+						{ lat: () => 47.61, lng: () => -122.31 }
+					])
+				}
+			},
+			importLibrary: vi.fn(async () => {}),
+			Polyline: PolylineMock,
+			SymbolPath: { FORWARD_CLOSED_ARROW: 1 }
+		}
+	};
+	return { PolylineMock };
+}
 
+describe('createPolyline casing', () => {
 	function makeProvider() {
 		const provider = new GoogleMapProvider('test-key', vi.fn());
 		provider.map = {};
@@ -565,5 +569,44 @@ describe('createPolyline casing', () => {
 		provider.clearAllPolylines();
 
 		expect(casing.setMap).toHaveBeenCalledWith(null);
+	});
+});
+
+describe('setPolylineLayer', () => {
+	function makeProvider() {
+		const provider = new GoogleMapProvider('test-key', vi.fn());
+		provider.map = {};
+		return provider;
+	}
+
+	// Google orders polylines purely by zIndex, so — unlike OSM, which must
+	// detach/reattach to change Leaflet panes — this is a single option update.
+	test('sets the zIndex for the given pane', async () => {
+		setupGoogleMapsForPolylines();
+		const provider = makeProvider();
+		const line = await provider.createPolyline('encoded', {
+			color: '#b02a37',
+			pane: 'obaRoute'
+		});
+
+		provider.setPolylineLayer(line, 'obaRoutePromoted');
+
+		expect(line.setOptions).toHaveBeenCalledWith({ zIndex: 30 });
+		expect(line.options.zIndex).toBe(30);
+	});
+
+	test('is a no-op with no map', async () => {
+		setupGoogleMapsForPolylines();
+		const provider = makeProvider();
+		const line = await provider.createPolyline('encoded', { color: '#b02a37', pane: 'obaRoute' });
+		provider.map = null;
+
+		expect(() => provider.setPolylineLayer(line, 'obaRoutePromoted')).not.toThrow();
+		expect(line.setOptions).not.toHaveBeenCalled();
+	});
+
+	test('is a no-op with no polyline', () => {
+		const provider = makeProvider();
+		expect(() => provider.setPolylineLayer(null, 'obaRoutePromoted')).not.toThrow();
 	});
 });

--- a/src/tests/lib/GoogleMapProvider.test.js
+++ b/src/tests/lib/GoogleMapProvider.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import GoogleMapProvider from '$lib/Provider/GoogleMapProvider.svelte.js';
 import { createVehicleIconSvg } from '$lib/MapHelpers/generateVehicleIcon';
+import { nightModeStyles } from '$lib/googleMaps';
 
 vi.mock('$components/map/StopMarker.svelte', () => ({ default: {} }));
 vi.mock('$components/map/PopupContent.svelte', () => ({ default: {} }));
@@ -19,11 +20,18 @@ vi.mock('$lib/MapHelpers/animateMarker', () => ({
 vi.mock('$lib/vehicleUtils', () => ({
 	buildVehiclePopupData: vi.fn(() => ({}))
 }));
-vi.mock('$lib/googleMaps', () => ({
-	loadGoogleMapsLibrary: vi.fn(),
-	createMap: vi.fn(),
-	nightModeStyles: vi.fn(() => [])
-}));
+// nightModeStyles is the real implementation (not stubbed to []): the
+// setBasemapDimmed/setTheme composition tests below need a genuinely
+// non-empty base theme to prove _applyStyles actually merges theme + dim,
+// rather than passing against an empty array regardless of composition.
+vi.mock('$lib/googleMaps', async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		loadGoogleMapsLibrary: vi.fn(),
+		createMap: vi.fn(),
+		nightModeStyles: actual.nightModeStyles
+	};
+});
 vi.mock('svelte', async (importOriginal) => {
 	const actual = await importOriginal();
 	return { ...actual, mount: vi.fn(), unmount: vi.fn() };
@@ -281,8 +289,8 @@ describe('stop emphasis', () => {
 		expect(selected.props.emphasis).toBe('full');
 	});
 
-	// addStopRouteMarker writes bare google.maps.Marker objects into markersMap;
-	// those have no reactive props to mutate.
+	// Defensive: markersMap entries are expected to always carry a reactive
+	// props object; skip gracefully rather than throw if that ever changes.
 	test('skips markers with no props', () => {
 		const provider = providerWithMarkers([['stop_a', { noProps: true }]]);
 		expect(() => provider.setStopEmphasis(new Map(), 'muted', null)).not.toThrow();
@@ -294,6 +302,56 @@ describe('stop emphasis', () => {
 		provider.resetStopEmphasis();
 		expect(a.props.emphasis).toBe('full');
 		expect(a.props.dotColor).toBeNull();
+	});
+});
+
+describe('addStopRouteMarker — does not clobber an existing stop-emphasis handle', () => {
+	let provider;
+
+	beforeEach(() => {
+		global.google = {
+			maps: {
+				Marker: makeGoogleMarkerMock(),
+				InfoWindow: vi.fn(function InfoWindow() {
+					this.open = vi.fn();
+					this.close = vi.fn();
+				}),
+				OverlayView: vi.fn(function OverlayView() {
+					this.setMap = vi.fn();
+					this.getPanes = vi.fn(() => ({
+						overlayMouseTarget: document.createElement('div')
+					}));
+				}),
+				SymbolPath: { CIRCLE: 0 },
+				Size: vi.fn(),
+				Point: vi.fn()
+			}
+		};
+
+		provider = new GoogleMapProvider('test-key', vi.fn());
+		provider.map = { getZoom: vi.fn(() => 10) };
+	});
+
+	// addMarker's StopMarker handle (with its reactive `props`) is what
+	// setStopEmphasis/highlightMarker/etc. mutate. If addStopRouteMarker
+	// overwrites that markersMap entry with a bare google.maps.Marker (no
+	// props), emphasis silently becomes a no-op for that stop.
+	test('a stop already tracked via addMarker keeps its emphasis handle after its route is drawn', () => {
+		const markerObj = provider.addMarker({
+			stop: STOP,
+			position: { lat: STOP.lat, lng: STOP.lon }
+		});
+
+		provider.addStopRouteMarker(STOP);
+
+		provider.setStopEmphasis(
+			new Map([[STOP.id, { emphasis: 'routeDot', dotColor: '#b02a37' }]]),
+			'muted',
+			null
+		);
+
+		expect(markerObj.props.emphasis).toBe('routeDot');
+		expect(markerObj.props.dotColor).toBe('#b02a37');
 	});
 });
 
@@ -326,8 +384,23 @@ describe('setBasemapDimmed / setTheme composition', () => {
 		expect(styles).toBeNull();
 	});
 
+	// Parity with OSM's `if (!browser || !this.map) return;` guard. The provider
+	// is constructed with this.map = null, and MapView.initMap swallows init
+	// failures in a try/catch, so a Google map that failed to initialize must
+	// no-op here rather than throw on this.map.setOptions.
+	test('no-ops when the map has not been initialized', () => {
+		const provider = makeProvider();
+		expect(provider.map).toBeNull();
+
+		expect(() => provider.setBasemapDimmed(true)).not.toThrow();
+	});
+
 	// Google replaces the whole `styles` array on setOptions, so theme and dim
 	// must be composed together — otherwise a theme toggle silently drops the dim.
+	// nightModeStyles() is the real (non-empty) implementation here, so this only
+	// passes if _applyStyles genuinely concatenates theme + dim, not just if a
+	// lone dim entry happens to satisfy a loose "some styler has saturation"
+	// check against an empty base.
 	test('a theme change preserves the basemap dim', () => {
 		const provider = makeProvider();
 		const setOptions = vi.fn();
@@ -337,9 +410,18 @@ describe('setBasemapDimmed / setTheme composition', () => {
 		provider.setTheme('dark');
 
 		const lastStyles = setOptions.mock.calls.at(-1)[0].styles;
-		expect(lastStyles.some((s) => s.stylers?.some((v) => 'saturation' in v))).toBe(true);
+		const base = nightModeStyles();
+		expect(base.length).toBeGreaterThan(0);
+		expect(lastStyles).toHaveLength(base.length + 1);
+		expect(lastStyles.slice(0, base.length)).toEqual(base);
+		expect(lastStyles.at(-1).stylers.some((v) => 'saturation' in v)).toBe(true);
 	});
 
+	// Distinct from the test above: theme applied first, dim toggled after.
+	// Before nightModeStyles() was de-stubbed this was byte-identical to
+	// 'setBasemapDimmed applies a desaturating style' (empty base both times) and
+	// asserted nothing about composition; with a real base it now genuinely
+	// checks that toggling the dim doesn't drop the theme's entries.
 	test('a dim toggle preserves the current theme', () => {
 		const provider = makeProvider();
 		const setOptions = vi.fn();
@@ -350,9 +432,11 @@ describe('setBasemapDimmed / setTheme composition', () => {
 		provider.setBasemapDimmed(true);
 
 		const lastStyles = setOptions.mock.calls.at(-1)[0].styles;
-		// nightModeStyles() is mocked to [] above, so assert the dim entry landed
-		// alongside whatever the (empty, mocked) dark-theme base produced.
-		expect(lastStyles.some((s) => s.stylers?.some((v) => 'saturation' in v))).toBe(true);
+		const base = nightModeStyles();
+		expect(base.length).toBeGreaterThan(0);
+		expect(lastStyles).toHaveLength(base.length + 1);
+		expect(lastStyles.slice(0, base.length)).toEqual(base);
+		expect(lastStyles.at(-1).stylers.some((v) => 'saturation' in v)).toBe(true);
 	});
 });
 
@@ -414,6 +498,38 @@ describe('createPolyline casing', () => {
 
 		expect(line.options.zIndex).toBe(20);
 		expect(line._casing.options.zIndex).toBe(10);
+	});
+
+	// A casing always gets an explicit zIndex, even with no pane (falls back to
+	// ROUTE_LAYER_Z_INDEX[CASING]). Without a matching explicit zIndex on the
+	// line, Google has no documented default for PolylineOptions.zIndex, so the
+	// casing's explicit 10 would beat the line's unset zIndex and paint the
+	// white casing on top of the colored route.
+	test('keeps the colored line above its casing when no pane is given', async () => {
+		setupGoogleMapsForPolylines();
+		const provider = makeProvider();
+
+		const line = await provider.createPolyline('encoded', {
+			color: '#b02a37',
+			casing: true
+		});
+
+		expect(line.options.zIndex).not.toBeUndefined();
+		expect(line.options.zIndex).toBeGreaterThan(line._casing.options.zIndex);
+	});
+
+	test('keeps the colored line above its casing when an explicit pane is given', async () => {
+		setupGoogleMapsForPolylines();
+		const provider = makeProvider();
+
+		const line = await provider.createPolyline('encoded', {
+			color: '#b02a37',
+			casing: true,
+			pane: 'obaRoute',
+			casingPane: 'obaRouteCasing'
+		});
+
+		expect(line.options.zIndex).toBeGreaterThan(line._casing.options.zIndex);
 	});
 
 	// The casing must stay out of this.polylines or fitToPolylines,

--- a/src/tests/lib/OpenStreetMapProvider.test.js
+++ b/src/tests/lib/OpenStreetMapProvider.test.js
@@ -765,3 +765,103 @@ describe('createPolyline casing', () => {
 		expect(casing.remove).toHaveBeenCalled();
 	});
 });
+
+describe('setPolylineLayer', () => {
+	function makeProvider() {
+		const provider = new OpenStreetMapProvider(vi.fn());
+		provider.L = makeFakeL(makeFakeMarker());
+		provider.map = { hasLayer: () => true, removeLayer: vi.fn() };
+		return provider;
+	}
+
+	test('moves the polyline to the new pane', () => {
+		const provider = makeProvider();
+		const line = provider.createPolyline('encoded', { color: '#b02a37', pane: 'obaRoute' });
+
+		provider.setPolylineLayer(line, 'obaRoutePromoted');
+
+		expect(line.remove).toHaveBeenCalledOnce();
+		expect(line.options.pane).toBe('obaRoutePromoted');
+		// addTo is called once by createPolyline, then again by setPolylineLayer.
+		expect(line.addTo).toHaveBeenCalledTimes(2);
+		expect(line.addTo).toHaveBeenLastCalledWith(provider.map);
+	});
+
+	// Path.beforeAdd resolves the renderer from options.pane once, at add time.
+	// SVG._initPath then creates a brand-new <path> on that add, discarding any
+	// in-flight reveal transition — so a pending draw-reveal timer must not
+	// later fire against the now-dead node.
+	test('clears a pending draw-reveal timeout before re-adding', () => {
+		const provider = makeProvider();
+		const line = provider.createPolyline('encoded', { color: '#b02a37', pane: 'obaRoute' });
+		line._drawTimeoutId = 1234;
+		const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+		provider.setPolylineLayer(line, 'obaRoutePromoted');
+
+		expect(clearTimeoutSpy).toHaveBeenCalledWith(1234);
+		expect(line._drawTimeoutId).toBeNull();
+		clearTimeoutSpy.mockRestore();
+	});
+
+	// The arrow decorator bakes `pane` into its Symbol.arrowHead pathOptions at
+	// construction time, so re-assigning options.pane on the existing decorator
+	// wouldn't move its arrows — it has to be rebuilt from scratch.
+	test('recreates the arrow decorator in the new pane rather than re-paning the old one', () => {
+		const provider = makeProvider();
+		const line = provider.createPolyline('encoded', { color: '#b02a37', pane: 'obaRoute' });
+		const originalDecorator = line.arrowDecorator;
+		expect(originalDecorator).toBeTruthy();
+
+		provider.setPolylineLayer(line, 'obaRoutePromoted');
+
+		expect(originalDecorator.remove).toHaveBeenCalledOnce();
+		expect(line.arrowDecorator).not.toBe(originalDecorator);
+		const lastPathOptions = provider.L.Symbol.arrowHead.mock.calls.at(-1)[0].pathOptions;
+		expect(lastPathOptions.pane).toBe('obaRoutePromoted');
+	});
+
+	// Must use layer.remove(), not provider.removePolyline() — that helper also
+	// splices the layer out of this.polylines, and addTo() doesn't push it back
+	// in, so a later clearAllPolylines() would leak the layer.
+	test('does not remove the polyline from the tracked polylines list', () => {
+		const provider = makeProvider();
+		provider.createPolyline('encoded', { color: '#b02a37', pane: 'obaRoute' });
+		const line = provider.polylines[0];
+
+		provider.setPolylineLayer(line, 'obaRoutePromoted');
+
+		expect(provider.getPolylinesCount()).toBe(1);
+	});
+
+	test('leaves the casing in its own pane', () => {
+		const provider = makeProvider();
+		const line = provider.createPolyline('encoded', {
+			color: '#b02a37',
+			casing: true,
+			pane: 'obaRoute',
+			casingPane: 'obaRouteCasing'
+		});
+
+		provider.setPolylineLayer(line, 'obaRoutePromoted');
+
+		expect(line._casing.options.pane).toBe('obaRouteCasing');
+	});
+
+	test('is a no-op with no map', () => {
+		const provider = makeProvider();
+		const line = provider.createPolyline('encoded', { color: '#b02a37', pane: 'obaRoute' });
+		line.remove.mockClear();
+		line.addTo.mockClear();
+		provider.map = null;
+
+		expect(() => provider.setPolylineLayer(line, 'obaRoutePromoted')).not.toThrow();
+		expect(line.remove).not.toHaveBeenCalled();
+		expect(line.addTo).not.toHaveBeenCalled();
+	});
+
+	test('is a no-op with no polyline', () => {
+		const provider = makeProvider();
+		expect(() => provider.setPolylineLayer(null, 'obaRoutePromoted')).not.toThrow();
+	});
+});

--- a/src/tests/lib/OpenStreetMapProvider.test.js
+++ b/src/tests/lib/OpenStreetMapProvider.test.js
@@ -504,3 +504,51 @@ describe('addUserLocationMarker — one marker, repositioned', () => {
 		expect(removeLayer).not.toHaveBeenCalled();
 	});
 });
+
+describe('revealPolylines', () => {
+	function fakePolyline() {
+		const path = {
+			style: {},
+			getTotalLength: () => 100,
+			getBoundingClientRect: () => ({})
+		};
+		return { _path: path, addTo: vi.fn(), remove: vi.fn() };
+	}
+
+	test('animates only the polylines passed in `only`', () => {
+		const provider = new OpenStreetMapProvider(vi.fn());
+		const a = fakePolyline();
+		const b = fakePolyline();
+		provider.map = { hasLayer: () => true, removeLayer: vi.fn() };
+		provider.polylines = [a, b];
+
+		provider.revealPolylines({ only: [a] });
+
+		expect(a._path.style.strokeDashoffset).toBe('0');
+		expect(b._path.style.strokeDashoffset).toBeUndefined();
+	});
+
+	test('animates a polyline casing alongside its polyline', () => {
+		const provider = new OpenStreetMapProvider(vi.fn());
+		const line = fakePolyline();
+		line._casing = fakePolyline();
+		provider.map = { hasLayer: () => true, removeLayer: vi.fn() };
+		provider.polylines = [line];
+
+		provider.revealPolylines({ only: [line] });
+
+		expect(line._casing._path.style.strokeDashoffset).toBe('0');
+	});
+
+	test('does not move the camera', () => {
+		const provider = new OpenStreetMapProvider(vi.fn());
+		const line = fakePolyline();
+		const flyToBounds = vi.fn();
+		provider.map = { hasLayer: () => true, removeLayer: vi.fn(), flyToBounds };
+		provider.polylines = [line];
+
+		provider.revealPolylines({ only: [line] });
+
+		expect(flyToBounds).not.toHaveBeenCalled();
+	});
+});

--- a/src/tests/lib/OpenStreetMapProvider.test.js
+++ b/src/tests/lib/OpenStreetMapProvider.test.js
@@ -454,3 +454,53 @@ describe('flyTo — vertical offset for the bottom sheet', () => {
 		expect(flyTo).toHaveBeenCalledWith(shiftedCenter, 16, { animate: true });
 	});
 });
+
+describe('addUserLocationMarker — one marker, repositioned', () => {
+	let provider;
+	let circleMarker;
+	let removeLayer;
+
+	beforeEach(() => {
+		circleMarker = vi.fn(() => ({
+			addTo: vi.fn().mockReturnThis(),
+			setLatLng: vi.fn()
+		}));
+		removeLayer = vi.fn();
+		provider = new OpenStreetMapProvider(vi.fn());
+		provider.L = { circleMarker };
+		provider.map = { removeLayer };
+	});
+
+	test('creates the marker on the first call', () => {
+		const marker = provider.addUserLocationMarker({ lat: 47.6, lng: -122.3 });
+
+		expect(circleMarker).toHaveBeenCalledOnce();
+		expect(circleMarker.mock.calls[0][0]).toEqual([47.6, -122.3]);
+		expect(marker.addTo).toHaveBeenCalledWith(provider.map);
+		expect(provider.userLocationMarker).toBe(marker);
+	});
+
+	test('moves the existing marker instead of stacking a second one', () => {
+		const first = provider.addUserLocationMarker({ lat: 47.6, lng: -122.3 });
+		const second = provider.addUserLocationMarker({ lat: 47.5, lng: -122.4 });
+
+		expect(circleMarker).toHaveBeenCalledOnce();
+		expect(second).toBe(first);
+		expect(first.setLatLng).toHaveBeenCalledWith([47.5, -122.4]);
+	});
+
+	test('removeUserLocationMarker drops the layer and clears the reference', () => {
+		const marker = provider.addUserLocationMarker({ lat: 47.6, lng: -122.3 });
+
+		provider.removeUserLocationMarker();
+
+		expect(removeLayer).toHaveBeenCalledWith(marker);
+		expect(provider.userLocationMarker).toBeNull();
+	});
+
+	test('removeUserLocationMarker is a no-op when no marker exists', () => {
+		provider.removeUserLocationMarker();
+
+		expect(removeLayer).not.toHaveBeenCalled();
+	});
+});

--- a/src/tests/lib/OpenStreetMapProvider.test.js
+++ b/src/tests/lib/OpenStreetMapProvider.test.js
@@ -540,7 +540,7 @@ describe('revealPolylines', () => {
 		expect(line._casing._path.style.strokeDashoffset).toBe('0');
 	});
 
-	test('does not move the camera', () => {
+	test('does not move the camera, but still runs the reveal', () => {
 		const provider = new OpenStreetMapProvider(vi.fn());
 		const line = fakePolyline();
 		const flyToBounds = vi.fn();
@@ -550,5 +550,61 @@ describe('revealPolylines', () => {
 		provider.revealPolylines({ only: [line] });
 
 		expect(flyToBounds).not.toHaveBeenCalled();
+		expect(line._path.style.strokeDashoffset).toBe('0');
+	});
+
+	test('an empty `only` array animates nothing', () => {
+		const provider = new OpenStreetMapProvider(vi.fn());
+		const a = fakePolyline();
+		const b = fakePolyline();
+		provider.map = { hasLayer: () => true, removeLayer: vi.fn() };
+		provider.polylines = [a, b];
+
+		provider.revealPolylines({ only: [] });
+
+		expect(a._path.style.strokeDashoffset).toBeUndefined();
+		expect(b._path.style.strokeDashoffset).toBeUndefined();
+	});
+
+	test('omitting `only` animates every tracked polyline', () => {
+		const provider = new OpenStreetMapProvider(vi.fn());
+		const a = fakePolyline();
+		const b = fakePolyline();
+		provider.map = { hasLayer: () => true, removeLayer: vi.fn() };
+		provider.polylines = [a, b];
+
+		provider.revealPolylines();
+
+		expect(a._path.style.strokeDashoffset).toBe('0');
+		expect(b._path.style.strokeDashoffset).toBe('0');
+	});
+
+	test('a second reveal call clears the prior pending draw timeout for the same polyline', () => {
+		vi.useFakeTimers();
+		const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+		try {
+			const provider = new OpenStreetMapProvider(vi.fn());
+			const line = fakePolyline();
+			provider.map = { hasLayer: () => true, removeLayer: vi.fn() };
+			provider.polylines = [line];
+
+			provider.revealPolylines({ only: [line] });
+			const firstTimeoutId = line._drawTimeoutId;
+			expect(firstTimeoutId).toBeDefined();
+
+			provider.revealPolylines({ only: [line] });
+			const secondTimeoutId = line._drawTimeoutId;
+
+			expect(clearTimeoutSpy).toHaveBeenCalledWith(firstTimeoutId);
+			expect(secondTimeoutId).not.toBe(firstTimeoutId);
+
+			// Only one timer should still be outstanding: advancing time should
+			// only ever fire once more (the second, still-pending timer), not
+			// throw or double-fire against a torn-down node.
+			expect(vi.getTimerCount()).toBe(1);
+		} finally {
+			clearTimeoutSpy.mockRestore();
+			vi.useRealTimers();
+		}
 	});
 });

--- a/src/tests/lib/OpenStreetMapProvider.test.js
+++ b/src/tests/lib/OpenStreetMapProvider.test.js
@@ -24,6 +24,15 @@ vi.mock('$lib/MapHelpers/animateMarker', () => ({
 	cancelMarkerAnimation: vi.fn()
 }));
 
+vi.mock('polyline-encoded', () => ({
+	default: {
+		decode: vi.fn(() => [
+			[47.6, -122.3],
+			[47.61, -122.31]
+		])
+	}
+}));
+
 // addMarker() bails early unless browser is true, and mounts the StopMarker
 // component. Force browser on and stub mount/unmount (the $state rune compiles
 // to svelte/internal/client, so it is unaffected by mocking the top-level module).
@@ -77,7 +86,16 @@ function makeFakeMarker() {
 function makeFakeL(fakeMarker) {
 	return {
 		divIcon: vi.fn(() => ({})),
-		marker: vi.fn(() => fakeMarker)
+		marker: vi.fn(() => fakeMarker),
+		Polyline: vi.fn(function FakePolyline(latlngs, options) {
+			this.options = options;
+			this.addTo = vi.fn().mockReturnThis();
+			this.remove = vi.fn();
+			this.getLatLngs = vi.fn(() => latlngs);
+			this.getBounds = vi.fn(() => ({}));
+		}),
+		polylineDecorator: vi.fn(() => ({ addTo: vi.fn().mockReturnThis(), remove: vi.fn() })),
+		Symbol: { arrowHead: vi.fn(() => ({})) }
 	};
 }
 
@@ -606,5 +624,144 @@ describe('revealPolylines', () => {
 			clearTimeoutSpy.mockRestore();
 			vi.useRealTimers();
 		}
+	});
+});
+
+describe('stop emphasis', () => {
+	function providerWithMarkers(entries) {
+		const provider = new OpenStreetMapProvider(vi.fn());
+		provider.markersMap = new Map(entries);
+		return provider;
+	}
+
+	test('applies per-stop emphasis and the default to everything else', () => {
+		const a = { props: { emphasis: 'full', dotColor: null } };
+		const b = { props: { emphasis: 'full', dotColor: null } };
+		const provider = providerWithMarkers([
+			['stop_a', a],
+			['stop_b', b]
+		]);
+
+		provider.setStopEmphasis(
+			new Map([['stop_a', { emphasis: 'routeDot', dotColor: '#b02a37' }]]),
+			'muted',
+			null
+		);
+
+		expect(a.props.emphasis).toBe('routeDot');
+		expect(a.props.dotColor).toBe('#b02a37');
+		expect(b.props.emphasis).toBe('muted');
+		expect(b.props.dotColor).toBeNull();
+	});
+
+	// The selected stop is served by the drawn trips, so it is always in the
+	// ring-dot map. Forcing 'full' here keeps the invariant in one place rather
+	// than at every call site.
+	test('forces the selected stop to full even when it is in the ring-dot map', () => {
+		const selected = { props: { emphasis: 'full', dotColor: null } };
+		const provider = providerWithMarkers([['stop_sel', selected]]);
+
+		provider.setStopEmphasis(
+			new Map([['stop_sel', { emphasis: 'routeDot', dotColor: '#b02a37' }]]),
+			'muted',
+			'stop_sel'
+		);
+
+		expect(selected.props.emphasis).toBe('full');
+	});
+
+	// GoogleMapProvider.addStopRouteMarker writes bare google.maps.Marker objects
+	// into markersMap; those have no reactive props to mutate.
+	test('skips markers with no props', () => {
+		const provider = providerWithMarkers([['stop_a', { noProps: true }]]);
+		expect(() => provider.setStopEmphasis(new Map(), 'muted', null)).not.toThrow();
+	});
+
+	test('resetStopEmphasis returns every marker to full', () => {
+		const a = { props: { emphasis: 'muted', dotColor: '#b02a37' } };
+		const provider = providerWithMarkers([['stop_a', a]]);
+		provider.resetStopEmphasis();
+		expect(a.props.emphasis).toBe('full');
+		expect(a.props.dotColor).toBeNull();
+	});
+});
+
+describe('setBasemapDimmed', () => {
+	test('toggles the dim class on the map container', () => {
+		const provider = new OpenStreetMapProvider(vi.fn());
+		const container = document.createElement('div');
+		provider.map = { getContainer: () => container };
+
+		provider.setBasemapDimmed(true);
+		expect(container.classList.contains('oba-dim-basemap')).toBe(true);
+
+		provider.setBasemapDimmed(false);
+		expect(container.classList.contains('oba-dim-basemap')).toBe(false);
+	});
+});
+
+describe('createPolyline casing', () => {
+	function makeProvider() {
+		const provider = new OpenStreetMapProvider(vi.fn());
+		provider.L = makeFakeL(makeFakeMarker());
+		provider.map = { hasLayer: () => true, removeLayer: vi.fn() };
+		return provider;
+	}
+
+	test('draws a wider white casing under the colored stroke', () => {
+		const provider = makeProvider();
+		const line = provider.createPolyline('encoded', { color: '#b02a37', casing: true, weight: 5 });
+
+		expect(line._casing).toBeTruthy();
+		expect(line._casing.options.color).toBe('#ffffff');
+		expect(line._casing.options.weight).toBeGreaterThan(line.options.weight);
+	});
+
+	test('gives the polyline and its casing the panes it was asked for', () => {
+		const provider = makeProvider();
+		const line = provider.createPolyline('encoded', {
+			color: '#b02a37',
+			casing: true,
+			pane: 'obaRoute',
+			casingPane: 'obaRouteCasing'
+		});
+
+		expect(line.options.pane).toBe('obaRoute');
+		expect(line._casing.options.pane).toBe('obaRouteCasing');
+	});
+
+	// Without this the arrow decorator builds its polyline in overlayPane (400),
+	// below the casings at 402, and every arrow vanishes under a white stroke.
+	test('draws the arrow decorator in the same pane as its polyline', () => {
+		const provider = makeProvider();
+		provider.createPolyline('encoded', { color: '#b02a37', pane: 'obaRoute' });
+
+		const decoratorOptions = provider.L.polylineDecorator.mock.calls[0][1];
+		expect(decoratorOptions.patterns[0].symbol).toBeDefined();
+		expect(provider.L.Symbol.arrowHead.mock.calls[0][0].pathOptions.pane).toBe('obaRoute');
+	});
+
+	// The casing must stay out of this.polylines or fitToPolylines,
+	// getPolylinesCount, and _getRoutePaths all double-count it.
+	test('does not track the casing in this.polylines', () => {
+		const provider = makeProvider();
+		provider.createPolyline('encoded', { color: '#b02a37', casing: true });
+		expect(provider.getPolylinesCount()).toBe(1);
+	});
+
+	test('removes the casing with its polyline', () => {
+		const provider = makeProvider();
+		const line = provider.createPolyline('encoded', { color: '#b02a37', casing: true });
+		const casing = line._casing;
+		provider.removePolyline(line);
+		expect(casing.remove).toHaveBeenCalled();
+	});
+
+	test('clearAllPolylines removes casings too', () => {
+		const provider = makeProvider();
+		const line = provider.createPolyline('encoded', { color: '#b02a37', casing: true });
+		const casing = line._casing;
+		provider.clearAllPolylines();
+		expect(casing.remove).toHaveBeenCalled();
 	});
 });

--- a/vitest-setup.js
+++ b/vitest-setup.js
@@ -45,12 +45,6 @@ vi.mock('svelte-i18n', () => ({
 			return () => {};
 		})
 	},
-	isLoading: {
-		subscribe: vi.fn((fn) => {
-			fn(false);
-			return () => {};
-		})
-	},
 	_: vi.fn((key) => key),
 	addMessages: vi.fn(),
 	init: vi.fn(),

--- a/vitest-setup.js
+++ b/vitest-setup.js
@@ -45,6 +45,12 @@ vi.mock('svelte-i18n', () => ({
 			return () => {};
 		})
 	},
+	isLoading: {
+		subscribe: vi.fn((fn) => {
+			fn(false);
+			return () => {};
+		})
+	},
 	_: vi.fn((key) => key),
 	addMessages: vi.fn(),
 	init: vi.fn(),


### PR DESCRIPTION
## Summary

When a rider selects a stop, the map now re-composes around it instead of staying a field of identical bus pins:

- **Non-selected stops de-emphasize to dots** — route-colored ring dots for stops on a drawn route, quiet gray dots otherwise; the selected stop keeps its emphasized pin.
- **The routes behind that stop's arrivals are drawn** as white-cased, per-route-colored polylines with live vehicles polled on one interval, plus a legend and a dimmed basemap. Only routes with an arrival *in-window* are drawn (a stop signed "128, 22, 773, C Line" draws just the ones you can actually catch now).
- **Every route's color is identical** across its polyline, vehicle markers, legend swatch, and arrival badge — resolved once and shared. Colliding/missing GTFS colors fall back to a computed light/dark palette; badge text color is chosen by true WCAG contrast.
- **Expanding an arrival row** promotes that route above its peers and glows its vehicle, without a redraw. Closing restores the default map.

Built as a spec → plan → 13 TDD tasks, each implemented and reviewed independently, followed by a whole-branch review and a live browser exercise. Both map providers (OSM/Leaflet and Google) stay at parity. The four mockup settings are inlined (dots / vehicles on / dim on / no flow animation).

The branch also carries two pre-existing commits unrelated to this feature (`7aecaaa` stop-sheet header restyle, `e8456ba` stale user-location dots).

## Test plan

- [x] Full suite green: **1623 tests, 89 files**; eslint + prettier clean.
- [x] Live browser exercise (Playwright, Puget Sound / OSM), cold-load deep-link to `/map/stops/1_19790`:
  - [x] Selected pin highlighted; 17 route ring-dots; 82 gray dots; 2 casings under 2 route lines in z-ordered panes (402/403/404); 16 vehicles matching the legend's "C 10 live + 128 6 live"; basemap dimmed.
  - [x] **Color identity on real GTFS**: C Line badge = line = swatch `#9c182f` (white text); 128 = `#fdb71a` (black text, via the WCAG-contrast fix).
  - [x] Only C Line + 128 drawn though the stop is signed for four routes (in-window honesty).
  - [x] Expand a row → route promoted to the top pane, exactly one vehicle gains the amber glow, no teardown storm.
  - [x] Close (Escape) → full restoration, all stops back to full pins, console clean.
- [x] Two bugs found in the browser and fixed with regression tests: a teardown seam that stranded a search-selected route, and a transient `RouteMap` mount throwing on close-after-expand.

## Review notes (non-blocking follow-ups surfaced during review)

- **Dark-mode dim reads as wash-out.** The dim uses `opacity()`, which blends against Leaflet's light container background — on a dark basemap it lightens rather than darkens. Verified good in light mode; wants a dark-mode-specific dim. (Design call, needs eyes on a dark map.)
- **Google provider** has no draw-in reveal and can't order coincident same-layer routes (`bringToFront` is a no-op); graduated stroke weights carry legibility. Google dark-mode dim composes a relative styler over an absolute-color night theme and is unverified in a real browser — needs a Google-configured manual pass.
- **Perf**: the basemap dim is a CSS filter over the MapLibre WebGL canvas during pan/zoom — worth a low-end-mobile check.
- **Pre-existing, not introduced here**: `MapView.initMap`'s catch swallows all init failures; `fitToPolylines` has no test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added map-based stop selection with highlighted route paths, live vehicles, route legends, and tiered stop markers.
  * Added consistent, accessible route colors across map lines and arrival badges, including dark-mode support.
  * Improved stop details layout and localization.
  * Added smoother route drawing and basemap dimming during stop selection.

* **Bug Fixes**
  * Improved cleanup when switching or closing stop and route views.
  * Prevented stale map data and vehicle markers from persisting.
  * Preserved vehicle markers when individual data requests fail.
  * Added safeguards for incomplete trip and map data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->