### PR TITLE
fix:StopRoutesLayer partial route rendering failures via toast notifications

### DIFF
--- a/src/components/map/StopRoutesLayer.svelte
+++ b/src/components/map/StopRoutesLayer.svelte
@@ -114,6 +114,7 @@
 	}
 
 	let notificationId = null;
+	let isMounted = true;
 
 	async function drawRoutes(routes, colors, token) {
 		if (token !== loadToken) return;
@@ -171,20 +172,27 @@
 				// turn trip-expansion into a full redraw.
 				const promoted = untrack(() => promotedRouteId);
 				const isPromoted = promoted != null && route.id === promoted;
-				const polyline = await mapProvider.createPolyline(shape.points, {
-					color,
-					casing: true,
-					weight: weightFor(index),
-					pane: isPromoted ? ROUTE_PANE.PROMOTED : ROUTE_PANE.LINE,
-					casingPane: ROUTE_PANE.CASING
-				});
+				let polyline = null;
+
+				try {
+					polyline = await mapProvider.createPolyline(shape.points, {
+						color,
+						casing: true,
+						weight: weightFor(index),
+						pane: isPromoted ? ROUTE_PANE.PROMOTED : ROUTE_PANE.LINE,
+						casingPane: ROUTE_PANE.CASING
+					});
+				} catch (error) {
+					console.error('StopRoutesLayer: could not create polyline', route.id, error);
+					return;
+				}
+
 				if (token !== loadToken) {
 					// A supersede ran clearAllPolylines() before this create resolved
 					// (Google's createPolyline is async, awaiting importLibrary), so
 					// the polyline this call just attached to the map is an orphan of
 					// the selection that's already gone — take it back off.
 					mapProvider.removePolyline(polyline);
-					attemptedRoutes--;
 					return;
 				}
 				if (!polyline) {
@@ -241,6 +249,8 @@
 				routeStopIds = new Map(nextStopIds);
 			})
 		);
+
+		if (token !== loadToken || !isMounted) return;
 
 		if (attemptedRoutes > 0 && drawnRoutes < attemptedRoutes) {
 			notificationId = notifyPartialRouteShape();
@@ -470,6 +480,7 @@
 
 	onDestroy(() => {
 		loadToken++;
+		isMounted = false;
 		teardown();
 	});
 </script>

--- a/src/components/map/StopRoutesLayer.svelte
+++ b/src/components/map/StopRoutesLayer.svelte
@@ -26,6 +26,8 @@
 	// provider here would pull its whole map stack into the bundle regardless of
 	// which one PUBLIC_OBA_MAP_PROVIDER selects.
 	import { ROUTE_PANE } from '$lib/mapPanes.js';
+	import { notifyPartialRouteShape } from '$lib/routeNotifications';
+	import { notifications } from '$stores/notificationStore';
 
 	let {
 		mapProvider,
@@ -111,6 +113,8 @@
 		return { points: shapeData?.data?.entry?.points, stopIds };
 	}
 
+	let notificationId = null;
+
 	async function drawRoutes(routes, colors, token) {
 		if (token !== loadToken) return;
 
@@ -134,6 +138,8 @@
 		// order createPolyline resolved, which is shape-fetch race order, not
 		// activeRoutes order.
 		const drawnPolylines = [];
+		let attemptedRoutes = 0;
+		let drawnRoutes = 0;
 
 		await Promise.all(
 			routes.map(async (route, index) => {
@@ -146,9 +152,17 @@
 					// other routes still draw, and this one is simply absent from the
 					// lines, the legend, and the ring dots.
 					console.error('StopRoutesLayer: could not load shape', route.id, error);
+					attemptedRoutes++;
 					return;
 				}
-				if (token !== loadToken || !shape.points) return;
+				if (token !== loadToken) return;
+
+				attemptedRoutes++;
+
+				if (!shape.points) {
+					console.error('StopRoutesLayer: route shape contains no points', route.id);
+					return;
+				}
 
 				// untrack: this read happens after an await, so Svelte would not treat
 				// it as an effect dependency anyway — but reading it explicitly through
@@ -170,9 +184,15 @@
 					// the polyline this call just attached to the map is an orphan of
 					// the selection that's already gone — take it back off.
 					mapProvider.removePolyline(polyline);
+					attemptedRoutes--;
 					return;
 				}
-				if (!polyline) return;
+				if (!polyline) {
+					console.error('StopRoutesLayer: could not create polyline', route.id);
+					return;
+				}
+
+				drawnRoutes++;
 
 				// Retained so the promotion effect can re-pane this route later
 				// without redrawing it. isPromoted was already decided above (from
@@ -221,6 +241,10 @@
 				routeStopIds = new Map(nextStopIds);
 			})
 		);
+
+		if (attemptedRoutes > 0 && drawnRoutes < attemptedRoutes) {
+			notificationId = notifyPartialRouteShape();
+		}
 	}
 
 	function stopVehiclePolling() {
@@ -232,6 +256,7 @@
 	}
 
 	function teardown() {
+		notifications.dismiss(notificationId);
 		stopVehiclePolling();
 		// mapProvider can be null: a cold deep-link whose arrivals land before
 		// initMap() resolves mounts this layer with no provider yet, and

--- a/src/components/map/__tests__/StopRoutesLayer.test.js
+++ b/src/components/map/__tests__/StopRoutesLayer.test.js
@@ -7,11 +7,16 @@ vi.mock('$lib/vehicleUtils.js', () => ({
 	fetchAndUpdateVehiclesForRoutes: vi.fn().mockResolvedValue({ intervalId: 42, tick: vi.fn() }),
 	removeVehicleMarkersForRoutes: vi.fn()
 }));
+vi.mock('$lib/routeNotifications', () => ({
+	notifyPartialRouteShape: vi.fn(() => 'toast-id')
+}));
+
 import {
 	fetchAndUpdateVehiclesForRoutes,
 	removeVehicleMarkersForRoutes
 } from '$lib/vehicleUtils.js';
 import { createLayerBindings } from './support/layerBindings.svelte.js';
+import { notifyPartialRouteShape } from '$lib/routeNotifications';
 
 function makeProvider() {
 	return {
@@ -225,6 +230,7 @@ describe('StopRoutesLayer', () => {
 			'r_22',
 			expect.any(Error)
 		);
+		expect(notifyPartialRouteShape).toHaveBeenCalledTimes(1);
 
 		consoleErrorSpy.mockRestore();
 	});
@@ -458,6 +464,13 @@ describe('StopRoutesLayer', () => {
 		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalled());
 		await flush(20);
 
+		expect(notifyPartialRouteShape).toHaveBeenCalledTimes(1);
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			'StopRoutesLayer: could not create polyline',
+			expect.any(String),
+			expect.any(Error)
+		);
 		process.off('unhandledRejection', onUnhandledRejection);
 		consoleErrorSpy.mockRestore();
 		expect(unhandled).toHaveLength(0);


### PR DESCRIPTION
### Summary
Surface partial route rendering failures in `StopRoutesLayer` using the existing notification infrastructure.

Previously, when a route shape failed to load, contained no points, or could not be decoded into a polyline, the affected route was silently omitted from the map (or only logged to the console). This change notifies riders when one or more routes cannot be rendered while preserving the existing behaviour of drawing all successfully rendered routes.

#### Closes: #579 

### Changes 

- Added route rendering counters to track attempted vs. successfully drawn routes.
- Log missing `shape.points` and polyline creation failures for consistency with shape fetch failures.
- Display a single `notifyPartialRouteShape()` warning when one or more routes fail to render.
- Store the returned `notificationId` and dismiss only that notification during component teardown.
- Exclude superseded route loads (token !== loadToken) from notification counts to avoid false warnings when users rapidly switch between stops. 

Testing

- ✅ npm run format
- ✅ npm run lint

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/wayfinder/pr/583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787945831&installation_model_id=429412&pr_number=583&repository=OneBusAway%2Fwayfinder&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fwayfinder%2Fpull%2F583&signature=ae481f9e30381626406003b904b0ef5c5c9370cd58d58f1df6b74190a676b7b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added partial-route notifications when some route shapes fail to load or render.
* **Bug Fixes**
  * Prevented partial notifications from being emitted after the map layer is torn down/destroyed.
  * Improved handling when polyline creation fails or completes after a newer selection, avoiding late/off-target updates.
* **Tests**
  * Extended coverage to assert partial-route notifications on shape-fetch failures and to verify error logging when polyline creation throws.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->