### PR TITLE
Improve color utility error handling and validation

### DIFF
--- a/src/lib/colorUtils.js
+++ b/src/lib/colorUtils.js
@@ -124,11 +124,16 @@ export function generatePalette(baseHex, fallbackHex = '#486621') {
  * @param {number} amount - Amount to darken (0-1, where 1 is pure black)
  * @returns {string} Darkened hex color
  */
-export function darkenColor(hexColor, amount) {
-	if (!hexColor) return '#000000';
-
+export function darkenColor(hexColor, amount, fallbackHex = '#486621') {
 	const rgb = hexToRgb(hexColor);
-	if (!rgb) return '#000000';
+	if (!rgb) {
+		if (fallbackHex === null) {
+			console.error(`Invalid hex color "${hexColor}" and no fallback available`);
+			return '#000000';
+		}
+		console.warn(`Invalid hex color "${hexColor}", falling back to "${fallbackHex}"`);
+		return darkenColor(fallbackHex, amount, null);
+	}
 
 	const black = { r: 0, g: 0, b: 0 };
 	const darkened = mixColors(rgb, black, amount);
@@ -143,11 +148,16 @@ export function darkenColor(hexColor, amount) {
  * @param {number} amount - Amount to lighten (0-1, where 1 is pure white)
  * @returns {string} Lightened hex color
  */
-export function lightenColor(hexColor, amount) {
-	if (!hexColor) return '#ffffff';
-
+export function lightenColor(hexColor, amount, fallbackHex = '#486621') {
 	const rgb = hexToRgb(hexColor);
-	if (!rgb) return '#ffffff';
+	if (!rgb) {
+		if (fallbackHex === null) {
+			console.error(`Invalid hex color "${hexColor}" and no fallback available`);
+			return '#ffffff';
+		}
+		console.warn(`Invalid hex color "${hexColor}", falling back to "${fallbackHex}"`);
+		return lightenColor(fallbackHex, amount, null);
+	}
 
 	const white = { r: 255, g: 255, b: 255 };
 	const lightened = mixColors(rgb, white, amount);

--- a/src/tests/lib/colorUtils.test.js
+++ b/src/tests/lib/colorUtils.test.js
@@ -9,7 +9,8 @@ import {
 	getBrightness,
 	adjustColorForDarkMode,
 	mapContrastColor,
-	polylineArrowColor
+	polylineArrowColor,
+	contrastRatio
 } from '$lib/colorUtils.js';
 
 describe('colorUtils', () => {
@@ -336,6 +337,12 @@ describe('colorUtils', () => {
 			const original = hexToRgb('#486621');
 			const darkened = hexToRgb(darkenColor('#486621', 0.15));
 			expect(getBrightness(darkened)).toBeLessThan(getBrightness(original));
+		});
+
+		test('brand accent hover color maintains AA contrast with white text', () => {
+			const hover = darkenColor(process.env.COLOR_BRAND_ACCENT, 0.15);
+
+			expect(contrastRatio('#ffffff', hover)).toBeGreaterThanOrEqual(4.5);
 		});
 	});
 

--- a/src/tests/lib/colorUtils.test.js
+++ b/src/tests/lib/colorUtils.test.js
@@ -257,6 +257,19 @@ describe('colorUtils', () => {
 	});
 
 	describe('darkenColor', () => {
+		let consoleWarnSpy;
+		let consoleErrorSpy;
+
+		beforeEach(() => {
+			consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+			consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		});
+
+		afterEach(() => {
+			consoleWarnSpy.mockRestore();
+			consoleErrorSpy.mockRestore();
+		});
+
 		test('should darken a light color by 50%', () => {
 			const result = darkenColor('#ffffff', 0.5);
 			expect(result).toBe('#808080'); // Mid-gray
@@ -278,14 +291,31 @@ describe('colorUtils', () => {
 			expect(result).toBe('#ff0000');
 		});
 
-		test('should return black for null or undefined input', () => {
-			expect(darkenColor(null, 0.5)).toBe('#000000');
-			expect(darkenColor(undefined, 0.5)).toBe('#000000');
-			expect(darkenColor('', 0.5)).toBe('#000000');
+		test('falls back to default on invalid input', () => {
+			const result = darkenColor('invalid', 0.15);
+
+			expect(consoleWarnSpy).toHaveBeenCalledWith(
+				'Invalid hex color "invalid", falling back to "#486621"'
+			);
+			expect(result).toBe('#3d571c');
 		});
 
-		test('should return black for invalid hex', () => {
-			expect(darkenColor('not-a-color', 0.5)).toBe('#000000');
+		test('handles null fallback gracefully', () => {
+			const result = darkenColor('invalid', 0.15, null);
+
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				'Invalid hex color "invalid" and no fallback available'
+			);
+			expect(result).toBe('#000000');
+		});
+
+		test('uses custom fallback when provided', () => {
+			const result = darkenColor('invalid', 0.5, '#ffffff');
+
+			expect(consoleWarnSpy).toHaveBeenCalledWith(
+				'Invalid hex color "invalid", falling back to "#ffffff"'
+			);
+			expect(result).toBe('#808080');
 		});
 
 		test('result is always darker than the input', () => {
@@ -296,6 +326,19 @@ describe('colorUtils', () => {
 	});
 
 	describe('lightenColor', () => {
+		let consoleWarnSpy;
+		let consoleErrorSpy;
+
+		beforeEach(() => {
+			consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+			consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		});
+
+		afterEach(() => {
+			consoleWarnSpy.mockRestore();
+			consoleErrorSpy.mockRestore();
+		});
+
 		test('should lighten a dark color by 50%', () => {
 			const result = lightenColor('#000000', 0.5);
 			expect(result).toBe('#808080'); // Mid-gray
@@ -321,15 +364,31 @@ describe('colorUtils', () => {
 			expect(result).toBe('#ff8080');
 		});
 
-		test('should return white for null or undefined input', () => {
-			expect(lightenColor(null, 0.5)).toBe('#ffffff');
-			expect(lightenColor(undefined, 0.5)).toBe('#ffffff');
-			expect(lightenColor('', 0.5)).toBe('#ffffff');
+		test('falls back to default on invalid input', () => {
+			const result = lightenColor('invalid', 0.15);
+
+			expect(consoleWarnSpy).toHaveBeenCalledWith(
+				'Invalid hex color "invalid", falling back to "#486621"'
+			);
+			expect(result).toBe('#637d42');
 		});
 
-		test('should return white for invalid hex color', () => {
-			const result = lightenColor('not-a-color', 0.5);
+		test('handles null fallback gracefully', () => {
+			const result = lightenColor('invalid', 0.15, null);
+
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				'Invalid hex color "invalid" and no fallback available'
+			);
 			expect(result).toBe('#ffffff');
+		});
+
+		test('uses custom fallback when provided', () => {
+			const result = lightenColor('invalid', 0.5, '#000000');
+
+			expect(consoleWarnSpy).toHaveBeenCalledWith(
+				'Invalid hex color "invalid", falling back to "#000000"'
+			);
+			expect(result).toBe('#808080');
 		});
 	});
 

--- a/src/tests/lib/colorUtils.test.js
+++ b/src/tests/lib/colorUtils.test.js
@@ -318,6 +318,20 @@ describe('colorUtils', () => {
 			expect(result).toBe('#808080');
 		});
 
+		test('handles invalid custom fallback gracefully', () => {
+			const result = darkenColor('invalid', 0.15, 'invalid-fallback');
+
+			expect(consoleWarnSpy).toHaveBeenCalledWith(
+				'Invalid hex color "invalid", falling back to "invalid-fallback"'
+			);
+
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				'Invalid hex color "invalid-fallback" and no fallback available'
+			);
+
+			expect(result).toBe('#000000');
+		});
+
 		test('result is always darker than the input', () => {
 			const original = hexToRgb('#486621');
 			const darkened = hexToRgb(darkenColor('#486621', 0.15));
@@ -389,6 +403,20 @@ describe('colorUtils', () => {
 				'Invalid hex color "invalid", falling back to "#000000"'
 			);
 			expect(result).toBe('#808080');
+		});
+
+		test('handles invalid custom fallback gracefully', () => {
+			const result = lightenColor('invalid', 0.15, 'invalid-fallback');
+
+			expect(consoleWarnSpy).toHaveBeenCalledWith(
+				'Invalid hex color "invalid", falling back to "invalid-fallback"'
+			);
+
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				'Invalid hex color "invalid-fallback" and no fallback available'
+			);
+
+			expect(result).toBe('#ffffff');
 		});
 	});
 


### PR DESCRIPTION
## Summary

This PR currently addresses the first two follow-up item from #529:

- [x] Add fallback handling and warning/error logging to `darkenColor` and `lightenColor`.
- [x] Add contrast-ratio regression test.
- [ ] Resolve the `validate-env` / `hexToRgb` 8-digit hex mismatch.

Unit tests have been updated to cover the new fallback behavior.

Working on the last fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color adjustments for invalid inputs by supporting fallback colors.
  * Added predictable default behavior when no valid fallback is available, returning black or white as appropriate.
  * Added warnings and errors to clarify invalid color handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->