### PR TITLE
feat: Fit map smoothly to trip itinerary after planning

### DIFF
--- a/src/components/navigation/BottomSheet.svelte
+++ b/src/components/navigation/BottomSheet.svelte
@@ -7,6 +7,7 @@
     the extremes.
 
     @prop {('peek'|'half'|'full')} snap - Bindable current snap point
+    @prop {HTMLElement | null} element - Bindable reference to the sheet DOM node (for measuring occlusion)
     @prop {import('svelte').Snippet} header - Condensed header rendered inside the drag-handle row
     @prop {import('svelte').Snippet} children - Scrollable sheet body
 -->
@@ -15,7 +16,7 @@
 	import '$lib/i18n.js';
 	import { t } from 'svelte-i18n';
 
-	let { snap = $bindable('half'), header, children } = $props();
+	let { snap = $bindable('half'), element = $bindable(null), header, children } = $props();
 
 	const SNAP_ORDER = ['peek', 'half', 'full'];
 	const PEEK_HEIGHT = 150;
@@ -88,6 +89,7 @@
 
 <div class="pointer-events-none absolute inset-0" bind:clientHeight={containerHeight}>
 	<div
+		bind:this={element}
 		class="pointer-events-auto absolute inset-x-0 bottom-0 flex flex-col overflow-hidden rounded-t-[14px] border border-b-0 border-gray-400 bg-surface/95 shadow-[0_-8px_24px_rgba(0,0,0,.18)] backdrop-blur dark:border-gray-600 dark:bg-surface-dark/95 dark:text-surface-foreground-dark"
 		style:height="{sheetHeight}px"
 		style:transition={dragging ? 'none' : 'height .28s cubic-bezier(0,0,.2,1)'}

--- a/src/components/trip-planner/TripPlanModal.svelte
+++ b/src/components/trip-planner/TripPlanModal.svelte
@@ -103,7 +103,15 @@
 			const style = getLegPolylineStyle(leg);
 			// Await: the Google provider's createPolyline is async and returns
 			// null on decode failure — skip nulls instead of tracking a Promise.
-			const polyline = await mapProvider.createPolyline(shape, style);
+			// A provider that throws instead of returning null must not reject
+			// this fire-and-forget draw: that would skip the fit *and* the
+			// midpoint fallback, stranding the camera with no route and no toast.
+			let polyline = null;
+			try {
+				polyline = await mapProvider.createPolyline(shape, style);
+			} catch (error) {
+				console.error('Error creating itinerary leg polyline:', error);
+			}
 			// A newer draw (tab switch / new results) took over while we were
 			// awaiting — remove the orphan so it can't strand on the map, then bail.
 			if (token !== drawToken) {

--- a/src/components/trip-planner/TripPlanModal.svelte
+++ b/src/components/trip-planner/TripPlanModal.svelte
@@ -11,6 +11,8 @@
 	import { browser } from '$app/environment';
 	import { notifyPartialRouteShape } from '$lib/routeNotifications';
 	import { notifications } from '$stores/notificationStore';
+	import { panelFitPadding } from '$lib/mapFitPadding.js';
+	import { calculateMidpoint } from '$lib/mathUtils.js';
 
 	/**
 	 * @typedef {Object} Props
@@ -38,6 +40,7 @@
 	let prevItinerariesRef = $state(null);
 	// Id of the toast this modal raised, so closing it clears only its own.
 	let notificationId = null;
+	let sheetElement = $state(null);
 
 	function toggleSteps(index) {
 		expandedSteps[index] = !expandedSteps[index];
@@ -50,6 +53,7 @@
 	}
 
 	let currPolylines = [];
+	let drawToken = 0;
 
 	// Build per-leg polyline style based on mode and route color
 	function getLegPolylineStyle(leg) {
@@ -72,6 +76,8 @@
 
 	// draw the current itinerary route based on the active itinerary tab
 	async function drawRoute() {
+		const token = ++drawToken;
+
 		if (currPolylines.length > 0) {
 			currPolylines.forEach((polyline) => {
 				mapProvider.removePolyline(polyline);
@@ -85,6 +91,7 @@
 
 		let drawnCount = 0;
 		let legCount = 0;
+		const drawn = [];
 
 		for (const leg of itineraries[activeTab].legs) {
 			// Counted before the geometry check: a leg with no geometry at all is
@@ -97,14 +104,45 @@
 			// Await: the Google provider's createPolyline is async and returns
 			// null on decode failure — skip nulls instead of tracking a Promise.
 			const polyline = await mapProvider.createPolyline(shape, style);
+			// A newer draw (tab switch / new results) took over while we were
+			// awaiting — remove the orphan so it can't strand on the map, then bail.
+			if (token !== drawToken) {
+				if (polyline) mapProvider.removePolyline(polyline);
+				for (const prior of drawn) mapProvider.removePolyline(prior);
+				return;
+			}
 			if (polyline) {
-				currPolylines.push(polyline);
+				drawn.push(polyline);
 				drawnCount++;
 			}
 		}
+		currPolylines = drawn;
 
 		if (legCount > 0 && drawnCount < legCount) {
 			notificationId = notifyPartialRouteShape();
+		}
+
+		const padding = panelFitPadding(sheetElement?.getBoundingClientRect(), {
+			width: window.innerWidth,
+			height: window.innerHeight
+		});
+
+		let fitted = false;
+		try {
+			fitted = await mapProvider.fitToPolylines?.({ padding });
+		} catch (error) {
+			console.error('Error fitting trip itinerary to view:', error);
+		}
+		if (token !== drawToken) return;
+
+		if (!fitted) {
+			// No drawable geometry (e.g. a leg missing legGeometry) — frame the
+			// itinerary endpoints instead of leaving the camera where it was.
+			const legs = itineraries[activeTab].legs;
+			const midpoint = calculateMidpoint([legs[0].from, legs.at(-1).to]);
+			if (midpoint) {
+				mapProvider.flyTo(midpoint.lat, midpoint.lon, 13);
+			}
 		}
 	}
 
@@ -143,6 +181,7 @@
 	});
 
 	onDestroy(() => {
+		drawToken++;
 		// Partial-shape warnings auto-dismiss, but clear ours immediately on close
 		// so it doesn't linger over the next view.
 		notifications.dismiss(notificationId);
@@ -158,7 +197,7 @@
 	});
 </script>
 
-<BottomSheet bind:snap>
+<BottomSheet bind:snap bind:element={sheetElement}>
 	{#snippet header()}
 		<div class="flex items-center gap-2.5">
 			<p class="min-w-0 flex-1 truncate text-base font-semibold text-black dark:text-white">

--- a/src/components/trip-planner/TripPlanModal.svelte
+++ b/src/components/trip-planner/TripPlanModal.svelte
@@ -138,8 +138,14 @@
 		if (!fitted) {
 			// No drawable geometry (e.g. a leg missing legGeometry) — frame the
 			// itinerary endpoints instead of leaving the camera where it was.
+			// Endpoints are filtered rather than trusted: an empty legs array or a
+			// leg missing from/to coordinates would otherwise throw here, or hand
+			// calculateMidpoint a NaN it happily averages into a NaN flyTo.
 			const legs = itineraries[activeTab].legs;
-			const midpoint = calculateMidpoint([legs[0].from, legs.at(-1).to]);
+			const endpoints = [legs[0]?.from, legs.at(-1)?.to].filter(
+				(point) => Number.isFinite(point?.lat) && Number.isFinite(point?.lon)
+			);
+			const midpoint = calculateMidpoint(endpoints);
 			if (midpoint) {
 				mapProvider.flyTo(midpoint.lat, midpoint.lon, 13);
 			}
@@ -185,11 +191,8 @@
 		// Partial-shape warnings auto-dismiss, but clear ours immediately on close
 		// so it doesn't linger over the next view.
 		notifications.dismiss(notificationId);
-		if (currPolylines.length > 0) {
-			currPolylines.forEach(async (polyline) => {
-				mapProvider.removePolyline(await polyline);
-			});
-		}
+		// currPolylines only ever holds polylines already awaited in drawRoute.
+		currPolylines.forEach((polyline) => mapProvider.removePolyline(polyline));
 
 		if (browser && itineraryTabsContainer) {
 			itineraryTabsContainer.removeEventListener('wheel', handleWheel);

--- a/src/components/trip-planner/__tests__/TripPlanModal.test.js
+++ b/src/components/trip-planner/__tests__/TripPlanModal.test.js
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
+import { get } from 'svelte/store';
 import userEvent from '@testing-library/user-event';
+import { notifications } from '$stores/notificationStore';
 import TripPlanModal from '../TripPlanModal.svelte';
 
 vi.mock('$app/environment', () => ({
@@ -30,18 +32,21 @@ function makeItinerary(legs, duration = 1200) {
 	return { duration, legs };
 }
 
+function makeMapProvider() {
+	let polylineId = 0;
+	return {
+		createPolyline: vi.fn(async () => ({ id: `line-${++polylineId}` })),
+		removePolyline: vi.fn(),
+		fitToPolylines: vi.fn().mockResolvedValue(true),
+		flyTo: vi.fn()
+	};
+}
+
 describe('TripPlanModal map fit', () => {
 	let mapProvider;
-	let polylineId;
 
 	beforeEach(() => {
-		polylineId = 0;
-		mapProvider = {
-			createPolyline: vi.fn(async () => ({ id: `line-${++polylineId}` })),
-			removePolyline: vi.fn(),
-			fitToPolylines: vi.fn().mockResolvedValue(true),
-			flyTo: vi.fn()
-		};
+		mapProvider = makeMapProvider();
 	});
 
 	afterEach(() => {
@@ -184,5 +189,224 @@ describe('TripPlanModal map fit', () => {
 		expect(mapProvider.flyTo).toHaveBeenCalledWith(47.7, -122.4, 13);
 
 		unmount();
+	});
+
+	it('does not throw on an itinerary with no legs', async () => {
+		mapProvider.fitToPolylines = vi.fn().mockResolvedValue(false);
+		// drawRoute is fired and forgotten from an $effect, so a throw inside it
+		// surfaces as an unobserved rejection on the process, not as a test failure.
+		const rejections = [];
+		const onRejection = (reason) => rejections.push(reason);
+		process.on('unhandledRejection', onRejection);
+
+		const { unmount } = render(TripPlanModal, {
+			props: { mapProvider, itineraries: [makeItinerary([])], closePane: vi.fn() }
+		});
+
+		await vi.waitFor(() => expect(mapProvider.fitToPolylines).toHaveBeenCalled());
+		// Give Node a turn to surface any unobserved rejection.
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		process.off('unhandledRejection', onRejection);
+
+		expect(rejections.map((r) => String(r?.message ?? r))).toEqual([]);
+		// Nothing to frame, so the camera is left where it was.
+		expect(mapProvider.flyTo).not.toHaveBeenCalled();
+
+		unmount();
+	});
+
+	it('skips the flyTo fallback when leg endpoints have no coordinates', async () => {
+		mapProvider.fitToPolylines = vi.fn().mockResolvedValue(false);
+		mapProvider.createPolyline = vi.fn().mockResolvedValue(null);
+
+		const { unmount } = render(TripPlanModal, {
+			props: {
+				mapProvider,
+				itineraries: [makeItinerary([makeLeg({ from: {}, to: {}, legGeometry: { points: '' } })])],
+				closePane: vi.fn()
+			}
+		});
+
+		await vi.waitFor(() => expect(mapProvider.fitToPolylines).toHaveBeenCalled());
+		await tick();
+		await Promise.resolve();
+
+		// Averaging absent coordinates yields NaN; panning there would break the map.
+		expect(mapProvider.flyTo).not.toHaveBeenCalled();
+
+		unmount();
+	});
+
+	it('still frames the endpoints when only one of them has coordinates', async () => {
+		mapProvider.fitToPolylines = vi.fn().mockResolvedValue(false);
+		mapProvider.createPolyline = vi.fn().mockResolvedValue(null);
+
+		const { unmount } = render(TripPlanModal, {
+			props: {
+				mapProvider,
+				itineraries: [
+					makeItinerary([
+						makeLeg({
+							from: { name: 'A', lat: 47.6, lon: -122.3 },
+							to: {},
+							legGeometry: { points: '' }
+						})
+					])
+				],
+				closePane: vi.fn()
+			}
+		});
+
+		await vi.waitFor(() => expect(mapProvider.flyTo).toHaveBeenCalled());
+
+		expect(mapProvider.flyTo).toHaveBeenCalledWith(47.6, -122.3, 13);
+
+		unmount();
+	});
+});
+
+// The partial-shape toast and the fit-to-itinerary camera work live in the same
+// drawRoute pass, so they are exercised together here: a leg can go missing from
+// the map while the remaining legs still need framing.
+describe('TripPlanModal partial-shape warnings', () => {
+	let mapProvider;
+
+	beforeEach(() => {
+		notifications.dismiss();
+		mapProvider = makeMapProvider();
+	});
+
+	afterEach(() => {
+		notifications.dismiss();
+		vi.clearAllMocks();
+	});
+
+	function renderWith(itineraries) {
+		return render(TripPlanModal, {
+			props: { mapProvider, itineraries, closePane: vi.fn() }
+		});
+	}
+
+	it('warns and still fits the map when only some legs draw', async () => {
+		mapProvider.createPolyline = vi.fn(async (shape) =>
+			shape === 'bad_shape' ? null : { id: 'line-ok' }
+		);
+
+		const { unmount } = renderWith([
+			makeItinerary([
+				makeLeg({ legGeometry: { points: 'good_shape' } }),
+				makeLeg({ legGeometry: { points: 'bad_shape' } })
+			])
+		]);
+
+		await vi.waitFor(() => expect(mapProvider.fitToPolylines).toHaveBeenCalled());
+
+		const active = get(notifications);
+		expect(active?.variant).toBe('warning');
+		expect(active?.message).toBe('notifications.route_shape_partial');
+		// The legs that did draw are still worth framing.
+		expect(mapProvider.flyTo).not.toHaveBeenCalled();
+
+		unmount();
+	});
+
+	it('counts a leg with no geometry at all toward the gap', async () => {
+		const { unmount } = renderWith([
+			makeItinerary([
+				makeLeg({ legGeometry: { points: 'shape_a' } }),
+				makeLeg({ legGeometry: undefined })
+			])
+		]);
+
+		await vi.waitFor(() => expect(mapProvider.fitToPolylines).toHaveBeenCalled());
+
+		// The geometry-less leg is skipped before createPolyline, but still counted.
+		expect(mapProvider.createPolyline).toHaveBeenCalledTimes(1);
+		expect(get(notifications)?.variant).toBe('warning');
+
+		unmount();
+	});
+
+	it('stays quiet when every leg draws', async () => {
+		const { unmount } = renderWith([
+			makeItinerary([
+				makeLeg({ legGeometry: { points: 'shape_a' } }),
+				makeLeg({ legGeometry: { points: 'shape_b' } })
+			])
+		]);
+
+		await vi.waitFor(() => expect(mapProvider.fitToPolylines).toHaveBeenCalled());
+
+		expect(get(notifications)).toBeNull();
+
+		unmount();
+	});
+
+	it('raises no stale warning from a draw that was superseded mid-flight', async () => {
+		let releaseFirst;
+		const firstCreate = new Promise((resolve) => {
+			releaseFirst = resolve;
+		});
+		let call = 0;
+		mapProvider.createPolyline = vi.fn(() => {
+			call += 1;
+			// The first itinerary's only leg fails to decode — but not until after
+			// the user has already switched to the second tab.
+			if (call === 1) return firstCreate.then(() => null);
+			return Promise.resolve({ id: `line-${call}` });
+		});
+
+		const { unmount } = renderWith([
+			makeItinerary([makeLeg({ legGeometry: { points: 'shape_a' } })], 600),
+			makeItinerary([makeLeg({ legGeometry: { points: 'shape_b' } })], 900)
+		]);
+
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(1));
+
+		const itineraryTabs = screen
+			.getAllByRole('button')
+			.filter((btn) => btn.classList.contains('itinerary-tab'));
+		await userEvent.click(itineraryTabs[1]);
+
+		await vi.waitFor(() => expect(mapProvider.fitToPolylines).toHaveBeenCalled());
+
+		releaseFirst();
+		await tick();
+		await Promise.resolve();
+
+		// The abandoned draw must not warn about an itinerary no longer on screen.
+		expect(get(notifications)).toBeNull();
+
+		unmount();
+	});
+
+	it('clears its own warning when the modal closes', async () => {
+		mapProvider.createPolyline = vi.fn().mockResolvedValue(null);
+
+		const { unmount } = renderWith([
+			makeItinerary([makeLeg({ legGeometry: { points: 'bad_shape' } })])
+		]);
+
+		await vi.waitFor(() => expect(get(notifications)?.variant).toBe('warning'));
+
+		unmount();
+
+		expect(get(notifications)).toBeNull();
+	});
+
+	it('leaves a newer notification alone when the modal closes', async () => {
+		mapProvider.createPolyline = vi.fn().mockResolvedValue(null);
+
+		const { unmount } = renderWith([
+			makeItinerary([makeLeg({ legGeometry: { points: 'bad_shape' } })])
+		]);
+
+		await vi.waitFor(() => expect(get(notifications)?.variant).toBe('warning'));
+
+		// Something else takes over the toast slot before the modal is dismissed.
+		const otherId = notifications.show({ message: 'unrelated', variant: 'error' });
+		unmount();
+
+		expect(get(notifications)?.id).toBe(otherId);
 	});
 });

--- a/src/components/trip-planner/__tests__/TripPlanModal.test.js
+++ b/src/components/trip-planner/__tests__/TripPlanModal.test.js
@@ -263,6 +263,44 @@ describe('TripPlanModal map fit', () => {
 
 		unmount();
 	});
+
+	it('survives a provider whose createPolyline throws', async () => {
+		mapProvider.fitToPolylines = vi.fn().mockResolvedValue(false);
+		mapProvider.createPolyline = vi.fn(async () => {
+			throw new Error('provider blew up');
+		});
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const rejections = [];
+		const onRejection = (reason) => rejections.push(reason);
+		process.on('unhandledRejection', onRejection);
+
+		const { unmount } = render(TripPlanModal, {
+			props: {
+				mapProvider,
+				itineraries: [makeItinerary([makeLeg()])],
+				closePane: vi.fn()
+			}
+		});
+
+		// A throw must not abort the draw: the fallback still has to run.
+		await vi.waitFor(() => expect(mapProvider.flyTo).toHaveBeenCalled());
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		process.off('unhandledRejection', onRejection);
+
+		expect(rejections.map((r) => String(r?.message ?? r))).toEqual([]);
+		expect(consoleError).toHaveBeenCalledWith(
+			'Error creating itinerary leg polyline:',
+			expect.any(Error)
+		);
+		expect(mapProvider.flyTo).toHaveBeenCalledWith(
+			expect.closeTo(47.65, 5),
+			expect.closeTo(-122.35, 5),
+			13
+		);
+
+		consoleError.mockRestore();
+		unmount();
+	});
 });
 
 // The partial-shape toast and the fit-to-itinerary camera work live in the same

--- a/src/components/trip-planner/__tests__/TripPlanModal.test.js
+++ b/src/components/trip-planner/__tests__/TripPlanModal.test.js
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import userEvent from '@testing-library/user-event';
+import TripPlanModal from '../TripPlanModal.svelte';
+
+vi.mock('$app/environment', () => ({
+	browser: true,
+	dev: false,
+	building: false,
+	version: '1.0.0'
+}));
+
+vi.mock('@fortawesome/svelte-fontawesome', () => ({
+	FontAwesomeIcon: vi.fn(() => ({ $$: { component: 'div' } }))
+}));
+
+function makeLeg(overrides = {}) {
+	return {
+		mode: 'BUS',
+		routeColor: 'ff0000',
+		from: { name: 'Origin', lat: 47.6, lon: -122.3 },
+		to: { name: 'Destination', lat: 47.7, lon: -122.4 },
+		legGeometry: { points: 'encoded_shape' },
+		...overrides
+	};
+}
+
+function makeItinerary(legs, duration = 1200) {
+	return { duration, legs };
+}
+
+describe('TripPlanModal map fit', () => {
+	let mapProvider;
+	let polylineId;
+
+	beforeEach(() => {
+		polylineId = 0;
+		mapProvider = {
+			createPolyline: vi.fn(async () => ({ id: `line-${++polylineId}` })),
+			removePolyline: vi.fn(),
+			fitToPolylines: vi.fn().mockResolvedValue(true),
+			flyTo: vi.fn()
+		};
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fits the map after itinerary results arrive', async () => {
+		const itineraries = [makeItinerary([makeLeg()])];
+		const { unmount } = render(TripPlanModal, {
+			props: {
+				mapProvider,
+				itineraries,
+				closePane: vi.fn()
+			}
+		});
+
+		await vi.waitFor(() => {
+			expect(mapProvider.createPolyline).toHaveBeenCalled();
+			expect(mapProvider.fitToPolylines).toHaveBeenCalled();
+		});
+
+		expect(mapProvider.fitToPolylines).toHaveBeenCalledWith(
+			expect.objectContaining({
+				padding: expect.objectContaining({
+					top: expect.any(Number),
+					right: expect.any(Number),
+					bottom: expect.any(Number),
+					left: expect.any(Number)
+				})
+			})
+		);
+		expect(mapProvider.flyTo).not.toHaveBeenCalled();
+
+		unmount();
+	});
+
+	it('re-fits when switching itinerary tabs', async () => {
+		const user = userEvent.setup();
+		const itineraries = [
+			makeItinerary([makeLeg({ legGeometry: { points: 'shape_a' } })], 600),
+			makeItinerary([makeLeg({ mode: 'WALK', legGeometry: { points: 'shape_b' } })], 900)
+		];
+		const { unmount } = render(TripPlanModal, {
+			props: {
+				mapProvider,
+				itineraries,
+				closePane: vi.fn()
+			}
+		});
+
+		await vi.waitFor(() => expect(mapProvider.fitToPolylines).toHaveBeenCalledTimes(1));
+
+		const tabs = screen.getAllByRole('button', { name: /min/i });
+		// First button is the close control; itinerary tabs follow.
+		const itineraryTabs = tabs.filter((btn) => btn.classList.contains('itinerary-tab'));
+		expect(itineraryTabs.length).toBe(2);
+
+		await user.click(itineraryTabs[1]);
+		await tick();
+
+		await vi.waitFor(() => expect(mapProvider.fitToPolylines).toHaveBeenCalledTimes(2));
+		expect(mapProvider.createPolyline).toHaveBeenCalledWith(
+			'shape_b',
+			expect.objectContaining({ dashArray: '8, 12' })
+		);
+
+		unmount();
+	});
+
+	it('removes orphan polylines when a tab switch supersedes an in-flight draw', async () => {
+		let releaseFirst;
+		const firstCreate = new Promise((resolve) => {
+			releaseFirst = resolve;
+		});
+		let call = 0;
+		mapProvider.createPolyline = vi.fn(() => {
+			call += 1;
+			if (call === 1) {
+				return firstCreate.then(() => ({ id: 'stale-line' }));
+			}
+			return Promise.resolve({ id: `line-${call}` });
+		});
+
+		const itineraries = [
+			makeItinerary([makeLeg({ legGeometry: { points: 'shape_a' } })], 600),
+			makeItinerary([makeLeg({ legGeometry: { points: 'shape_b' } })], 900)
+		];
+		const { unmount } = render(TripPlanModal, {
+			props: {
+				mapProvider,
+				itineraries,
+				closePane: vi.fn()
+			}
+		});
+
+		// Wait until the first draw is blocked on createPolyline.
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(1));
+
+		const itineraryTabs = screen
+			.getAllByRole('button')
+			.filter((btn) => btn.classList.contains('itinerary-tab'));
+		await userEvent.click(itineraryTabs[1]);
+
+		// Second draw starts and completes while the first is still pending.
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
+		await vi.waitFor(() => expect(mapProvider.fitToPolylines).toHaveBeenCalled());
+
+		releaseFirst({ id: 'stale-line' });
+		await tick();
+		await Promise.resolve();
+
+		expect(mapProvider.removePolyline).toHaveBeenCalledWith({ id: 'stale-line' });
+
+		unmount();
+	});
+
+	it('falls back to flyTo when fitToPolylines returns false', async () => {
+		mapProvider.fitToPolylines = vi.fn().mockResolvedValue(false);
+		mapProvider.createPolyline = vi.fn().mockResolvedValue(null);
+
+		const itineraries = [
+			makeItinerary([
+				makeLeg({
+					from: { name: 'A', lat: 47.6, lon: -122.3 },
+					to: { name: 'B', lat: 47.8, lon: -122.5 },
+					legGeometry: { points: '' }
+				})
+			])
+		];
+		const { unmount } = render(TripPlanModal, {
+			props: {
+				mapProvider,
+				itineraries,
+				closePane: vi.fn()
+			}
+		});
+
+		await vi.waitFor(() => expect(mapProvider.flyTo).toHaveBeenCalled());
+
+		expect(mapProvider.flyTo).toHaveBeenCalledWith(47.7, -122.4, 13);
+
+		unmount();
+	});
+});

--- a/src/components/trip-planner/__tests__/TripPlanModal.test.js
+++ b/src/components/trip-planner/__tests__/TripPlanModal.test.js
@@ -155,10 +155,10 @@ describe('TripPlanModal map fit', () => {
 		await vi.waitFor(() => expect(mapProvider.fitToPolylines).toHaveBeenCalled());
 
 		releaseFirst({ id: 'stale-line' });
-		await tick();
-		await Promise.resolve();
 
-		expect(mapProvider.removePolyline).toHaveBeenCalledWith({ id: 'stale-line' });
+		await vi.waitFor(() =>
+			expect(mapProvider.removePolyline).toHaveBeenCalledWith({ id: 'stale-line' })
+		);
 
 		unmount();
 	});

--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -826,7 +826,7 @@ export default class GoogleMapProvider {
 	/**
 	 * Fits the map view to the bounds of all currently drawn polylines so the
 	 * full route is centered and visible. Returns true when a fit was applied.
-	 * @param {{ padding?: number, maxZoom?: number }} [options]
+	 * @param {{ padding?: number | { top?: number, right?: number, bottom?: number, left?: number }, maxZoom?: number }} [options]
 	 * @returns {Promise<boolean>} resolves once the view has settled
 	 */
 	async fitToPolylines(options = {}) {

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -35,6 +35,30 @@ function getVehicleLabel(activeTrip) {
 		: translate('vehicle.label');
 }
 
+/**
+ * Normalize padding for Leaflet `flyToBounds` / `fitBounds`.
+ * Accepts a number, an `[x, y]` pair, or a `{top,right,bottom,left}` object
+ * (Google Maps Padding shape) and returns the options Leaflet expects.
+ *
+ * @param {number | [number, number] | { top?: number, right?: number, bottom?: number, left?: number } | null | undefined} padding
+ * @returns {{ padding: [number, number] } | { paddingTopLeft: [number, number], paddingBottomRight: [number, number] }}
+ */
+export function toLeafletPadding(padding) {
+	if (padding == null) {
+		return { padding: [50, 50] };
+	}
+	if (typeof padding === 'number') {
+		return { padding: [padding, padding] };
+	}
+	if (Array.isArray(padding)) {
+		return { padding };
+	}
+	return {
+		paddingTopLeft: [padding.left ?? 50, padding.top ?? 50],
+		paddingBottomRight: [padding.right ?? 50, padding.bottom ?? 50]
+	};
+}
+
 export default class OpenStreetMapProvider {
 	constructor(handleStopMarkerSelect) {
 		this.handleStopMarkerSelect = handleStopMarkerSelect;
@@ -1013,7 +1037,7 @@ export default class OpenStreetMapProvider {
 	 * Smoothly flies the map view to the bounds of all currently drawn
 	 * polylines so the full route is centered and visible. Returns true when a
 	 * fit was applied.
-	 * @param {{ padding?: [number, number], maxZoom?: number, duration?: number, drawDuration?: number }} [options]
+	 * @param {{ padding?: number | [number, number] | { top?: number, right?: number, bottom?: number, left?: number }, maxZoom?: number, duration?: number, drawDuration?: number }} [options]
 	 * @returns {Promise<boolean>} resolves once the route reveal begins
 	 */
 	async fitToPolylines(options = {}) {
@@ -1059,7 +1083,7 @@ export default class OpenStreetMapProvider {
 			setTimeout(reveal, duration * 1000 + 250);
 
 			this.map.flyToBounds(bounds, {
-				padding: options.padding ?? [50, 50],
+				...toLeafletPadding(options.padding),
 				maxZoom: options.maxZoom ?? 16,
 				duration
 			});

--- a/src/lib/__tests__/mapFitPadding.test.js
+++ b/src/lib/__tests__/mapFitPadding.test.js
@@ -73,6 +73,19 @@ describe('panelFitPadding', () => {
 		expect(padding.top).toBe(base);
 	});
 
+	it('pads the top for a wide overlay anchored to the top of the viewport', () => {
+		const viewport = { width: 400, height: 800 };
+		// Wide banner occupying the top of the viewport rather than the bottom.
+		const banner = { top: 0, left: 0, right: 400, bottom: 200, width: 400, height: 200 };
+
+		const padding = panelFitPadding(banner, viewport, base);
+
+		expect(padding.top).toBe(200 + base);
+		expect(padding.bottom).toBe(base);
+		expect(padding.left).toBe(base);
+		expect(padding.right).toBe(base);
+	});
+
 	it('clamps any single side to 60% of the viewport', () => {
 		const viewport = { width: 400, height: 800 };
 		// Full-height sheet would otherwise demand ~800+48 bottom padding.

--- a/src/lib/__tests__/mapFitPadding.test.js
+++ b/src/lib/__tests__/mapFitPadding.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { panelFitPadding } from '../mapFitPadding.js';
+
+describe('panelFitPadding', () => {
+	const base = 48;
+
+	it('returns uniform base padding for a null/zero rect', () => {
+		const viewport = { width: 400, height: 800 };
+		expect(panelFitPadding(null, viewport, base)).toEqual({
+			top: base,
+			right: base,
+			bottom: base,
+			left: base
+		});
+		expect(
+			panelFitPadding({ top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 }, viewport, base)
+		).toEqual({
+			top: base,
+			right: base,
+			bottom: base,
+			left: base
+		});
+		expect(
+			panelFitPadding(
+				{ top: 400, left: 0, right: 400, bottom: 800, width: 400, height: 400 },
+				null,
+				base
+			)
+		).toEqual({
+			top: base,
+			right: base,
+			bottom: base,
+			left: base
+		});
+	});
+
+	it('pads the bottom for a mobile bottom sheet (wide overlay)', () => {
+		const viewport = { width: 400, height: 800 };
+		// Half detent: sheet covers the bottom ~55% of the viewport.
+		const sheet = { top: 360, left: 0, right: 400, bottom: 800, width: 400, height: 440 };
+
+		const padding = panelFitPadding(sheet, viewport, base);
+
+		// Occlusion is vh - sheet.top = 440, plus base = 488, clamped to 0.6 * 800 = 480.
+		expect(padding.bottom).toBe(480);
+		expect(padding.top).toBe(base);
+		expect(padding.left).toBe(base);
+		expect(padding.right).toBe(base);
+	});
+
+	it('pads the left for a desktop side column', () => {
+		const viewport = { width: 1280, height: 800 };
+		// md:w-96 column with md:mx-4 margin.
+		const panel = { top: 80, left: 16, right: 400, bottom: 800, width: 384, height: 720 };
+
+		const padding = panelFitPadding(panel, viewport, base);
+
+		expect(padding.left).toBe(400 + base);
+		expect(padding.right).toBe(base);
+		expect(padding.bottom).toBe(base);
+		expect(padding.top).toBe(base);
+	});
+
+	it('pads the right for an RTL side column', () => {
+		const viewport = { width: 1280, height: 800 };
+		const panel = { top: 80, left: 880, right: 1264, bottom: 800, width: 384, height: 720 };
+
+		const padding = panelFitPadding(panel, viewport, base);
+
+		expect(padding.right).toBe(1280 - 880 + base);
+		expect(padding.left).toBe(base);
+		expect(padding.bottom).toBe(base);
+		expect(padding.top).toBe(base);
+	});
+
+	it('clamps any single side to 60% of the viewport', () => {
+		const viewport = { width: 400, height: 800 };
+		// Full-height sheet would otherwise demand ~800+48 bottom padding.
+		const sheet = { top: 0, left: 0, right: 400, bottom: 800, width: 400, height: 800 };
+
+		const padding = panelFitPadding(sheet, viewport, base);
+
+		expect(padding.bottom).toBe(viewport.height * 0.6);
+	});
+});

--- a/src/lib/mapFitPadding.js
+++ b/src/lib/mapFitPadding.js
@@ -1,0 +1,53 @@
+/**
+ * Derive per-side map fit padding from an overlay panel's bounding rect so a
+ * fitted route frames into the visible map area rather than under the panel.
+ *
+ * Pads whichever edge the overlay occupies: a wide bottom sheet below md, or
+ * the side column (left, or right under RTL) from md up. Reading the real rect
+ * keeps this correct for RTL and for every snap detent without duplicating the
+ * sheet's layout constants.
+ *
+ * Clamps any single side to 60% of the viewport so a full-height sheet can't
+ * force an absurd zoom-out. Returns uniform `base` padding for a zero/absent
+ * rect (jsdom, or a not-yet-measured sheet).
+ *
+ * @param {{ top: number, right: number, bottom: number, left: number, width: number, height: number } | null | undefined} panelRect
+ * @param {{ width: number, height: number } | null | undefined} viewport
+ * @param {number} [base=48]
+ * @returns {{ top: number, right: number, bottom: number, left: number }}
+ */
+export function panelFitPadding(panelRect, viewport, base = 48) {
+	const uniform = { top: base, right: base, bottom: base, left: base };
+	if (!panelRect || !viewport?.width || !viewport?.height) return uniform;
+	if (panelRect.width <= 0 || panelRect.height <= 0) return uniform;
+
+	const { width: vw, height: vh } = viewport;
+	const clamp = (value, max) => Math.min(Math.max(value, base), max);
+
+	const padding = { ...uniform };
+
+	// Tall + narrow → side panel (desktop itinerary column). Wide → bottom sheet.
+	const isSidePanel = panelRect.width < vw * 0.5;
+
+	if (isSidePanel) {
+		const centerX = panelRect.left + panelRect.width / 2;
+		if (centerX < vw / 2) {
+			// Panel on the left: pad by how far it extends from the left edge.
+			padding.left = clamp(Math.max(0, panelRect.right) + base, vw * 0.6);
+		} else {
+			// Panel on the right (RTL): pad by how far it extends from the right edge.
+			padding.right = clamp(Math.max(0, vw - panelRect.left) + base, vw * 0.6);
+		}
+	} else {
+		const centerY = panelRect.top + panelRect.height / 2;
+		if (centerY >= vh / 2) {
+			// Bottom sheet: pad by the occluded strip from the panel's top to the
+			// bottom of the viewport.
+			padding.bottom = clamp(Math.max(0, vh - panelRect.top) + base, vh * 0.6);
+		} else {
+			padding.top = clamp(Math.max(0, panelRect.bottom) + base, vh * 0.6);
+		}
+	}
+
+	return padding;
+}

--- a/src/tests/lib/GoogleMapProvider.test.js
+++ b/src/tests/lib/GoogleMapProvider.test.js
@@ -613,3 +613,42 @@ describe('setPolylineLayer', () => {
 		expect(() => provider.setPolylineLayer(null, 'obaRoutePromoted')).not.toThrow();
 	});
 });
+
+describe('fitToPolylines padding', () => {
+	test('forwards an object padding to map.fitBounds unchanged', async () => {
+		const fitBounds = vi.fn();
+		const addListenerOnce = vi.fn((target, event, handler) => {
+			if (event === 'idle') queueMicrotask(handler);
+			return {};
+		});
+		const removeListener = vi.fn();
+		global.google = {
+			maps: {
+				LatLngBounds: vi.fn(function Bounds() {
+					this.extend = vi.fn();
+					this.isEmpty = vi.fn(() => false);
+				}),
+				event: { addListenerOnce, removeListener }
+			}
+		};
+
+		const provider = new GoogleMapProvider('test-key', vi.fn());
+		provider.map = {
+			fitBounds,
+			getZoom: vi.fn(() => 14),
+			setZoom: vi.fn()
+		};
+		provider.polylines = [
+			{
+				getPath: () => ({
+					forEach: (fn) => fn({ lat: () => 47.6, lng: () => -122.3 })
+				})
+			}
+		];
+
+		const padding = { top: 10, right: 20, bottom: 300, left: 40 };
+		await provider.fitToPolylines({ padding });
+
+		expect(fitBounds).toHaveBeenCalledWith(expect.any(Object), padding);
+	});
+});

--- a/src/tests/lib/OpenStreetMapProvider.test.js
+++ b/src/tests/lib/OpenStreetMapProvider.test.js
@@ -1,5 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import OpenStreetMapProvider from '$lib/Provider/OpenStreetMapProvider.svelte.js';
+import OpenStreetMapProvider, {
+	toLeafletPadding
+} from '$lib/Provider/OpenStreetMapProvider.svelte.js';
 import { createVehicleIconSvg } from '$lib/MapHelpers/generateVehicleIcon';
 
 // Minimal Svelte component stubs — only imported by the module, never called
@@ -863,5 +865,58 @@ describe('setPolylineLayer', () => {
 	test('is a no-op with no polyline', () => {
 		const provider = makeProvider();
 		expect(() => provider.setPolylineLayer(null, 'obaRoutePromoted')).not.toThrow();
+	});
+});
+
+describe('toLeafletPadding / fitToPolylines padding', () => {
+	test('object padding becomes paddingTopLeft / paddingBottomRight', () => {
+		expect(toLeafletPadding({ top: 10, right: 20, bottom: 30, left: 40 })).toEqual({
+			paddingTopLeft: [40, 10],
+			paddingBottomRight: [20, 30]
+		});
+	});
+
+	test('array and number forms still pass through', () => {
+		expect(toLeafletPadding([12, 24])).toEqual({ padding: [12, 24] });
+		expect(toLeafletPadding(50)).toEqual({ padding: [50, 50] });
+		expect(toLeafletPadding(null)).toEqual({ padding: [50, 50] });
+	});
+
+	test('fitToPolylines forwards object padding to flyToBounds', async () => {
+		const provider = new OpenStreetMapProvider(vi.fn());
+		const flyToBounds = vi.fn();
+		const bounds = {
+			isValid: () => true,
+			extend: vi.fn()
+		};
+		provider.L = {
+			latLngBounds: vi.fn(() => bounds)
+		};
+		provider.map = {
+			flyToBounds,
+			once: vi.fn(),
+			hasLayer: () => false,
+			removeLayer: vi.fn()
+		};
+		provider.polylines = [{ getBounds: () => ({}) }];
+		provider._setPolylinesVisible = vi.fn();
+		provider.revealPolylines = vi.fn();
+
+		const fitPromise = provider.fitToPolylines({
+			padding: { top: 10, right: 20, bottom: 300, left: 40 },
+			duration: 0
+		});
+		const moveend = provider.map.once.mock.calls.find((c) => c[0] === 'moveend');
+		expect(moveend).toBeTruthy();
+		moveend[1]();
+		await fitPromise;
+
+		expect(flyToBounds).toHaveBeenCalledWith(
+			bounds,
+			expect.objectContaining({
+				paddingTopLeft: [40, 10],
+				paddingBottomRight: [20, 300]
+			})
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- After a successful trip plan, the map now smoothly fits to the active itinerary’s polylines (same building block route selection already uses).
- Switching itinerary tabs re-fits the camera to that option’s route.
- Padding accounts for the mobile bottom sheet and the desktop side panel so the route lands in the visible map, not under the UI. Works on both OSM and Google.


## What changed
- **`TripPlanModal`:** after drawing an itinerary’s leg polylines, call `fitToPolylines` so the map frames the route. Same path runs on new results and on tab switches. A draw token cleans up orphan polylines if you switch tabs mid-draw; if fit fails (e.g. missing geometry), fall back to `flyTo` on the itinerary midpoint.
- **`mapFitPadding`:** new helper that turns the sheet/panel’s bounding rect into per-side padding so the route lands in the visible map (above the mobile bottom sheet, beside the desktop side column) instead of under the UI. Caps any side at 60% of the viewport.
- **`BottomSheet`:** expose a bindable `element` so the modal can measure the sheet without poking at test ids.
- **Map providers:** OSM `fitToPolylines` now accepts `{ top, right, bottom, left }` padding (via `toLeafletPadding`) in addition to the existing number / `[x, y]` forms. Google already forwarded object padding to `fitBounds` — JSDoc only. Route selection callers are unchanged.
- **Tests:** unit coverage for padding math, provider padding translation, and TripPlanModal fit / re-fit / stale-draw / fallback behavior.

## Screenshot
<img width="800" height="405" alt="ScreenRecording2026-07-26at1 30 11PM-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/e7d2ba83-d16b-45fd-918e-2993bf729436" />

Closes #537

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added map-fit padding computation (`panelFitPadding`) for bottom sheets and side panels.
  - Exposed a bindable `BottomSheet` root element reference to support accurate viewport padding.
  - Added padding normalization for OpenStreetMap map fitting (`toLeafletPadding`).

- **Bug Fixes**
  - Improved itinerary route framing using per-panel padding.
  - Prevented stale/overlapping route polylines and race-condition issues during rapid itinerary switching.
  - Added safer fallback behavior when automatic fitting can’t be performed, including partial-geometry warnings.

- **Tests**
  - Expanded map fitting, padding normalization, itinerary switching, stale draw cleanup, and warning/toast lifecycle coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->