### PR TITLE
feat: favorites for stops and routes

### DIFF
--- a/src/components/MapExperience.svelte
+++ b/src/components/MapExperience.svelte
@@ -34,6 +34,7 @@
 	import TripOptionsModal from '$components/trip-planner/TripOptionsModal.svelte';
 	import { showTripOptionsModal } from '$stores/tripOptionsStore';
 	import { mapStopPath } from '$lib/mapStopUrl.js';
+	import { removeAgencyPrefix } from '$lib/utils';
 	import { clearVehicleMarkersMap } from '$lib/vehicleUtils';
 	import { activeRoutesFromArrivals, assignRouteColors } from '$lib/activeRoutes.js';
 
@@ -144,15 +145,14 @@
 	 */
 	function handleFavoriteStopClick(favorite) {
 		if (!mapProvider) return;
+		// Seed the marker so the selection effect has something to highlight, then
+		// hand off. Framing is the effect's job — flying here too would fight it.
 		mapProvider.addMarker({
 			stop: favorite,
 			position: { lat: favorite.lat, lng: favorite.lon },
 			onClick: () => handleStopMarkerSelect(favorite)
 		});
-		mapProvider.flyTo(favorite.lat, favorite.lon, 20);
-		setTimeout(() => {
-			handleStopMarkerSelect(favorite);
-		}, 100);
+		handleStopMarkerSelect(favorite);
 	}
 
 	/**
@@ -161,13 +161,16 @@
 	 * @param {Object} favorite
 	 */
 	function handleFavoriteRouteClick(favorite) {
+		// The listener drives the map straight away (clearAllPolylines et al), so
+		// don't fire before MapContainer has handed us a provider.
+		if (!mapProvider) return;
 		window.dispatchEvent(
 			new CustomEvent('routeSelectedFromModal', {
 				detail: {
 					route: {
 						id: favorite.id,
 						shortName: favorite.shortName,
-						nullSafeShortName: favorite.shortName,
+						nullSafeShortName: favorite.shortName ?? removeAgencyPrefix(favorite.id),
 						description: favorite.description,
 						type: favorite.routeType
 					}

--- a/src/components/MapExperience.svelte
+++ b/src/components/MapExperience.svelte
@@ -6,6 +6,7 @@
 	import MapContainer from '$components/MapContainer.svelte';
 	import RouteModal from '$components/routes/RouteModal.svelte';
 	import ViewAllRoutesModal from '$components/routes/ViewAllRoutesModal.svelte';
+	import FavoritesFloatingControl from '$components/favorites/FavoritesFloatingControl.svelte';
 	import { isLoading } from 'svelte-i18n';
 	import AlertsModal from '$components/navigation/AlertsModal.svelte';
 	import { onMount, onDestroy } from 'svelte';
@@ -135,6 +136,44 @@
 		// structured-clones its state argument (DataCloneError on a proxy). Snapshot
 		// yields a plain, clone-safe copy.
 		pushState(mapStopPath(stopData.id), { stopData: $state.snapshot(stopData) });
+	}
+
+	/**
+	 * Open a favorited stop from the map floating control.
+	 * @param {Object} favorite
+	 */
+	function handleFavoriteStopClick(favorite) {
+		if (!mapProvider) return;
+		mapProvider.addMarker({
+			stop: favorite,
+			position: { lat: favorite.lat, lng: favorite.lon },
+			onClick: () => handleStopMarkerSelect(favorite)
+		});
+		mapProvider.flyTo(favorite.lat, favorite.lon, 20);
+		setTimeout(() => {
+			handleStopMarkerSelect(favorite);
+		}, 100);
+	}
+
+	/**
+	 * Open a favorited route via the same event ViewAllRoutesModal uses, so
+	 * SearchPane's existing handleRouteClick path loads shapes and vehicles.
+	 * @param {Object} favorite
+	 */
+	function handleFavoriteRouteClick(favorite) {
+		window.dispatchEvent(
+			new CustomEvent('routeSelectedFromModal', {
+				detail: {
+					route: {
+						id: favorite.id,
+						shortName: favorite.shortName,
+						nullSafeShortName: favorite.shortName,
+						description: favorite.description,
+						type: favorite.routeType
+					}
+				}
+			})
+		);
 	}
 
 	$effect(() => {
@@ -504,6 +543,10 @@
 {:else}
 	<h1 class="sr-only">{PUBLIC_OBA_REGION_NAME}</h1>
 	<div class="pointer-events-none absolute bottom-0 left-0 right-0 top-0 z-40">
+		<FavoritesFloatingControl
+			onStopClick={handleFavoriteStopClick}
+			onRouteClick={handleFavoriteRouteClick}
+		/>
 		<!-- Top spacing is padding (not margin) so h-full keeps the column's bottom
 		     edge — where the sheet anchors — exactly at the viewport bottom. Below md,
 		     horizontal margins live on the search wrapper and on each pane (not the

--- a/src/components/MapExperience.svelte
+++ b/src/components/MapExperience.svelte
@@ -571,9 +571,11 @@
 			</div>
 
 			<!-- Mobile: sit in flow below the search pane. Desktop: pin to the map's
-			     top-right (absolute against the full-screen overlay ancestor). -->
+			     top-right (absolute against the full-screen overlay ancestor).
+			     Wrapper stays pointer-events transparent (and shrink-wrapped) so it
+			     cannot steal map pans; the control itself opts back in. -->
 			<div
-				class="pointer-events-auto relative z-30 mx-2 mt-2 flex justify-end md:absolute md:right-4 md:top-4 md:mx-0 md:mt-0"
+				class="relative z-30 mx-2 mt-2 w-fit self-end md:absolute md:right-4 md:top-4 md:mx-0 md:mt-0"
 			>
 				<FavoritesFloatingControl
 					onStopClick={handleFavoriteStopClick}

--- a/src/components/MapExperience.svelte
+++ b/src/components/MapExperience.svelte
@@ -543,10 +543,6 @@
 {:else}
 	<h1 class="sr-only">{PUBLIC_OBA_REGION_NAME}</h1>
 	<div class="pointer-events-none absolute bottom-0 left-0 right-0 top-0 z-40">
-		<FavoritesFloatingControl
-			onStopClick={handleFavoriteStopClick}
-			onRouteClick={handleFavoriteRouteClick}
-		/>
 		<!-- Top spacing is padding (not margin) so h-full keeps the column's bottom
 		     edge — where the sheet anchors — exactly at the viewport bottom. Below md,
 		     horizontal margins live on the search wrapper and on each pane (not the
@@ -572,6 +568,17 @@
 						<SurveyLauncher />
 					{/snippet}
 				</SearchPane>
+			</div>
+
+			<!-- Mobile: sit in flow below the search pane. Desktop: pin to the map's
+			     top-right (absolute against the full-screen overlay ancestor). -->
+			<div
+				class="pointer-events-auto relative z-30 mx-2 mt-2 flex justify-end md:absolute md:right-4 md:top-4 md:mx-0 md:mt-0"
+			>
+				<FavoritesFloatingControl
+					onStopClick={handleFavoriteStopClick}
+					onRouteClick={handleFavoriteRouteClick}
+				/>
 			</div>
 
 			<div class="relative mt-2 flex-1 md:mt-4">

--- a/src/components/favorites/FavoriteToggle.svelte
+++ b/src/components/favorites/FavoriteToggle.svelte
@@ -13,7 +13,7 @@
 	@prop {string} [shortName] - Required for type=route
 	@prop {string|null} [description]
 	@prop {number|null} [routeType]
-	@prop {string} [class] - Extra classes on the button
+	@prop {string} [class] - Extra classes on the button (include h-/w- to override default size)
 -->
 <script>
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
@@ -43,6 +43,9 @@
 
 	let label = $derived(isFav ? $t('favorites.remove') : $t('favorites.add'));
 	let icon = $derived(isFav ? faStarSolid : faStarRegular);
+	// Omit default size when the caller passes size classes — Tailwind cannot
+	// override conflicting utilities by HTML class order.
+	let sizeClass = $derived(className ? '' : 'h-10 w-12');
 
 	function handleClick() {
 		const result = favorites.toggle({
@@ -72,7 +75,7 @@
 	aria-pressed={isFav}
 	aria-label={label}
 	title={label}
-	class="flex h-10 w-12 flex-none items-center justify-center rounded-xl border border-gray-300 text-black hover:bg-gray-100 dark:border-gray-600 dark:text-white dark:hover:bg-gray-700 {className}"
+	class="flex {sizeClass} flex-none items-center justify-center rounded-xl border border-gray-300 text-black hover:bg-gray-100 dark:border-gray-600 dark:text-white dark:hover:bg-gray-700 {className}"
 >
 	<!-- {#key} remounts FontAwesome when the glyph swaps; the SVG component
 	     does not always update in place when only the icon prop changes. -->

--- a/src/components/favorites/FavoriteToggle.svelte
+++ b/src/components/favorites/FavoriteToggle.svelte
@@ -21,6 +21,7 @@
 	import { faStar as faStarRegular } from '@fortawesome/free-regular-svg-icons';
 	import { t } from 'svelte-i18n';
 	import { favorites } from '$stores/favoritesStore';
+	import { notifyFavoriteSaved, notifyFavoriteRemoved } from '$lib/favoriteNotifications';
 
 	let {
 		type,
@@ -44,7 +45,7 @@
 	let icon = $derived(isFav ? faStarSolid : faStarRegular);
 
 	function handleClick() {
-		favorites.toggle({
+		const result = favorites.toggle({
 			type,
 			id,
 			name,
@@ -56,6 +57,12 @@
 			description,
 			routeType
 		});
+
+		if (result === 'added') {
+			notifyFavoriteSaved();
+		} else if (result === 'removed') {
+			notifyFavoriteRemoved();
+		}
 	}
 </script>
 

--- a/src/components/favorites/FavoriteToggle.svelte
+++ b/src/components/favorites/FavoriteToggle.svelte
@@ -1,0 +1,71 @@
+<!--
+	@component
+	Star button that toggles a stop or route in the favorites store.
+	Membership is derived from `favoriteKeys` — no local isFavorite state.
+
+	@prop {'stop'|'route'} type
+	@prop {string} id - Full agency-prefixed OBA id
+	@prop {string} [name] - Stop name (required for type=stop)
+	@prop {string|null} [code]
+	@prop {string|null} [direction]
+	@prop {number} [lat] - Required for type=stop
+	@prop {number} [lon] - Required for type=stop
+	@prop {string} [shortName] - Required for type=route
+	@prop {string|null} [description]
+	@prop {number|null} [routeType]
+	@prop {string} [class] - Extra classes on the button
+-->
+<script>
+	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
+	import { faStar as faStarSolid } from '@fortawesome/free-solid-svg-icons';
+	import { faStar as faStarRegular } from '@fortawesome/free-regular-svg-icons';
+	import { t } from 'svelte-i18n';
+	import { favorites, favoriteKeys } from '$stores/favoritesStore';
+
+	let {
+		type,
+		id,
+		name = null,
+		code = null,
+		direction = null,
+		lat = null,
+		lon = null,
+		shortName = null,
+		description = null,
+		routeType = null,
+		class: className = ''
+	} = $props();
+
+	let key = $derived(`${type}:${id}`);
+	let isFav = $derived($favoriteKeys.has(key));
+
+	let label = $derived(isFav ? $t('favorites.remove') : $t('favorites.add'));
+
+	function handleClick() {
+		favorites.toggle({
+			type,
+			id,
+			name,
+			code,
+			direction,
+			lat,
+			lon,
+			shortName,
+			description,
+			routeType
+		});
+	}
+</script>
+
+<button
+	type="button"
+	onclick={handleClick}
+	aria-pressed={isFav}
+	aria-label={label}
+	title={label}
+	class="flex h-10 w-12 flex-none items-center justify-center rounded-xl border border-gray-300 text-black hover:bg-gray-100 dark:border-gray-600 dark:text-white dark:hover:bg-gray-700 {isFav
+		? 'text-brand-accent dark:text-brand-accent'
+		: ''} {className}"
+>
+	<FontAwesomeIcon icon={isFav ? faStarSolid : faStarRegular} />
+</button>

--- a/src/components/favorites/FavoriteToggle.svelte
+++ b/src/components/favorites/FavoriteToggle.svelte
@@ -1,7 +1,7 @@
 <!--
 	@component
 	Star button that toggles a stop or route in the favorites store.
-	Membership is derived from `favoriteKeys` — no local isFavorite state.
+	Membership is derived from `$favorites` — no local isFavorite state.
 
 	@prop {'stop'|'route'} type
 	@prop {string} id - Full agency-prefixed OBA id
@@ -20,7 +20,7 @@
 	import { faStar as faStarSolid } from '@fortawesome/free-solid-svg-icons';
 	import { faStar as faStarRegular } from '@fortawesome/free-regular-svg-icons';
 	import { t } from 'svelte-i18n';
-	import { favorites, favoriteKeys } from '$stores/favoritesStore';
+	import { favorites } from '$stores/favoritesStore';
 
 	let {
 		type,
@@ -36,10 +36,12 @@
 		class: className = ''
 	} = $props();
 
-	let key = $derived(`${type}:${id}`);
-	let isFav = $derived($favoriteKeys.has(key));
+	// Read membership from the writable array (not a Set derived store) so the
+	// auto-subscription always invalidates when favorites.toggle() writes.
+	let isFav = $derived($favorites.some((f) => f.type === type && f.id === id));
 
 	let label = $derived(isFav ? $t('favorites.remove') : $t('favorites.add'));
+	let icon = $derived(isFav ? faStarSolid : faStarRegular);
 
 	function handleClick() {
 		favorites.toggle({
@@ -63,9 +65,11 @@
 	aria-pressed={isFav}
 	aria-label={label}
 	title={label}
-	class="flex h-10 w-12 flex-none items-center justify-center rounded-xl border border-gray-300 text-black hover:bg-gray-100 dark:border-gray-600 dark:text-white dark:hover:bg-gray-700 {isFav
-		? 'text-brand-accent dark:text-brand-accent'
-		: ''} {className}"
+	class="flex h-10 w-12 flex-none items-center justify-center rounded-xl border border-gray-300 text-black hover:bg-gray-100 dark:border-gray-600 dark:text-white dark:hover:bg-gray-700 {className}"
 >
-	<FontAwesomeIcon icon={isFav ? faStarSolid : faStarRegular} />
+	<!-- {#key} remounts FontAwesome when the glyph swaps; the SVG component
+	     does not always update in place when only the icon prop changes. -->
+	{#key isFav}
+		<FontAwesomeIcon {icon} class={isFav ? 'text-black dark:text-white' : ''} />
+	{/key}
 </button>

--- a/src/components/favorites/FavoritesFloatingControl.svelte
+++ b/src/components/favorites/FavoritesFloatingControl.svelte
@@ -7,6 +7,7 @@
 	@prop {Function} [onRouteClick] - Called with a route favorite when selected
 -->
 <script>
+	import { tick } from 'svelte';
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 	import { faStar } from '@fortawesome/free-solid-svg-icons';
 	import { t } from 'svelte-i18n';
@@ -17,26 +18,38 @@
 
 	let open = $state(false);
 	let rootEl = $state(null);
+	let toggleBtn = $state(null);
+	let panelEl = $state(null);
+
+	const panelId = `favorites-floating-panel-${crypto.randomUUID()}`;
 
 	let count = $derived($favorites.length);
 	let toggleLabel = $derived(open ? $t('favorites.close_panel') : $t('favorites.open_panel'));
 
-	function toggle(event) {
+	async function toggle(event) {
 		event.stopPropagation();
 		open = !open;
+		if (open) {
+			await tick();
+			panelEl?.focus();
+		}
 	}
 
-	function close() {
+	function close({ restoreFocus = true } = {}) {
+		if (!open) return;
 		open = false;
+		if (restoreFocus) {
+			tick().then(() => toggleBtn?.focus());
+		}
 	}
 
 	function handleStopClick(item) {
-		close();
+		close({ restoreFocus: false });
 		onStopClick?.(item);
 	}
 
 	function handleRouteClick(item) {
-		close();
+		close({ restoreFocus: false });
 		onRouteClick?.(item);
 	}
 
@@ -49,6 +62,7 @@
 
 	function handleKeydown(event) {
 		if (event.key === 'Escape' && open) {
+			event.preventDefault();
 			close();
 		}
 	}
@@ -58,10 +72,11 @@
 
 <div bind:this={rootEl} class="relative">
 	<button
+		bind:this={toggleBtn}
 		type="button"
 		onclick={toggle}
 		aria-expanded={open}
-		aria-controls="favorites-floating-panel"
+		aria-controls={panelId}
 		aria-label={toggleLabel}
 		title={toggleLabel}
 		class="relative flex h-11 w-11 items-center justify-center rounded-xl border border-gray-300 bg-white/95 text-black shadow-md backdrop-blur-sm hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800/95 dark:text-white dark:hover:bg-gray-700"
@@ -77,11 +92,15 @@
 	</button>
 
 	{#if open}
+		<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 		<div
-			id="favorites-floating-panel"
+			bind:this={panelEl}
+			id={panelId}
 			role="dialog"
+			aria-modal="true"
 			aria-label={$t('favorites.title')}
-			class="absolute right-0 top-full z-40 mt-2 max-h-[min(24rem,70vh)] w-[min(20rem,calc(100vw-1.5rem))] overflow-y-auto rounded-xl border border-gray-300 bg-white/95 p-3 shadow-lg backdrop-blur-sm dark:border-gray-600 dark:bg-gray-800/95"
+			tabindex="-1"
+			class="absolute right-0 top-full z-40 mt-2 max-h-[min(24rem,70vh)] w-[min(20rem,calc(100vw-1.5rem))] overflow-y-auto rounded-xl border border-gray-300 bg-white/95 p-3 shadow-lg backdrop-blur-sm outline-none dark:border-gray-600 dark:bg-gray-800/95"
 		>
 			<FavoritesList onStopClick={handleStopClick} onRouteClick={handleRouteClick} />
 		</div>

--- a/src/components/favorites/FavoritesFloatingControl.svelte
+++ b/src/components/favorites/FavoritesFloatingControl.svelte
@@ -1,7 +1,7 @@
 <!--
 	@component
-	Map-floating control (top-right) that opens a favorites panel. Keeps the
-	search pane uncluttered; same FavoritesList used for the list body.
+	Favorites map control: opens a panel with FavoritesList. Placement is owned by
+	the parent (in-flow below search on small screens; map top-right on desktop).
 
 	@prop {Function} [onStopClick] - Called with a stop favorite when selected
 	@prop {Function} [onRouteClick] - Called with a route favorite when selected
@@ -56,7 +56,7 @@
 
 <svelte:window onclick={handleWindowClick} onkeydown={handleKeydown} />
 
-<div bind:this={rootEl} class="pointer-events-auto absolute right-3 top-3 z-30 md:right-4 md:top-4">
+<div bind:this={rootEl} class="relative">
 	<button
 		type="button"
 		onclick={toggle}
@@ -81,7 +81,7 @@
 			id="favorites-floating-panel"
 			role="dialog"
 			aria-label={$t('favorites.title')}
-			class="absolute right-0 top-full mt-2 max-h-[min(24rem,70vh)] w-[min(20rem,calc(100vw-1.5rem))] overflow-y-auto rounded-xl border border-gray-300 bg-white/95 p-3 shadow-lg backdrop-blur-sm dark:border-gray-600 dark:bg-gray-800/95"
+			class="absolute right-0 top-full z-40 mt-2 max-h-[min(24rem,70vh)] w-[min(20rem,calc(100vw-1.5rem))] overflow-y-auto rounded-xl border border-gray-300 bg-white/95 p-3 shadow-lg backdrop-blur-sm dark:border-gray-600 dark:bg-gray-800/95"
 		>
 			<FavoritesList onStopClick={handleStopClick} onRouteClick={handleRouteClick} />
 		</div>

--- a/src/components/favorites/FavoritesFloatingControl.svelte
+++ b/src/components/favorites/FavoritesFloatingControl.svelte
@@ -61,9 +61,10 @@
 		if (!(target instanceof Node)) return;
 
 		// Removing a row (or Clear All) detaches the very node that was clicked:
-		// Svelte flushes at the microtask checkpoint between listeners, so by the
-		// time this window handler runs the target is gone and contains() would
-		// report it as outside. A disconnected target came from inside the panel.
+		// the event path is fixed at dispatch time so the click still reaches this
+		// window listener, but with a target contains() reports as outside. A
+		// disconnected target came from inside the panel — don't treat it as an
+		// outside click.
 		if (!target.isConnected) return;
 
 		if (!rootEl.contains(target)) {

--- a/src/components/favorites/FavoritesFloatingControl.svelte
+++ b/src/components/favorites/FavoritesFloatingControl.svelte
@@ -70,7 +70,7 @@
 
 <svelte:window onclick={handleWindowClick} onkeydown={handleKeydown} />
 
-<div bind:this={rootEl} class="relative">
+<div bind:this={rootEl} class="pointer-events-auto relative">
 	<button
 		bind:this={toggleBtn}
 		type="button"
@@ -96,7 +96,6 @@
 			bind:this={panelEl}
 			id={panelId}
 			role="dialog"
-			aria-modal="true"
 			aria-label={$t('favorites.title')}
 			tabindex="-1"
 			class="absolute right-0 top-full z-40 mt-2 max-h-[min(24rem,70vh)] w-[min(20rem,calc(100vw-1.5rem))] overflow-y-auto rounded-xl border border-gray-300 bg-white/95 p-3 shadow-lg outline-none backdrop-blur-sm dark:border-gray-600 dark:bg-gray-800/95"

--- a/src/components/favorites/FavoritesFloatingControl.svelte
+++ b/src/components/favorites/FavoritesFloatingControl.svelte
@@ -55,7 +55,18 @@
 
 	function handleWindowClick(event) {
 		if (!open || !rootEl) return;
-		if (!rootEl.contains(event.target)) {
+
+		// contains() throws on a non-Node target (a click dispatched on window).
+		const target = event.target;
+		if (!(target instanceof Node)) return;
+
+		// Removing a row (or Clear All) detaches the very node that was clicked:
+		// Svelte flushes at the microtask checkpoint between listeners, so by the
+		// time this window handler runs the target is gone and contains() would
+		// report it as outside. A disconnected target came from inside the panel.
+		if (!target.isConnected) return;
+
+		if (!rootEl.contains(target)) {
 			close();
 		}
 	}

--- a/src/components/favorites/FavoritesFloatingControl.svelte
+++ b/src/components/favorites/FavoritesFloatingControl.svelte
@@ -92,7 +92,6 @@
 	</button>
 
 	{#if open}
-		<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 		<div
 			bind:this={panelEl}
 			id={panelId}

--- a/src/components/favorites/FavoritesFloatingControl.svelte
+++ b/src/components/favorites/FavoritesFloatingControl.svelte
@@ -100,7 +100,7 @@
 			aria-modal="true"
 			aria-label={$t('favorites.title')}
 			tabindex="-1"
-			class="absolute right-0 top-full z-40 mt-2 max-h-[min(24rem,70vh)] w-[min(20rem,calc(100vw-1.5rem))] overflow-y-auto rounded-xl border border-gray-300 bg-white/95 p-3 shadow-lg backdrop-blur-sm outline-none dark:border-gray-600 dark:bg-gray-800/95"
+			class="absolute right-0 top-full z-40 mt-2 max-h-[min(24rem,70vh)] w-[min(20rem,calc(100vw-1.5rem))] overflow-y-auto rounded-xl border border-gray-300 bg-white/95 p-3 shadow-lg outline-none backdrop-blur-sm dark:border-gray-600 dark:bg-gray-800/95"
 		>
 			<FavoritesList onStopClick={handleStopClick} onRouteClick={handleRouteClick} />
 		</div>

--- a/src/components/favorites/FavoritesFloatingControl.svelte
+++ b/src/components/favorites/FavoritesFloatingControl.svelte
@@ -1,0 +1,89 @@
+<!--
+	@component
+	Map-floating control (top-right) that opens a favorites panel. Keeps the
+	search pane uncluttered; same FavoritesList used for the list body.
+
+	@prop {Function} [onStopClick] - Called with a stop favorite when selected
+	@prop {Function} [onRouteClick] - Called with a route favorite when selected
+-->
+<script>
+	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
+	import { faStar } from '@fortawesome/free-solid-svg-icons';
+	import { t } from 'svelte-i18n';
+	import { favorites } from '$stores/favoritesStore';
+	import FavoritesList from '$components/favorites/FavoritesList.svelte';
+
+	let { onStopClick = null, onRouteClick = null } = $props();
+
+	let open = $state(false);
+	let rootEl = $state(null);
+
+	let count = $derived($favorites.length);
+	let toggleLabel = $derived(open ? $t('favorites.close_panel') : $t('favorites.open_panel'));
+
+	function toggle(event) {
+		event.stopPropagation();
+		open = !open;
+	}
+
+	function close() {
+		open = false;
+	}
+
+	function handleStopClick(item) {
+		close();
+		onStopClick?.(item);
+	}
+
+	function handleRouteClick(item) {
+		close();
+		onRouteClick?.(item);
+	}
+
+	function handleWindowClick(event) {
+		if (!open || !rootEl) return;
+		if (!rootEl.contains(event.target)) {
+			close();
+		}
+	}
+
+	function handleKeydown(event) {
+		if (event.key === 'Escape' && open) {
+			close();
+		}
+	}
+</script>
+
+<svelte:window onclick={handleWindowClick} onkeydown={handleKeydown} />
+
+<div bind:this={rootEl} class="pointer-events-auto absolute right-3 top-3 z-30 md:right-4 md:top-4">
+	<button
+		type="button"
+		onclick={toggle}
+		aria-expanded={open}
+		aria-controls="favorites-floating-panel"
+		aria-label={toggleLabel}
+		title={toggleLabel}
+		class="relative flex h-11 w-11 items-center justify-center rounded-xl border border-gray-300 bg-white/95 text-black shadow-md backdrop-blur-sm hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800/95 dark:text-white dark:hover:bg-gray-700"
+	>
+		<FontAwesomeIcon icon={faStar} />
+		{#if count > 0}
+			<span
+				class="absolute -right-1.5 -top-1.5 flex h-5 min-w-5 items-center justify-center rounded-full bg-brand-accent px-1 text-[10px] font-bold text-white"
+			>
+				{count > 99 ? '99+' : count}
+			</span>
+		{/if}
+	</button>
+
+	{#if open}
+		<div
+			id="favorites-floating-panel"
+			role="dialog"
+			aria-label={$t('favorites.title')}
+			class="absolute right-0 top-full mt-2 max-h-[min(24rem,70vh)] w-[min(20rem,calc(100vw-1.5rem))] overflow-y-auto rounded-xl border border-gray-300 bg-white/95 p-3 shadow-lg backdrop-blur-sm dark:border-gray-600 dark:bg-gray-800/95"
+		>
+			<FavoritesList onStopClick={handleStopClick} onRouteClick={handleRouteClick} />
+		</div>
+	{/if}
+</div>

--- a/src/components/favorites/FavoritesList.svelte
+++ b/src/components/favorites/FavoritesList.svelte
@@ -111,7 +111,7 @@
 
 					<button
 						type="button"
-						class="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1.5 text-gray-400 opacity-0 transition-opacity hover:bg-gray-200 hover:text-red-500 group-hover:opacity-100 dark:hover:bg-gray-600"
+						class="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1.5 text-gray-400 opacity-0 transition-opacity hover:bg-gray-200 hover:text-red-500 focus-visible:opacity-100 group-hover:opacity-100 dark:hover:bg-gray-600"
 						onclick={() => handleRemove(item)}
 						aria-label={$t('favorites.remove_item', { values: { name: title } })}
 					>

--- a/src/components/favorites/FavoritesList.svelte
+++ b/src/components/favorites/FavoritesList.svelte
@@ -112,7 +112,7 @@
 
 					<button
 						type="button"
-						class="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1.5 text-gray-400 opacity-0 transition-opacity hover:bg-gray-200 hover:text-red-500 focus-visible:opacity-100 group-hover:opacity-100 dark:hover:bg-gray-600"
+						class="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1.5 text-gray-400 opacity-100 transition-opacity hover:bg-gray-200 hover:text-red-500 focus-visible:opacity-100 dark:hover:bg-gray-600 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100"
 						onclick={() => handleRemove(item)}
 						aria-label={$t('favorites.remove_item', { values: { name: title } })}
 					>

--- a/src/components/favorites/FavoritesList.svelte
+++ b/src/components/favorites/FavoritesList.svelte
@@ -32,7 +32,8 @@
 
 	function itemTitle(item) {
 		if (item.type === 'stop') return item.name;
-		return `${$t('route')} ${item.shortName}`;
+		// Mirrors SearchPane: routes without a shortName fall back to the id.
+		return `${$t('route')} ${removeAgencyPrefix(item.shortName || item.id)}`;
 	}
 
 	function itemSubtitle(item) {

--- a/src/components/favorites/FavoritesList.svelte
+++ b/src/components/favorites/FavoritesList.svelte
@@ -1,0 +1,122 @@
+<!--
+	@component
+	Lists favorited stops and routes. Item select and delete are sibling buttons
+	(no nested interactive controls). Renders an empty state when there are none.
+
+	@prop {Function} [onStopClick] - Called with the stop favorite entry
+	@prop {Function} [onRouteClick] - Called with the route favorite entry
+-->
+<script>
+	import { t } from 'svelte-i18n';
+	import { favorites } from '$stores/favoritesStore';
+	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
+	import { faStar, faSignsPost, faTimes } from '@fortawesome/free-solid-svg-icons';
+	import { prioritizedRouteTypeForDisplay } from '$config/routeConfig';
+	import { removeAgencyPrefix } from '$lib/utils';
+
+	let { onStopClick = null, onRouteClick = null } = $props();
+
+	let items = $derived($favorites);
+
+	function handleItemClick(item) {
+		if (item.type === 'stop') {
+			onStopClick?.(item);
+		} else if (item.type === 'route') {
+			onRouteClick?.(item);
+		}
+	}
+
+	function handleRemove(item) {
+		favorites.remove(item.type, item.id);
+	}
+
+	function itemTitle(item) {
+		if (item.type === 'stop') return item.name;
+		return `${$t('route')} ${item.shortName}`;
+	}
+
+	function itemSubtitle(item) {
+		if (item.type === 'stop') {
+			const parts = [];
+			if (item.direction) {
+				parts.push($t(`direction.${item.direction}`));
+			}
+			if (item.code) {
+				parts.push(`${$t('favorites.stop_code')}: ${item.code}`);
+			} else {
+				parts.push(`${$t('favorites.stop_code')}: ${removeAgencyPrefix(item.id)}`);
+			}
+			return parts.join(' · ');
+		}
+		return item.description ?? '';
+	}
+
+	function itemIcon(item) {
+		if (item.type === 'stop') return faSignsPost;
+		return prioritizedRouteTypeForDisplay(item.routeType);
+	}
+
+	function itemAriaLabel(item) {
+		return $t('favorites.open_item', { values: { name: itemTitle(item) } });
+	}
+</script>
+
+<div class="mt-4">
+	<div class="mb-2 flex items-center justify-between">
+		<h2 class="flex items-center gap-1.5 text-sm font-semibold text-gray-500 dark:text-gray-400">
+			<FontAwesomeIcon icon={faStar} class="h-3.5 w-3.5" />
+			{$t('favorites.title')}
+		</h2>
+		{#if items.length > 0}
+			<button
+				type="button"
+				class="text-xs text-gray-600 transition-colors hover:text-red-500 dark:text-gray-400"
+				onclick={() => favorites.clearAll()}
+			>
+				{$t('favorites.clear_all')}
+			</button>
+		{/if}
+	</div>
+
+	{#if items.length === 0}
+		<p class="text-sm text-gray-500 dark:text-gray-400">{$t('favorites.empty')}</p>
+	{:else}
+		<div class="space-y-2">
+			{#each items as item (`${item.type}:${item.id}`)}
+				<div
+					class="dark:hover:bg-gray-750 group relative flex items-stretch rounded-lg border border-gray-200 bg-white shadow-sm transition-all hover:bg-gray-50 hover:shadow-md dark:border-gray-700 dark:bg-gray-800"
+				>
+					<button
+						type="button"
+						aria-label={itemAriaLabel(item)}
+						class="flex min-w-0 flex-1 items-center rounded-lg p-2.5 pr-10 text-left"
+						onclick={() => handleItemClick(item)}
+					>
+						<div class="mr-3 text-gray-400">
+							<FontAwesomeIcon icon={itemIcon(item)} class="h-3.5 w-3.5" />
+						</div>
+						<div class="min-w-0 flex-1 text-left">
+							<div class="truncate text-sm font-medium text-gray-900 dark:text-gray-100">
+								{itemTitle(item)}
+							</div>
+							{#if itemSubtitle(item)}
+								<div class="truncate text-xs text-gray-500 dark:text-gray-400">
+									{itemSubtitle(item)}
+								</div>
+							{/if}
+						</div>
+					</button>
+
+					<button
+						type="button"
+						class="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1.5 text-gray-400 opacity-0 transition-opacity hover:bg-gray-200 hover:text-red-500 group-hover:opacity-100 dark:hover:bg-gray-600"
+						onclick={() => handleRemove(item)}
+						aria-label={$t('favorites.remove_item', { values: { name: itemTitle(item) } })}
+					>
+						<FontAwesomeIcon icon={faTimes} class="h-3 w-3" />
+					</button>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/src/components/favorites/FavoritesList.svelte
+++ b/src/components/favorites/FavoritesList.svelte
@@ -83,8 +83,10 @@
 	{:else}
 		<div class="space-y-2">
 			{#each items as item (`${item.type}:${item.id}`)}
+				{@const subtitle = itemSubtitle(item)}
+				{@const title = itemTitle(item)}
 				<div
-					class="dark:hover:bg-gray-750 group relative flex items-stretch rounded-lg border border-gray-200 bg-white shadow-sm transition-all hover:bg-gray-50 hover:shadow-md dark:border-gray-700 dark:bg-gray-800"
+					class="group relative flex items-stretch rounded-lg border border-gray-200 bg-white shadow-sm transition-all hover:bg-gray-50 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700"
 				>
 					<button
 						type="button"
@@ -97,11 +99,11 @@
 						</div>
 						<div class="min-w-0 flex-1 text-left">
 							<div class="truncate text-sm font-medium text-gray-900 dark:text-gray-100">
-								{itemTitle(item)}
+								{title}
 							</div>
-							{#if itemSubtitle(item)}
+							{#if subtitle}
 								<div class="truncate text-xs text-gray-500 dark:text-gray-400">
-									{itemSubtitle(item)}
+									{subtitle}
 								</div>
 							{/if}
 						</div>
@@ -111,7 +113,7 @@
 						type="button"
 						class="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1.5 text-gray-400 opacity-0 transition-opacity hover:bg-gray-200 hover:text-red-500 group-hover:opacity-100 dark:hover:bg-gray-600"
 						onclick={() => handleRemove(item)}
-						aria-label={$t('favorites.remove_item', { values: { name: itemTitle(item) } })}
+						aria-label={$t('favorites.remove_item', { values: { name: title } })}
 					>
 						<FontAwesomeIcon icon={faTimes} class="h-3 w-3" />
 					</button>

--- a/src/components/favorites/FavoritesList.svelte
+++ b/src/components/favorites/FavoritesList.svelte
@@ -14,7 +14,7 @@
 	import { prioritizedRouteTypeForDisplay } from '$config/routeConfig';
 	import { removeAgencyPrefix } from '$lib/utils';
 
-	let { onStopClick = null, onRouteClick = null } = $props();
+	let { onStopClick = null, onRouteClick = null, class: className = '' } = $props();
 
 	let items = $derived($favorites);
 
@@ -61,7 +61,7 @@
 	}
 </script>
 
-<div class="mt-4">
+<div class={className}>
 	<div class="mb-2 flex items-center justify-between">
 		<h2 class="flex items-center gap-1.5 text-sm font-semibold text-gray-500 dark:text-gray-400">
 			<FontAwesomeIcon icon={faStar} class="h-3.5 w-3.5" />

--- a/src/components/favorites/__tests__/FavoriteToggle.test.js
+++ b/src/components/favorites/__tests__/FavoriteToggle.test.js
@@ -22,11 +22,10 @@ vi.mock('svelte-i18n', () => {
 	};
 });
 
-const { mockToggle, mockFavorites, mockKeys } = vi.hoisted(() => {
+const { mockToggle, mockFavorites } = vi.hoisted(() => {
 	return {
 		mockToggle: vi.fn(),
-		mockFavorites: { current: [] },
-		mockKeys: { current: new Set() }
+		mockFavorites: { current: [] }
 	};
 });
 
@@ -37,12 +36,6 @@ vi.mock('$stores/favoritesStore', () => ({
 			return () => {};
 		}),
 		toggle: mockToggle
-	},
-	favoriteKeys: {
-		subscribe: vi.fn((fn) => {
-			fn(mockKeys.current);
-			return () => {};
-		})
 	}
 }));
 
@@ -62,7 +55,6 @@ describe('FavoriteToggle', () => {
 	beforeEach(() => {
 		user = userEvent.setup();
 		mockFavorites.current = [];
-		mockKeys.current = new Set();
 		vi.clearAllMocks();
 	});
 
@@ -75,7 +67,7 @@ describe('FavoriteToggle', () => {
 	});
 
 	it('renders remove label and aria-pressed when favorited', () => {
-		mockKeys.current = new Set(['stop:1_75403']);
+		mockFavorites.current = [{ type: 'stop', id: '1_75403' }];
 
 		render(FavoriteToggle, { props: stopProps });
 

--- a/src/components/favorites/__tests__/FavoriteToggle.test.js
+++ b/src/components/favorites/__tests__/FavoriteToggle.test.js
@@ -22,10 +22,12 @@ vi.mock('svelte-i18n', () => {
 	};
 });
 
-const { mockToggle, mockFavorites } = vi.hoisted(() => {
+const { mockToggle, mockFavorites, mockNotifySaved, mockNotifyRemoved } = vi.hoisted(() => {
 	return {
 		mockToggle: vi.fn(),
-		mockFavorites: { current: [] }
+		mockFavorites: { current: [] },
+		mockNotifySaved: vi.fn(),
+		mockNotifyRemoved: vi.fn()
 	};
 });
 
@@ -37,6 +39,11 @@ vi.mock('$stores/favoritesStore', () => ({
 		}),
 		toggle: mockToggle
 	}
+}));
+
+vi.mock('$lib/favoriteNotifications', () => ({
+	notifyFavoriteSaved: mockNotifySaved,
+	notifyFavoriteRemoved: mockNotifyRemoved
 }));
 
 describe('FavoriteToggle', () => {
@@ -75,7 +82,8 @@ describe('FavoriteToggle', () => {
 		expect(button).toHaveAttribute('aria-pressed', 'true');
 	});
 
-	it('calls favorites.toggle with the entry on click', async () => {
+	it('calls favorites.toggle and notifies when a stop is saved', async () => {
+		mockToggle.mockReturnValue('added');
 		render(FavoriteToggle, { props: stopProps });
 
 		await user.click(screen.getByRole('button', { name: 'Add to favorites' }));
@@ -90,9 +98,25 @@ describe('FavoriteToggle', () => {
 				lon: -122.3363
 			})
 		);
+		expect(mockNotifySaved).toHaveBeenCalledTimes(1);
+		expect(mockNotifyRemoved).not.toHaveBeenCalled();
+	});
+
+	it('notifies when a favorite is removed', async () => {
+		mockFavorites.current = [{ type: 'stop', id: '1_75403' }];
+		mockToggle.mockReturnValue('removed');
+
+		render(FavoriteToggle, { props: stopProps });
+
+		await user.click(screen.getByRole('button', { name: 'Remove from favorites' }));
+
+		expect(mockNotifyRemoved).toHaveBeenCalledTimes(1);
+		expect(mockNotifySaved).not.toHaveBeenCalled();
 	});
 
 	it('toggles a route entry', async () => {
+		mockToggle.mockReturnValue('added');
+
 		render(FavoriteToggle, {
 			props: {
 				type: 'route',
@@ -112,6 +136,17 @@ describe('FavoriteToggle', () => {
 				shortName: '10'
 			})
 		);
+		expect(mockNotifySaved).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not toast when toggle returns null', async () => {
+		mockToggle.mockReturnValue(null);
+		render(FavoriteToggle, { props: stopProps });
+
+		await user.click(screen.getByRole('button', { name: 'Add to favorites' }));
+
+		expect(mockNotifySaved).not.toHaveBeenCalled();
+		expect(mockNotifyRemoved).not.toHaveBeenCalled();
 	});
 
 	it('uses a native button with no onkeydown attribute', () => {

--- a/src/components/favorites/__tests__/FavoriteToggle.test.js
+++ b/src/components/favorites/__tests__/FavoriteToggle.test.js
@@ -155,4 +155,18 @@ describe('FavoriteToggle', () => {
 		expect(button.tagName).toBe('BUTTON');
 		expect(button.getAttribute('onkeydown')).toBeNull();
 	});
+
+	it('applies default size classes when no class prop is passed', () => {
+		render(FavoriteToggle, { props: stopProps });
+		const button = screen.getByRole('button', { name: 'Add to favorites' });
+		expect(button).toHaveClass('h-10', 'w-12');
+	});
+
+	it('omits default size classes when a class prop provides sizing', () => {
+		render(FavoriteToggle, { props: { ...stopProps, class: 'h-8 w-8' } });
+		const button = screen.getByRole('button', { name: 'Add to favorites' });
+		expect(button).toHaveClass('h-8', 'w-8');
+		expect(button).not.toHaveClass('h-10');
+		expect(button).not.toHaveClass('w-12');
+	});
 });

--- a/src/components/favorites/__tests__/FavoriteToggle.test.js
+++ b/src/components/favorites/__tests__/FavoriteToggle.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import FavoriteToggle from '../FavoriteToggle.svelte';
+
+vi.mock('@fortawesome/svelte-fontawesome', () => ({
+	FontAwesomeIcon: vi.fn(() => ({ $$: { component: 'div' } }))
+}));
+
+vi.mock('svelte-i18n', () => {
+	const translations = {
+		'favorites.add': 'Add to favorites',
+		'favorites.remove': 'Remove from favorites'
+	};
+	return {
+		t: {
+			subscribe: vi.fn((fn) => {
+				fn((key) => translations[key] || key);
+				return { unsubscribe: () => {} };
+			})
+		}
+	};
+});
+
+const { mockToggle, mockFavorites, mockKeys } = vi.hoisted(() => {
+	return {
+		mockToggle: vi.fn(),
+		mockFavorites: { current: [] },
+		mockKeys: { current: new Set() }
+	};
+});
+
+vi.mock('$stores/favoritesStore', () => ({
+	favorites: {
+		subscribe: vi.fn((fn) => {
+			fn(mockFavorites.current);
+			return () => {};
+		}),
+		toggle: mockToggle
+	},
+	favoriteKeys: {
+		subscribe: vi.fn((fn) => {
+			fn(mockKeys.current);
+			return () => {};
+		})
+	}
+}));
+
+describe('FavoriteToggle', () => {
+	let user;
+
+	const stopProps = {
+		type: 'stop',
+		id: '1_75403',
+		name: 'Pine St & 3rd Ave',
+		code: '75403',
+		direction: 'N',
+		lat: 47.6105,
+		lon: -122.3363
+	};
+
+	beforeEach(() => {
+		user = userEvent.setup();
+		mockFavorites.current = [];
+		mockKeys.current = new Set();
+		vi.clearAllMocks();
+	});
+
+	it('renders a button with add label when not favorited', () => {
+		render(FavoriteToggle, { props: stopProps });
+
+		const button = screen.getByRole('button', { name: 'Add to favorites' });
+		expect(button).toBeInTheDocument();
+		expect(button).toHaveAttribute('aria-pressed', 'false');
+	});
+
+	it('renders remove label and aria-pressed when favorited', () => {
+		mockKeys.current = new Set(['stop:1_75403']);
+
+		render(FavoriteToggle, { props: stopProps });
+
+		const button = screen.getByRole('button', { name: 'Remove from favorites' });
+		expect(button).toHaveAttribute('aria-pressed', 'true');
+	});
+
+	it('calls favorites.toggle with the entry on click', async () => {
+		render(FavoriteToggle, { props: stopProps });
+
+		await user.click(screen.getByRole('button', { name: 'Add to favorites' }));
+
+		expect(mockToggle).toHaveBeenCalledTimes(1);
+		expect(mockToggle).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'stop',
+				id: '1_75403',
+				name: 'Pine St & 3rd Ave',
+				lat: 47.6105,
+				lon: -122.3363
+			})
+		);
+	});
+
+	it('toggles a route entry', async () => {
+		render(FavoriteToggle, {
+			props: {
+				type: 'route',
+				id: '1_100479',
+				shortName: '10',
+				description: 'Capitol Hill',
+				routeType: 3
+			}
+		});
+
+		await user.click(screen.getByRole('button', { name: 'Add to favorites' }));
+
+		expect(mockToggle).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'route',
+				id: '1_100479',
+				shortName: '10'
+			})
+		);
+	});
+
+	it('uses a native button with no onkeydown attribute', () => {
+		render(FavoriteToggle, { props: stopProps });
+		const button = screen.getByRole('button', { name: 'Add to favorites' });
+		expect(button.tagName).toBe('BUTTON');
+		expect(button.getAttribute('onkeydown')).toBeNull();
+	});
+});

--- a/src/components/favorites/__tests__/FavoritesFloatingControl.test.js
+++ b/src/components/favorites/__tests__/FavoritesFloatingControl.test.js
@@ -124,6 +124,39 @@ describe('FavoritesFloatingControl', () => {
 		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 	});
 
+	it('stays open when the clicked node was detached by its own handler', async () => {
+		render(FavoritesFloatingControl);
+
+		await user.click(screen.getByRole('button', { name: 'Open favorites' }));
+		expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+		// Removing a row detaches the clicked button before the window listener
+		// runs, so contains() reports it as outside. Simulate that exact shape.
+		const detached = document.createElement('button');
+		document.body.appendChild(detached);
+		detached.remove();
+
+		detached.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		window.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+		expect(screen.getByRole('dialog')).toBeInTheDocument();
+	});
+
+	it('closes when a click lands on a node outside the control', async () => {
+		render(FavoritesFloatingControl);
+
+		await user.click(screen.getByRole('button', { name: 'Open favorites' }));
+		expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+		const outside = document.createElement('div');
+		document.body.appendChild(outside);
+
+		await user.click(outside);
+
+		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+		outside.remove();
+	});
+
 	it('closes on Escape and restores focus to the toggle', async () => {
 		render(FavoritesFloatingControl);
 

--- a/src/components/favorites/__tests__/FavoritesFloatingControl.test.js
+++ b/src/components/favorites/__tests__/FavoritesFloatingControl.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { tick } from 'svelte';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import FavoritesFloatingControl from '../FavoritesFloatingControl.svelte';
@@ -124,20 +125,23 @@ describe('FavoritesFloatingControl', () => {
 		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 	});
 
-	it('stays open when the clicked node was detached by its own handler', async () => {
+	it('stays open when a node inside the panel detaches itself in its own handler', async () => {
 		render(FavoritesFloatingControl);
 
 		await user.click(screen.getByRole('button', { name: 'Open favorites' }));
 		expect(screen.getByRole('dialog')).toBeInTheDocument();
 
-		// Removing a row detaches the clicked button before the window listener
-		// runs, so contains() reports it as outside. Simulate that exact shape.
-		const detached = document.createElement('button');
-		document.body.appendChild(detached);
-		detached.remove();
+		// A row's ✕ removes its own DOM node mid-click. The event path is fixed at
+		// dispatch time, so the click still reaches <svelte:window> — but with a
+		// detached target whose contains() reads false. Without the isConnected
+		// guard the panel would wrongly close; this asserts it does not.
+		const row = document.createElement('button');
+		screen.getByRole('dialog').appendChild(row);
+		row.addEventListener('click', () => row.remove());
 
-		detached.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-		window.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		row.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		// Let any (wrongful) close() flush to the DOM before asserting.
+		await tick();
 
 		expect(screen.getByRole('dialog')).toBeInTheDocument();
 	});

--- a/src/components/favorites/__tests__/FavoritesFloatingControl.test.js
+++ b/src/components/favorites/__tests__/FavoritesFloatingControl.test.js
@@ -74,11 +74,19 @@ describe('FavoritesFloatingControl', () => {
 
 		await user.click(screen.getByRole('button', { name: 'Open favorites' }));
 
-		expect(screen.getByRole('dialog', { name: 'Favorites' })).toBeInTheDocument();
+		const dialog = screen.getByRole('dialog', { name: 'Favorites' });
+		expect(dialog).toBeInTheDocument();
+		expect(dialog).toHaveAttribute('aria-modal', 'true');
+		expect(dialog).toHaveAttribute('id');
+		expect(dialog).toHaveFocus();
 		expect(screen.getByText('No favorites yet')).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Close favorites' })).toHaveAttribute(
 			'aria-expanded',
 			'true'
+		);
+		expect(screen.getByRole('button', { name: 'Close favorites' })).toHaveAttribute(
+			'aria-controls',
+			dialog.getAttribute('id')
 		);
 	});
 
@@ -116,13 +124,15 @@ describe('FavoritesFloatingControl', () => {
 		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 	});
 
-	it('closes on Escape', async () => {
+	it('closes on Escape and restores focus to the toggle', async () => {
 		render(FavoritesFloatingControl);
 
-		await user.click(screen.getByRole('button', { name: 'Open favorites' }));
+		const toggle = screen.getByRole('button', { name: 'Open favorites' });
+		await user.click(toggle);
 		expect(screen.getByRole('dialog')).toBeInTheDocument();
 
 		await user.keyboard('{Escape}');
 		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+		expect(toggle).toHaveFocus();
 	});
 });

--- a/src/components/favorites/__tests__/FavoritesFloatingControl.test.js
+++ b/src/components/favorites/__tests__/FavoritesFloatingControl.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import FavoritesFloatingControl from '../FavoritesFloatingControl.svelte';
+
+vi.mock('@fortawesome/svelte-fontawesome', () => ({
+	FontAwesomeIcon: vi.fn(() => ({ $$: { component: 'div' } }))
+}));
+
+vi.mock('svelte-i18n', () => {
+	const translations = {
+		'favorites.title': 'Favorites',
+		'favorites.open_panel': 'Open favorites',
+		'favorites.close_panel': 'Close favorites',
+		'favorites.empty': 'No favorites yet',
+		'favorites.clear_all': 'Clear All',
+		'favorites.stop_code': 'Code',
+		'favorites.open_item': 'Open {name}',
+		'favorites.remove_item': 'Remove {name} from favorites',
+		route: 'Route',
+		'direction.N': 'North'
+	};
+	return {
+		t: {
+			subscribe: vi.fn((fn) => {
+				fn((key, opts) => {
+					let text = translations[key] || key;
+					if (opts?.values) {
+						for (const [k, v] of Object.entries(opts.values)) {
+							text = text.replace(`{${k}}`, v);
+						}
+					}
+					return text;
+				});
+				return { unsubscribe: () => {} };
+			})
+		}
+	};
+});
+
+const { mockStoreValue } = vi.hoisted(() => ({
+	mockStoreValue: { current: [] }
+}));
+
+vi.mock('$stores/favoritesStore', () => ({
+	favorites: {
+		subscribe: vi.fn((fn) => {
+			fn(mockStoreValue.current);
+			return () => {};
+		}),
+		remove: vi.fn(),
+		clearAll: vi.fn()
+	}
+}));
+
+describe('FavoritesFloatingControl', () => {
+	let user;
+
+	beforeEach(() => {
+		user = userEvent.setup();
+		mockStoreValue.current = [];
+		vi.clearAllMocks();
+	});
+
+	it('renders a floating open-favorites button', () => {
+		render(FavoritesFloatingControl);
+
+		expect(screen.getByRole('button', { name: 'Open favorites' })).toBeInTheDocument();
+		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+	});
+
+	it('opens the favorites panel on click', async () => {
+		render(FavoritesFloatingControl);
+
+		await user.click(screen.getByRole('button', { name: 'Open favorites' }));
+
+		expect(screen.getByRole('dialog', { name: 'Favorites' })).toBeInTheDocument();
+		expect(screen.getByText('No favorites yet')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Close favorites' })).toHaveAttribute(
+			'aria-expanded',
+			'true'
+		);
+	});
+
+	it('shows a count badge when favorites exist', () => {
+		mockStoreValue.current = [
+			{ type: 'stop', id: '1_1', name: 'A', lat: 1, lon: 2 },
+			{ type: 'route', id: '1_r', shortName: '10' }
+		];
+
+		render(FavoritesFloatingControl);
+
+		expect(screen.getByText('2')).toBeInTheDocument();
+	});
+
+	it('calls onStopClick and closes when a favorite stop is selected', async () => {
+		mockStoreValue.current = [
+			{
+				type: 'stop',
+				id: '1_75403',
+				name: 'Pine St & 3rd Ave',
+				code: '75403',
+				direction: 'N',
+				lat: 47.61,
+				lon: -122.33
+			}
+		];
+		const onStopClick = vi.fn();
+
+		render(FavoritesFloatingControl, { props: { onStopClick } });
+
+		await user.click(screen.getByRole('button', { name: 'Open favorites' }));
+		await user.click(screen.getByLabelText('Open Pine St & 3rd Ave'));
+
+		expect(onStopClick).toHaveBeenCalledTimes(1);
+		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+	});
+
+	it('closes on Escape', async () => {
+		render(FavoritesFloatingControl);
+
+		await user.click(screen.getByRole('button', { name: 'Open favorites' }));
+		expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+		await user.keyboard('{Escape}');
+		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+	});
+});

--- a/src/components/favorites/__tests__/FavoritesFloatingControl.test.js
+++ b/src/components/favorites/__tests__/FavoritesFloatingControl.test.js
@@ -76,7 +76,7 @@ describe('FavoritesFloatingControl', () => {
 
 		const dialog = screen.getByRole('dialog', { name: 'Favorites' });
 		expect(dialog).toBeInTheDocument();
-		expect(dialog).toHaveAttribute('aria-modal', 'true');
+		expect(dialog).not.toHaveAttribute('aria-modal');
 		expect(dialog).toHaveAttribute('id');
 		expect(dialog).toHaveFocus();
 		expect(screen.getByText('No favorites yet')).toBeInTheDocument();

--- a/src/components/favorites/__tests__/FavoritesList.test.js
+++ b/src/components/favorites/__tests__/FavoritesList.test.js
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import FavoritesList from '../FavoritesList.svelte';
+
+vi.mock('@fortawesome/svelte-fontawesome', () => ({
+	FontAwesomeIcon: vi.fn(() => ({ $$: { component: 'div' } }))
+}));
+
+vi.mock('svelte-i18n', () => {
+	const translations = {
+		'favorites.title': 'Favorites',
+		'favorites.clear_all': 'Clear All',
+		'favorites.empty': 'No favorites yet',
+		'favorites.stop_code': 'Code',
+		'favorites.open_item': 'Open {name}',
+		'favorites.remove_item': 'Remove {name} from favorites',
+		route: 'Route',
+		'direction.N': 'Northbound'
+	};
+	return {
+		t: {
+			subscribe: vi.fn((fn) => {
+				fn((key, opts) => {
+					let text = translations[key] || key;
+					if (opts?.values) {
+						for (const [k, v] of Object.entries(opts.values)) {
+							text = text.replace(`{${k}}`, v);
+						}
+					}
+					return text;
+				});
+				return { unsubscribe: () => {} };
+			})
+		}
+	};
+});
+
+const { mockRemove, mockClearAll, mockStoreValue } = vi.hoisted(() => {
+	return {
+		mockRemove: vi.fn(),
+		mockClearAll: vi.fn(),
+		mockStoreValue: { current: [] }
+	};
+});
+
+vi.mock('$stores/favoritesStore', () => ({
+	favorites: {
+		subscribe: vi.fn((fn) => {
+			fn(mockStoreValue.current);
+			return () => {};
+		}),
+		remove: mockRemove,
+		clearAll: mockClearAll
+	}
+}));
+
+describe('FavoritesList', () => {
+	let user;
+
+	const sampleFavorites = [
+		{
+			schemaVersion: 1,
+			type: 'stop',
+			id: '1_75403',
+			name: 'Pine St & 3rd Ave',
+			code: '75403',
+			direction: 'N',
+			lat: 47.61,
+			lon: -122.33,
+			savedAt: 1
+		},
+		{
+			schemaVersion: 1,
+			type: 'route',
+			id: '1_100479',
+			shortName: '10',
+			description: 'Capitol Hill - Downtown',
+			routeType: 3,
+			savedAt: 2
+		}
+	];
+
+	beforeEach(() => {
+		user = userEvent.setup();
+		mockStoreValue.current = [];
+		vi.clearAllMocks();
+	});
+
+	it('renders the empty state when there are no favorites', () => {
+		render(FavoritesList);
+
+		expect(screen.getByText('No favorites yet')).toBeInTheDocument();
+		expect(screen.getByRole('heading', { level: 2, name: 'Favorites' })).toBeInTheDocument();
+		expect(screen.queryByText('Clear All')).toBeNull();
+	});
+
+	it('renders stop and route favorites', () => {
+		mockStoreValue.current = sampleFavorites;
+
+		render(FavoritesList);
+
+		expect(screen.getByText('Pine St & 3rd Ave')).toBeInTheDocument();
+		expect(screen.getByText(/Northbound/)).toBeInTheDocument();
+		expect(screen.getByText('Route 10')).toBeInTheDocument();
+		expect(screen.getByText('Capitol Hill - Downtown')).toBeInTheDocument();
+		expect(screen.getByText('Clear All')).toBeInTheDocument();
+	});
+
+	it('keeps the item button and delete button as siblings', () => {
+		mockStoreValue.current = sampleFavorites;
+
+		render(FavoritesList);
+
+		const itemButton = screen.getByLabelText('Open Pine St & 3rd Ave');
+		expect(itemButton.tagName).toBe('BUTTON');
+		expect(itemButton.querySelector('button')).toBeNull();
+
+		const removeButton = screen.getByLabelText('Remove Pine St & 3rd Ave from favorites');
+		expect(removeButton.tagName).toBe('BUTTON');
+		expect(itemButton.contains(removeButton)).toBe(false);
+	});
+
+	it('calls onStopClick when a stop is selected', async () => {
+		mockStoreValue.current = sampleFavorites;
+		const onStopClick = vi.fn();
+		const onRouteClick = vi.fn();
+
+		render(FavoritesList, { props: { onStopClick, onRouteClick } });
+
+		await user.click(screen.getByLabelText('Open Pine St & 3rd Ave'));
+
+		expect(onStopClick).toHaveBeenCalledTimes(1);
+		expect(onStopClick).toHaveBeenCalledWith(sampleFavorites[0]);
+		expect(onRouteClick).not.toHaveBeenCalled();
+	});
+
+	it('calls onRouteClick when a route is selected', async () => {
+		mockStoreValue.current = sampleFavorites;
+		const onStopClick = vi.fn();
+		const onRouteClick = vi.fn();
+
+		render(FavoritesList, { props: { onStopClick, onRouteClick } });
+
+		await user.click(screen.getByLabelText('Open Route 10'));
+
+		expect(onRouteClick).toHaveBeenCalledTimes(1);
+		expect(onRouteClick).toHaveBeenCalledWith(sampleFavorites[1]);
+		expect(onStopClick).not.toHaveBeenCalled();
+	});
+
+	it('calls remove without triggering onStopClick', async () => {
+		mockStoreValue.current = sampleFavorites;
+		const onStopClick = vi.fn();
+
+		render(FavoritesList, { props: { onStopClick } });
+
+		await user.click(screen.getByLabelText('Remove Pine St & 3rd Ave from favorites'));
+
+		expect(mockRemove).toHaveBeenCalledTimes(1);
+		expect(mockRemove).toHaveBeenCalledWith('stop', '1_75403');
+		expect(onStopClick).not.toHaveBeenCalled();
+	});
+
+	it('calls clearAll when Clear All is clicked', async () => {
+		mockStoreValue.current = sampleFavorites;
+
+		render(FavoritesList);
+
+		await user.click(screen.getByText('Clear All'));
+
+		expect(mockClearAll).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/components/map/RouteLegend.svelte
+++ b/src/components/map/RouteLegend.svelte
@@ -16,7 +16,7 @@
 
 {#if routes.length > 0}
 	<div
-		class="route-legend pointer-events-auto absolute right-4 top-4 z-30 hidden min-w-44 rounded-lg border border-gray-300 bg-white/95 p-3 shadow-md backdrop-blur-sm dark:border-gray-600 dark:bg-gray-800/95 md:block"
+		class="route-legend pointer-events-auto absolute right-4 top-16 z-30 hidden min-w-44 rounded-lg border border-gray-300 bg-white/95 p-3 shadow-md backdrop-blur-sm dark:border-gray-600 dark:bg-gray-800/95 md:block"
 	>
 		<h2
 			class="mb-2 text-[10.5px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"

--- a/src/components/notification/Toast.svelte
+++ b/src/components/notification/Toast.svelte
@@ -4,6 +4,15 @@
 
 	let notification = $derived($notifications);
 
+	const VARIANT_CLASSES = {
+		error:
+			'border-red-200 bg-red-50/95 text-red-900 dark:border-red-800 dark:bg-red-950/95 dark:text-red-100',
+		warning:
+			'border-amber-200 bg-amber-50/95 text-amber-950 dark:border-amber-800 dark:bg-amber-950/95 dark:text-amber-100',
+		success:
+			'border-green-200 bg-green-50/95 text-green-900 dark:border-green-800 dark:bg-green-950/95 dark:text-green-100'
+	};
+
 	function dismiss() {
 		// Unscoped: the user asked for this one to go away, whoever raised it.
 		notifications.dismiss();
@@ -32,10 +41,9 @@
 		aria-live={notification.variant === 'error' ? 'assertive' : 'polite'}
 	>
 		<div
-			class="pointer-events-auto flex items-start gap-3 rounded-lg border px-4 py-3 shadow-lg backdrop-blur-sm
-				{notification.variant === 'error'
-				? 'border-red-200 bg-red-50/95 text-red-900 dark:border-red-800 dark:bg-red-950/95 dark:text-red-100'
-				: 'border-amber-200 bg-amber-50/95 text-amber-950 dark:border-amber-800 dark:bg-amber-950/95 dark:text-amber-100'}"
+			class="pointer-events-auto flex items-start gap-3 rounded-lg border px-4 py-3 shadow-lg backdrop-blur-sm {VARIANT_CLASSES[
+				notification.variant
+			] ?? VARIANT_CLASSES.warning}"
 		>
 			<p class="flex-1 text-sm leading-snug">
 				{notification.message}

--- a/src/components/notification/__tests__/Toast.test.js
+++ b/src/components/notification/__tests__/Toast.test.js
@@ -56,6 +56,16 @@ describe('Toast', () => {
 		expect(status).toHaveAttribute('aria-live', 'polite');
 	});
 
+	test('renders a success toast as a polite status', async () => {
+		render(Toast);
+
+		notifications.show({ message: 'Saved to favorites.', variant: 'success' });
+
+		const status = await screen.findByRole('status');
+		expect(status).toHaveAttribute('aria-live', 'polite');
+		expect(status).toHaveTextContent('Saved to favorites.');
+	});
+
 	test('shows the retry button only when the notification is retriable', async () => {
 		render(Toast);
 

--- a/src/components/routes/RouteModal.svelte
+++ b/src/components/routes/RouteModal.svelte
@@ -15,6 +15,7 @@
 <script>
 	import StopItem from '$components/StopItem.svelte';
 	import BottomSheet from '$components/navigation/BottomSheet.svelte';
+	import FavoriteToggle from '$components/favorites/FavoriteToggle.svelte';
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 	import { faX } from '@fortawesome/free-solid-svg-icons';
 	import { keybinding } from '$lib/keybinding';
@@ -62,6 +63,16 @@
 			<p class="min-w-0 flex-1 truncate text-base font-semibold text-black dark:text-white">
 				{title()}
 			</p>
+			{#if selectedRoute}
+				<FavoriteToggle
+					type="route"
+					id={selectedRoute.id}
+					shortName={selectedRoute.shortName}
+					description={selectedRoute.description}
+					routeType={selectedRoute.type}
+					class="h-8 w-8"
+				/>
+			{/if}
 			<button
 				type="button"
 				onclick={closePane}

--- a/src/components/routes/__tests__/RouteModal.test.js
+++ b/src/components/routes/__tests__/RouteModal.test.js
@@ -14,6 +14,9 @@ vi.mock('svelte-i18n', () => ({
 				const translations = {
 					show_more: 'Show more',
 					show_less: 'Show less',
+					'sheet.close': 'Close',
+					'favorites.add': 'Add to favorites',
+					'favorites.remove': 'Remove from favorites',
 					route_modal_title: options?.values?.name
 						? `Route ${options.values.name}`
 						: 'route_modal_title'
@@ -213,6 +216,32 @@ describe('RouteModal', () => {
 		await user.click(closeButton);
 
 		expect(mockClosePane).toHaveBeenCalledTimes(1);
+	});
+
+	test('renders a favorite toggle for the selected route', () => {
+		render(RouteModal, {
+			props: {
+				selectedRoute: mockRoute,
+				stops: mockStops,
+				mapProvider: mockMapProvider,
+				closePane: mockClosePane
+			}
+		});
+
+		expect(screen.getByRole('button', { name: 'Add to favorites' })).toBeInTheDocument();
+	});
+
+	test('hides the favorite toggle when no route is selected', () => {
+		render(RouteModal, {
+			props: {
+				selectedRoute: null,
+				stops: mockStops,
+				mapProvider: mockMapProvider,
+				closePane: mockClosePane
+			}
+		});
+
+		expect(screen.queryByRole('button', { name: 'Add to favorites' })).not.toBeInTheDocument();
 	});
 
 	test('is keyboard accessible', async () => {

--- a/src/components/search/SearchPane.svelte
+++ b/src/components/search/SearchPane.svelte
@@ -1,7 +1,6 @@
 <script>
 	import SearchField from '$components/search/SearchField.svelte';
 	import SearchResultItem from '$components/search/SearchResultItem.svelte';
-	import FavoritesList from '$components/favorites/FavoritesList.svelte';
 	import { onMount, onDestroy, tick } from 'svelte';
 	import { prioritizedRouteTypeForDisplay } from '$config/routeConfig';
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
@@ -75,32 +74,6 @@
 		setTimeout(() => {
 			handleStopMarkerSelect(stop);
 		}, 100);
-	}
-
-	/**
-	 * Open a favorited stop once the map is ready. Favorites store denormalized
-	 * stop fields that match what handleStopClick already expects.
-	 * @param {Object} favorite
-	 */
-	function handleFavoriteStopClick(favorite) {
-		if (!mapLoaded || !mapProvider) return;
-		handleStopClick(favorite);
-	}
-
-	/**
-	 * Open a favorited route. Map stored `routeType`/`shortName` onto the shape
-	 * handleRouteClick and vehicle polling expect from search results.
-	 * @param {Object} favorite
-	 */
-	function handleFavoriteRouteClick(favorite) {
-		if (!mapLoaded || !mapProvider) return;
-		handleRouteClick({
-			id: favorite.id,
-			shortName: favorite.shortName,
-			nullSafeShortName: favorite.shortName,
-			description: favorite.description,
-			type: favorite.routeType
-		});
 	}
 
 	/**
@@ -401,13 +374,6 @@
 				<div class="mt-2">
 					{@render childContent()}
 				</div>
-			{/if}
-
-			{#if !query}
-				<FavoritesList
-					onStopClick={handleFavoriteStopClick}
-					onRouteClick={handleFavoriteRouteClick}
-				/>
 			{/if}
 
 			{#if query}

--- a/src/components/search/SearchPane.svelte
+++ b/src/components/search/SearchPane.svelte
@@ -1,6 +1,7 @@
 <script>
 	import SearchField from '$components/search/SearchField.svelte';
 	import SearchResultItem from '$components/search/SearchResultItem.svelte';
+	import FavoritesList from '$components/favorites/FavoritesList.svelte';
 	import { onMount, onDestroy, tick } from 'svelte';
 	import { prioritizedRouteTypeForDisplay } from '$config/routeConfig';
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
@@ -74,6 +75,32 @@
 		setTimeout(() => {
 			handleStopMarkerSelect(stop);
 		}, 100);
+	}
+
+	/**
+	 * Open a favorited stop once the map is ready. Favorites store denormalized
+	 * stop fields that match what handleStopClick already expects.
+	 * @param {Object} favorite
+	 */
+	function handleFavoriteStopClick(favorite) {
+		if (!mapLoaded || !mapProvider) return;
+		handleStopClick(favorite);
+	}
+
+	/**
+	 * Open a favorited route. Map stored `routeType`/`shortName` onto the shape
+	 * handleRouteClick and vehicle polling expect from search results.
+	 * @param {Object} favorite
+	 */
+	function handleFavoriteRouteClick(favorite) {
+		if (!mapLoaded || !mapProvider) return;
+		handleRouteClick({
+			id: favorite.id,
+			shortName: favorite.shortName,
+			nullSafeShortName: favorite.shortName,
+			description: favorite.description,
+			type: favorite.routeType
+		});
 	}
 
 	/**
@@ -374,6 +401,13 @@
 				<div class="mt-2">
 					{@render childContent()}
 				</div>
+			{/if}
+
+			{#if !query}
+				<FavoritesList
+					onStopClick={handleFavoriteStopClick}
+					onRouteClick={handleFavoriteRouteClick}
+				/>
 			{/if}
 
 			{#if query}

--- a/src/components/search/__tests__/SearchPane.test.js
+++ b/src/components/search/__tests__/SearchPane.test.js
@@ -62,7 +62,10 @@ vi.mock('svelte-i18n', () => {
 		'search.clear_results': 'Clear Results',
 		'search.results_for': 'Results for',
 		'tabs.stops-and-stations': 'Stops & Stations',
-		'tabs.plan_trip': 'Plan Trip'
+		'tabs.plan_trip': 'Plan Trip',
+		'favorites.title': 'Favorites',
+		'favorites.empty': 'No favorites yet',
+		'favorites.clear_all': 'Clear All'
 	};
 
 	return {
@@ -169,6 +172,13 @@ describe('SearchPane', () => {
 			// Verify basic components are present instead
 			expect(screen.getByText('Stops & Stations')).toBeInTheDocument();
 			expect(screen.getByRole('textbox')).toBeInTheDocument();
+		});
+
+		test('shows favorites section when the search query is empty', () => {
+			render(SearchPane, { props: mockProps });
+
+			expect(screen.getByRole('heading', { level: 2, name: 'Favorites' })).toBeInTheDocument();
+			expect(screen.getByText('No favorites yet')).toBeInTheDocument();
 		});
 	});
 

--- a/src/components/search/__tests__/SearchPane.test.js
+++ b/src/components/search/__tests__/SearchPane.test.js
@@ -62,10 +62,7 @@ vi.mock('svelte-i18n', () => {
 		'search.clear_results': 'Clear Results',
 		'search.results_for': 'Results for',
 		'tabs.stops-and-stations': 'Stops & Stations',
-		'tabs.plan_trip': 'Plan Trip',
-		'favorites.title': 'Favorites',
-		'favorites.empty': 'No favorites yet',
-		'favorites.clear_all': 'Clear All'
+		'tabs.plan_trip': 'Plan Trip'
 	};
 
 	return {
@@ -172,13 +169,6 @@ describe('SearchPane', () => {
 			// Verify basic components are present instead
 			expect(screen.getByText('Stops & Stations')).toBeInTheDocument();
 			expect(screen.getByRole('textbox')).toBeInTheDocument();
-		});
-
-		test('shows favorites section when the search query is empty', () => {
-			render(SearchPane, { props: mockProps });
-
-			expect(screen.getByRole('heading', { level: 2, name: 'Favorites' })).toBeInTheDocument();
-			expect(screen.getByText('No favorites yet')).toBeInTheDocument();
 		});
 	});
 

--- a/src/components/stops/StopBottomSheet.svelte
+++ b/src/components/stops/StopBottomSheet.svelte
@@ -18,6 +18,7 @@
 <script>
 	import BottomSheet from '$components/navigation/BottomSheet.svelte';
 	import StopPane from '$components/stops/StopPane.svelte';
+	import FavoriteToggle from '$components/favorites/FavoriteToggle.svelte';
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 	import { faCircleInfo, faX, faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 	import { keybinding } from '$lib/keybinding';
@@ -93,6 +94,15 @@
 						<FontAwesomeIcon icon={faArrowsRotate} />
 					</span>
 				</button>
+				<FavoriteToggle
+					type="stop"
+					id={stop.id}
+					name={stop.name}
+					code={stop.code}
+					direction={stop.direction}
+					lat={stop.lat}
+					lon={stop.lon}
+				/>
 				<a
 					href={`/stops/${stop.id}`}
 					class="flex h-10 items-center gap-2 rounded-xl border border-gray-300 px-4 text-base font-semibold text-black hover:bg-gray-100 dark:border-gray-600 dark:text-white dark:hover:bg-gray-700"

--- a/src/components/stops/StopPageHeader.svelte
+++ b/src/components/stops/StopPageHeader.svelte
@@ -32,8 +32,10 @@
 	</div>
 
 	<div class="text-center">
-		<h1 class="flex items-center justify-center gap-2 text-3xl font-bold text-brand-accent">
-			{stopName}
+		<div class="flex items-center justify-center gap-2">
+			<h1 class="text-3xl font-bold text-brand-accent">
+				{stopName}
+			</h1>
 			{#if stopLat != null && stopLon != null}
 				<FavoriteToggle
 					type="stop"
@@ -46,7 +48,7 @@
 					class="h-9 w-9"
 				/>
 			{/if}
-		</h1>
+		</div>
 		<div class="text-normal mt-2 flex items-center justify-center gap-x-8 text-gray-700">
 			<div class="rounded-md bg-gray-50 px-2 py-1">
 				<FontAwesomeIcon icon={faMapMarkerAlt} />

--- a/src/components/stops/StopPageHeader.svelte
+++ b/src/components/stops/StopPageHeader.svelte
@@ -2,13 +2,21 @@
 	import { faMapMarkerAlt, faArrowLeft, faMap } from '@fortawesome/free-solid-svg-icons';
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 	import CompassArrow from '$components/controls/CompassArrow.svelte';
+	import FavoriteToggle from '$components/favorites/FavoriteToggle.svelte';
 	import TabContainer from '$components/tabs/TabContainer.svelte';
 	import TabLink from '$components/tabs/TabLink.svelte';
 	import { page } from '$app/stores';
 
 	import { t, isLoading } from 'svelte-i18n';
 	import { removeAgencyPrefix } from '$lib/utils';
-	let { stopName, stopId, stopDirection } = $props();
+	let {
+		stopName,
+		stopId,
+		stopDirection,
+		stopLat = null,
+		stopLon = null,
+		stopCode = null
+	} = $props();
 </script>
 
 <div class="my-4">
@@ -26,6 +34,18 @@
 	<div class="text-center">
 		<h1 class="flex items-center justify-center gap-2 text-3xl font-bold text-brand-accent">
 			{stopName}
+			{#if stopLat != null && stopLon != null}
+				<FavoriteToggle
+					type="stop"
+					id={stopId}
+					name={stopName}
+					code={stopCode}
+					direction={stopDirection}
+					lat={stopLat}
+					lon={stopLon}
+					class="h-9 w-9"
+				/>
+			{/if}
 		</h1>
 		<div class="text-normal mt-2 flex items-center justify-center gap-x-8 text-gray-700">
 			<div class="rounded-md bg-gray-50 px-2 py-1">

--- a/src/components/stops/__tests__/StopBottomSheet.test.js
+++ b/src/components/stops/__tests__/StopBottomSheet.test.js
@@ -61,6 +61,12 @@ describe('StopBottomSheet', () => {
 		);
 	});
 
+	test('renders a favorite toggle in the action row', () => {
+		render(StopBottomSheet, { props: defaultProps });
+
+		expect(screen.getByRole('button', { name: 'favorites.add' })).toBeInTheDocument();
+	});
+
 	test('does not render a schedule link', () => {
 		render(StopBottomSheet, { props: defaultProps });
 

--- a/src/components/stops/__tests__/StopPageHeader.test.js
+++ b/src/components/stops/__tests__/StopPageHeader.test.js
@@ -74,6 +74,16 @@ describe('StopPageHeader', () => {
 		expect(screen.getByRole('button', { name: 'Add to favorites' })).toBeInTheDocument();
 	});
 
+	test('keeps the favorite toggle outside the heading accessible name', () => {
+		render(StopPageHeader, { props: defaultProps });
+
+		const heading = screen.getByRole('heading', { level: 1 });
+		const toggle = screen.getByRole('button', { name: 'Add to favorites' });
+
+		expect(heading).toHaveAccessibleName('Pine St & 3rd Ave');
+		expect(heading.contains(toggle)).toBe(false);
+	});
+
 	test('hides the favorite toggle when stop coordinates are missing', () => {
 		render(StopPageHeader, {
 			props: {
@@ -114,7 +124,7 @@ describe('StopPageHeader', () => {
 		const mainContainer = screen.getByRole('heading', { level: 1 }).closest('.my-4');
 		expect(mainContainer).toHaveClass('my-4');
 
-		const headerContainer = screen.getByRole('heading', { level: 1 }).parentElement;
+		const headerContainer = screen.getByRole('heading', { level: 1 }).closest('.text-center');
 		expect(headerContainer).toHaveClass('text-center');
 	});
 

--- a/src/components/stops/__tests__/StopPageHeader.test.js
+++ b/src/components/stops/__tests__/StopPageHeader.test.js
@@ -29,7 +29,9 @@ vi.mock('svelte-i18n', () => ({
 					'schedule_for_stop.direction': 'Direction',
 					'arrivals_and_departures_for_stop.title': 'Arrivals & Departures',
 					'schedule_for_stop.route_schedules': 'Route Schedules',
-					'navigation.back_to_map': 'Back to Map'
+					'navigation.back_to_map': 'Back to Map',
+					'favorites.add': 'Add to favorites',
+					'favorites.remove': 'Remove from favorites'
 				};
 				return translations[key] || key;
 			});
@@ -60,8 +62,29 @@ describe('StopPageHeader', () => {
 	const defaultProps = {
 		stopName: 'Pine St & 3rd Ave',
 		stopId: '1_75403',
-		stopDirection: 'N'
+		stopDirection: 'N',
+		stopLat: 47.6105,
+		stopLon: -122.3363,
+		stopCode: '75403'
 	};
+
+	test('renders a favorite toggle next to the stop name when coords are present', () => {
+		render(StopPageHeader, { props: defaultProps });
+
+		expect(screen.getByRole('button', { name: 'Add to favorites' })).toBeInTheDocument();
+	});
+
+	test('hides the favorite toggle when stop coordinates are missing', () => {
+		render(StopPageHeader, {
+			props: {
+				stopName: 'Pine St & 3rd Ave',
+				stopId: '1_75403',
+				stopDirection: 'N'
+			}
+		});
+
+		expect(screen.queryByRole('button', { name: 'Add to favorites' })).not.toBeInTheDocument();
+	});
 
 	test('displays stop name as main heading', () => {
 		render(StopPageHeader, { props: defaultProps });

--- a/src/lib/__tests__/favoriteNotifications.test.js
+++ b/src/lib/__tests__/favoriteNotifications.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { notifications } from '$stores/notificationStore';
+import { notifyFavoriteSaved, notifyFavoriteRemoved } from '../favoriteNotifications';
+
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
+
+vi.mock('svelte-i18n', () => ({
+	t: {
+		subscribe: vi.fn((fn) => {
+			fn((key) => {
+				const messages = {
+					'notifications.favorite_saved': 'Saved to favorites.',
+					'notifications.favorite_removed': 'Removed from favorites.'
+				};
+				return messages[key] ?? key;
+			});
+			return () => {};
+		})
+	}
+}));
+
+describe('favoriteNotifications', () => {
+	beforeEach(() => {
+		notifications.dismiss();
+	});
+
+	afterEach(() => {
+		notifications.dismiss();
+	});
+
+	it('notifyFavoriteSaved shows a short success toast', () => {
+		const id = notifyFavoriteSaved();
+
+		const active = get(notifications);
+		expect(id).toBe(active.id);
+		expect(active.variant).toBe('success');
+		expect(active.message).toBe('Saved to favorites.');
+		expect(active.onRetry).toBeNull();
+	});
+
+	it('notifyFavoriteRemoved shows a short success toast', () => {
+		notifyFavoriteRemoved();
+
+		const active = get(notifications);
+		expect(active.variant).toBe('success');
+		expect(active.message).toBe('Removed from favorites.');
+	});
+});

--- a/src/lib/favoriteNotifications.js
+++ b/src/lib/favoriteNotifications.js
@@ -1,0 +1,29 @@
+import { get } from 'svelte/store';
+import { t } from 'svelte-i18n';
+import { notifications } from '$stores/notificationStore';
+
+const FAVORITE_TOAST_MS = 3000;
+
+/**
+ * Confirm a stop or route was saved to favorites.
+ * @returns {number | null}
+ */
+export function notifyFavoriteSaved() {
+	return notifications.show({
+		message: get(t)('notifications.favorite_saved'),
+		variant: 'success',
+		duration: FAVORITE_TOAST_MS
+	});
+}
+
+/**
+ * Confirm a stop or route was removed from favorites.
+ * @returns {number | null}
+ */
+export function notifyFavoriteRemoved() {
+	return notifications.show({
+		message: get(t)('notifications.favorite_removed'),
+		variant: 'success',
+		duration: FAVORITE_TOAST_MS
+	});
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -71,6 +71,8 @@
 		"add": "Add to favorites",
 		"remove": "Remove from favorites",
 		"clear_all": "Clear All",
+		"open_panel": "Open favorites",
+		"close_panel": "Close favorites",
 		"empty": "No favorites yet. Tap the star on a stop or route to save it here.",
 		"stop_code": "Code",
 		"open_item": "Open {name}",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -66,6 +66,16 @@
 		"stops-and-stations": "Stops and Stations",
 		"plan_trip": "Plan a Trip"
 	},
+	"favorites": {
+		"title": "Favorites",
+		"add": "Add to favorites",
+		"remove": "Remove from favorites",
+		"clear_all": "Clear All",
+		"empty": "No favorites yet. Tap the star on a stop or route to save it here.",
+		"stop_code": "Code",
+		"open_item": "Open {name}",
+		"remove_item": "Remove {name} from favorites"
+	},
 	"search": {
 		"placeholder": "Search for stops, routes, and places",
 		"results_for": "Search results for",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -152,6 +152,8 @@
 		"route_load_failed": "Couldn't load this route.",
 		"route_shape_failed": "Couldn't draw this route on the map.",
 		"route_shape_partial": "Part of this route couldn't be drawn. The map may be missing a segment.",
+		"favorite_saved": "Saved to favorites.",
+		"favorite_removed": "Removed from favorites.",
 		"tap_to_retry": "Tap to retry.",
 		"dismiss": "Dismiss"
 	},

--- a/src/routes/stops/[stopID]/+page.svelte
+++ b/src/routes/stops/[stopID]/+page.svelte
@@ -43,6 +43,13 @@
 </svelte:head>
 
 <StandalonePage>
-	<StopPageHeader stopName={stop.name} stopId={stop.id} stopDirection={stop.direction} />
+	<StopPageHeader
+		stopName={stop.name}
+		stopId={stop.id}
+		stopDirection={stop.direction}
+		stopLat={stop.lat}
+		stopLon={stop.lon}
+		stopCode={stop.code}
+	/>
 	<StopPane {stop} bind:arrivalsAndDeparturesResponse />
 </StandalonePage>

--- a/src/routes/stops/[stopID]/schedule/+page.svelte
+++ b/src/routes/stops/[stopID]/schedule/+page.svelte
@@ -18,6 +18,9 @@
 	let stopName = $state('');
 	let stopId = $state('');
 	let stopDirection = $state('');
+	let stopLat = $state(null);
+	let stopLon = $state(null);
+	let stopCode = $state(null);
 	let accordionComponent = $state();
 	let allRoutesExpanded = $state(false);
 
@@ -66,6 +69,9 @@
 		stopName = stop.name;
 		stopId = stop.id;
 		stopDirection = stop.direction;
+		stopLat = stop.lat ?? null;
+		stopLon = stop.lon ?? null;
+		stopCode = stop.code ?? null;
 	}
 
 	function processRouteSchedules(routeSchedules) {
@@ -148,7 +154,7 @@
 </svelte:head>
 
 <StandalonePage>
-	<StopPageHeader {stopName} {stopId} {stopDirection} />
+	<StopPageHeader {stopName} {stopId} {stopDirection} {stopLat} {stopLon} {stopCode} />
 
 	<div class="flex flex-col">
 		<div class="flex flex-1 flex-col">

--- a/src/stores/__tests__/favoritesStore.test.js
+++ b/src/stores/__tests__/favoritesStore.test.js
@@ -8,7 +8,6 @@ vi.mock('$app/environment', () => ({
 
 describe('favoritesStore', () => {
 	let favorites;
-	let favoriteKeys;
 
 	beforeEach(async () => {
 		localStorage.getItem.mockReset();
@@ -20,7 +19,6 @@ describe('favoritesStore', () => {
 		vi.resetModules();
 		const mod = await import('../../stores/favoritesStore.js');
 		favorites = mod.favorites;
-		favoriteKeys = mod.favoriteKeys;
 	});
 
 	function getStoreValue(store) {
@@ -138,17 +136,6 @@ describe('favoritesStore', () => {
 
 		expect(getStoreValue(favorites)).toHaveLength(0);
 		expect(localStorage.removeItem).toHaveBeenCalledWith('wayfinder_favorites');
-	});
-
-	it('should expose favoriteKeys as a Set of type:id', () => {
-		favorites.add(makeStop());
-		favorites.add(makeRoute());
-
-		const keys = getStoreValue(favoriteKeys);
-		expect(keys).toBeInstanceOf(Set);
-		expect(keys.has('stop:1_75403')).toBe(true);
-		expect(keys.has('route:1_100479')).toBe(true);
-		expect(keys.has('stop:missing')).toBe(false);
 	});
 
 	it('should reject stop entries with missing or non-finite coordinates', () => {

--- a/src/stores/__tests__/favoritesStore.test.js
+++ b/src/stores/__tests__/favoritesStore.test.js
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Override the global vitest-setup mock: store tests need browser = true
+// so localStorage calls actually execute
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
+
+describe('favoritesStore', () => {
+	let favorites;
+	let favoriteKeys;
+
+	beforeEach(async () => {
+		localStorage.getItem.mockReset();
+		localStorage.setItem.mockReset();
+		localStorage.removeItem.mockReset();
+		localStorage.clear.mockReset();
+		localStorage.getItem.mockReturnValue(null);
+
+		vi.resetModules();
+		const mod = await import('../../stores/favoritesStore.js');
+		favorites = mod.favorites;
+		favoriteKeys = mod.favoriteKeys;
+	});
+
+	function getStoreValue(store) {
+		let value;
+		store.subscribe((v) => (value = v))();
+		return value;
+	}
+
+	function makeStop(overrides = {}) {
+		return {
+			type: 'stop',
+			id: '1_75403',
+			name: 'Pine St & 3rd Ave',
+			code: '75403',
+			direction: 'N',
+			lat: 47.6105,
+			lon: -122.3363,
+			...overrides
+		};
+	}
+
+	function makeRoute(overrides = {}) {
+		return {
+			type: 'route',
+			id: '1_100479',
+			shortName: '10',
+			description: 'Capitol Hill - Downtown Seattle',
+			routeType: 3,
+			...overrides
+		};
+	}
+
+	it('should add a stop favorite and persist to localStorage', () => {
+		favorites.add(makeStop());
+
+		const value = getStoreValue(favorites);
+		expect(value).toHaveLength(1);
+		expect(value[0]).toMatchObject({
+			schemaVersion: 1,
+			type: 'stop',
+			id: '1_75403',
+			name: 'Pine St & 3rd Ave',
+			code: '75403',
+			direction: 'N',
+			lat: 47.6105,
+			lon: -122.3363
+		});
+		expect(value[0]).toHaveProperty('savedAt');
+		expect(localStorage.setItem).toHaveBeenCalledWith('wayfinder_favorites', expect.any(String));
+	});
+
+	it('should add a route favorite keyed by full OBA id', () => {
+		favorites.add(makeRoute());
+
+		const value = getStoreValue(favorites);
+		expect(value).toHaveLength(1);
+		expect(value[0].id).toBe('1_100479');
+		expect(value[0].shortName).toBe('10');
+		expect(value[0].type).toBe('route');
+	});
+
+	it('should deduplicate on type+id and keep the newest first', () => {
+		favorites.add(makeStop({ name: 'Old name' }));
+		favorites.add(makeStop({ name: 'New name' }));
+
+		const value = getStoreValue(favorites);
+		expect(value).toHaveLength(1);
+		expect(value[0].name).toBe('New name');
+	});
+
+	it('should allow the same numeric shortName for different route ids', () => {
+		favorites.add(makeRoute({ id: '1_100', shortName: '1' }));
+		favorites.add(makeRoute({ id: '40_200', shortName: '1' }));
+
+		const value = getStoreValue(favorites);
+		expect(value).toHaveLength(2);
+	});
+
+	it('should cap at 50 favorites and drop the oldest', () => {
+		for (let i = 0; i < 55; i++) {
+			favorites.add(makeStop({ id: `1_${i}`, name: `Stop ${i}`, lat: i, lon: i }));
+		}
+
+		const value = getStoreValue(favorites);
+		expect(value).toHaveLength(50);
+		expect(value[0].id).toBe('1_54');
+		expect(value[49].id).toBe('1_5');
+	});
+
+	it('should remove a favorite by type and id', () => {
+		favorites.add(makeStop());
+		favorites.add(makeRoute());
+
+		favorites.remove('stop', '1_75403');
+
+		const value = getStoreValue(favorites);
+		expect(value).toHaveLength(1);
+		expect(value[0].type).toBe('route');
+		expect(localStorage.setItem).toHaveBeenCalled();
+	});
+
+	it('should toggle a favorite on and off', () => {
+		favorites.toggle(makeStop());
+		expect(getStoreValue(favorites)).toHaveLength(1);
+
+		favorites.toggle(makeStop());
+		expect(getStoreValue(favorites)).toHaveLength(0);
+	});
+
+	it('should clear all favorites and remove from localStorage', () => {
+		favorites.add(makeStop());
+		favorites.add(makeRoute());
+
+		favorites.clearAll();
+
+		expect(getStoreValue(favorites)).toHaveLength(0);
+		expect(localStorage.removeItem).toHaveBeenCalledWith('wayfinder_favorites');
+	});
+
+	it('should expose favoriteKeys as a Set of type:id', () => {
+		favorites.add(makeStop());
+		favorites.add(makeRoute());
+
+		const keys = getStoreValue(favoriteKeys);
+		expect(keys).toBeInstanceOf(Set);
+		expect(keys.has('stop:1_75403')).toBe(true);
+		expect(keys.has('route:1_100479')).toBe(true);
+		expect(keys.has('stop:missing')).toBe(false);
+	});
+
+	it('should reject stop entries with missing or non-finite coordinates', () => {
+		favorites.add(makeStop({ lat: null, lon: -122 }));
+		favorites.add(makeStop({ lat: undefined, lon: -122 }));
+		favorites.add(makeStop({ lat: NaN, lon: -122 }));
+		favorites.add(makeStop({ lat: 47.6, lon: Infinity }));
+		favorites.add(makeStop({ id: '1_ok', lat: 47.6, lon: -122 }));
+
+		const value = getStoreValue(favorites);
+		expect(value).toHaveLength(1);
+		expect(value[0].id).toBe('1_ok');
+	});
+
+	it('should accept stop coordinates at zero (equator / prime meridian)', () => {
+		favorites.add(makeStop({ id: '1_zero', lat: 0, lon: 0 }));
+
+		const value = getStoreValue(favorites);
+		expect(value).toHaveLength(1);
+		expect(value[0].lat).toBe(0);
+		expect(value[0].lon).toBe(0);
+	});
+
+	it('should reject route entries without a shortName', () => {
+		favorites.add(makeRoute({ shortName: '' }));
+		favorites.add(makeRoute({ shortName: null }));
+		expect(getStoreValue(favorites)).toHaveLength(0);
+	});
+
+	it('should use ?? for optional fields so empty strings are preserved', () => {
+		favorites.add(makeStop({ direction: '', code: '' }));
+
+		const value = getStoreValue(favorites);
+		expect(value[0].direction).toBe('');
+		expect(value[0].code).toBe('');
+	});
+
+	it('should filter out malformed entries from localStorage on load', async () => {
+		const malformedData = [
+			makeStop({ id: '1_good' }),
+			{ type: 'stop', id: '1_bad', name: 'No coords' },
+			{ type: 'route', id: '1_r', shortName: '10' },
+			{ type: 'route', id: '1_bad_route' },
+			null,
+			'invalid'
+		];
+		localStorage.getItem.mockReturnValue(JSON.stringify(malformedData));
+
+		vi.resetModules();
+		const mod = await import('../../stores/favoritesStore.js');
+		const value = getStoreValue(mod.favorites);
+
+		expect(value).toHaveLength(2);
+		expect(value.map((f) => f.id)).toEqual(['1_good', '1_r']);
+	});
+
+	it('should survive corrupted JSON in localStorage', async () => {
+		localStorage.getItem.mockReturnValue('{not-json');
+
+		vi.resetModules();
+		const mod = await import('../../stores/favoritesStore.js');
+		expect(getStoreValue(mod.favorites)).toEqual([]);
+	});
+
+	it('should not throw when localStorage.setItem exceeds quota', () => {
+		localStorage.setItem.mockImplementation(() => {
+			throw new DOMException('QuotaExceededError');
+		});
+
+		expect(() => favorites.add(makeStop())).not.toThrow();
+		expect(getStoreValue(favorites)).toHaveLength(1);
+	});
+
+	it('should ignore add/toggle with invalid type or id', () => {
+		favorites.add({ type: 'place', id: 'x', name: 'Nope', lat: 1, lon: 2 });
+		favorites.toggle({ type: 'stop', id: '' });
+		favorites.toggle(null);
+		expect(getStoreValue(favorites)).toHaveLength(0);
+	});
+});

--- a/src/stores/__tests__/favoritesStore.test.js
+++ b/src/stores/__tests__/favoritesStore.test.js
@@ -159,9 +159,18 @@ describe('favoritesStore', () => {
 		expect(value[0].lon).toBe(0);
 	});
 
-	it('should reject route entries without a shortName', () => {
-		favorites.add(makeRoute({ shortName: '' }));
-		favorites.add(makeRoute({ shortName: null }));
+	it('should keep route entries without a shortName', () => {
+		favorites.add(makeRoute({ id: '1_noshort', shortName: null }));
+		favorites.add(makeRoute({ id: '1_emptyshort', shortName: '' }));
+
+		const value = getStoreValue(favorites);
+		expect(value).toHaveLength(2);
+		expect(value.map((f) => f.id)).toEqual(['1_emptyshort', '1_noshort']);
+	});
+
+	it('should reject route entries without a usable id', () => {
+		favorites.add(makeRoute({ id: '' }));
+		favorites.add(makeRoute({ id: null }));
 		expect(getStoreValue(favorites)).toHaveLength(0);
 	});
 
@@ -178,7 +187,8 @@ describe('favoritesStore', () => {
 			makeStop({ id: '1_good' }),
 			{ type: 'stop', id: '1_bad', name: 'No coords' },
 			{ type: 'route', id: '1_r', shortName: '10' },
-			{ type: 'route', id: '1_bad_route' },
+			{ type: 'route', id: '1_no_short' },
+			{ type: 'route' },
 			null,
 			'invalid'
 		];
@@ -188,8 +198,8 @@ describe('favoritesStore', () => {
 		const mod = await import('../../stores/favoritesStore.js');
 		const value = getStoreValue(mod.favorites);
 
-		expect(value).toHaveLength(2);
-		expect(value.map((f) => f.id)).toEqual(['1_good', '1_r']);
+		expect(value).toHaveLength(3);
+		expect(value.map((f) => f.id)).toEqual(['1_good', '1_r', '1_no_short']);
 	});
 
 	it('should survive corrupted JSON in localStorage', async () => {

--- a/src/stores/__tests__/favoritesStore.test.js
+++ b/src/stores/__tests__/favoritesStore.test.js
@@ -123,10 +123,10 @@ describe('favoritesStore', () => {
 	});
 
 	it('should toggle a favorite on and off', () => {
-		favorites.toggle(makeStop());
+		expect(favorites.toggle(makeStop())).toBe('added');
 		expect(getStoreValue(favorites)).toHaveLength(1);
 
-		favorites.toggle(makeStop());
+		expect(favorites.toggle(makeStop())).toBe('removed');
 		expect(getStoreValue(favorites)).toHaveLength(0);
 	});
 
@@ -224,8 +224,8 @@ describe('favoritesStore', () => {
 
 	it('should ignore add/toggle with invalid type or id', () => {
 		favorites.add({ type: 'place', id: 'x', name: 'Nope', lat: 1, lon: 2 });
-		favorites.toggle({ type: 'stop', id: '' });
-		favorites.toggle(null);
+		expect(favorites.toggle({ type: 'stop', id: '' })).toBeNull();
+		expect(favorites.toggle(null)).toBeNull();
 		expect(getStoreValue(favorites)).toHaveLength(0);
 	});
 });

--- a/src/stores/favoritesStore.js
+++ b/src/stores/favoritesStore.js
@@ -28,8 +28,11 @@ function isValidFavorite(entry) {
 		return true;
 	}
 
-	const { shortName } = /** @type {{ shortName?: unknown }} */ (entry);
-	return typeof shortName === 'string' && !!shortName;
+	// Routes can genuinely lack a shortName (the OBA data carries
+	// nullSafeShortName for exactly this), so the id alone identifies one and the
+	// list falls back to it for display. Requiring shortName here would make the
+	// star silently no-op on those routes.
+	return true;
 }
 
 /**
@@ -60,7 +63,7 @@ function normalizeFavorite(entry) {
 		schemaVersion: SCHEMA_VERSION,
 		type: 'route',
 		id: entry.id,
-		shortName: entry.shortName,
+		shortName: entry.shortName ?? null,
 		description: entry.description ?? null,
 		routeType: entry.routeType ?? null,
 		savedAt

--- a/src/stores/favoritesStore.js
+++ b/src/stores/favoritesStore.js
@@ -136,27 +136,35 @@ function createFavoritesStore() {
 		/**
 		 * Toggle a favorite on/off.
 		 * @param {Object} entry
+		 * @returns {'added' | 'removed' | null}
 		 */
 		toggle: (entry) => {
 			const type = entry?.type;
 			const id = entry?.id;
 			if ((type !== 'stop' && type !== 'route') || typeof id !== 'string' || !id) {
-				return;
+				return null;
 			}
+
+			/** @type {'added' | 'removed' | null} */
+			let result = null;
 
 			update((favorites) => {
 				const exists = favorites.some((f) => f.type === type && f.id === id);
 				let updated;
 				if (exists) {
 					updated = favorites.filter((f) => !(f.type === type && f.id === id));
+					result = 'removed';
 				} else {
 					const normalized = normalizeFavorite({ ...entry, savedAt: Date.now() });
 					if (!normalized) return favorites;
 					updated = [normalized, ...favorites].slice(0, MAX_FAVORITES);
+					result = 'added';
 				}
 				persist(updated);
 				return updated;
 			});
+
+			return result;
 		},
 
 		/**

--- a/src/stores/favoritesStore.js
+++ b/src/stores/favoritesStore.js
@@ -1,4 +1,4 @@
-import { writable, derived } from 'svelte/store';
+import { writable } from 'svelte/store';
 import { browser } from '$app/environment';
 
 const MAX_FAVORITES = 50;
@@ -184,9 +184,3 @@ function createFavoritesStore() {
 }
 
 export const favorites = createFavoritesStore();
-
-/** Set of `${type}:${id}` keys for O(1) membership checks in components. */
-export const favoriteKeys = derived(
-	favorites,
-	($favorites) => new Set($favorites.map((f) => `${f.type}:${f.id}`))
-);

--- a/src/stores/favoritesStore.js
+++ b/src/stores/favoritesStore.js
@@ -1,0 +1,184 @@
+import { writable, derived } from 'svelte/store';
+import { browser } from '$app/environment';
+
+const MAX_FAVORITES = 50;
+const STORAGE_KEY = 'wayfinder_favorites';
+const SCHEMA_VERSION = 1;
+
+/**
+ * @param {unknown} entry
+ * @returns {boolean}
+ */
+function isValidFavorite(entry) {
+	if (!entry || typeof entry !== 'object') return false;
+
+	const { type, id } = /** @type {{ type?: unknown, id?: unknown }} */ (entry);
+	if ((type !== 'stop' && type !== 'route') || typeof id !== 'string' || !id) {
+		return false;
+	}
+
+	if (type === 'stop') {
+		const { lat, lon, name } = /** @type {{ lat?: unknown, lon?: unknown, name?: unknown }} */ (
+			entry
+		);
+		if (typeof name !== 'string' || !name) return false;
+		// Reject non-finite coords so favorites never call flyTo/addMarker with undefined.
+		// Use Number.isFinite (not truthiness) so lat/lon === 0 survive.
+		if (!Number.isFinite(lat) || !Number.isFinite(lon)) return false;
+		return true;
+	}
+
+	const { shortName } = /** @type {{ shortName?: unknown }} */ (entry);
+	return typeof shortName === 'string' && !!shortName;
+}
+
+/**
+ * Normalize a favorite entry for storage (denormalized snapshot for zero-API list UI).
+ * @param {Object} entry
+ * @returns {Object|null}
+ */
+function normalizeFavorite(entry) {
+	if (!isValidFavorite(entry)) return null;
+
+	const savedAt = typeof entry.savedAt === 'number' ? entry.savedAt : Date.now();
+
+	if (entry.type === 'stop') {
+		return {
+			schemaVersion: SCHEMA_VERSION,
+			type: 'stop',
+			id: entry.id,
+			name: entry.name,
+			code: entry.code ?? null,
+			direction: entry.direction ?? null,
+			lat: entry.lat,
+			lon: entry.lon,
+			savedAt
+		};
+	}
+
+	return {
+		schemaVersion: SCHEMA_VERSION,
+		type: 'route',
+		id: entry.id,
+		shortName: entry.shortName,
+		description: entry.description ?? null,
+		routeType: entry.routeType ?? null,
+		savedAt
+	};
+}
+
+function persist(favorites) {
+	if (!browser) return;
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(favorites));
+	} catch (e) {
+		console.warn('Failed to persist favorites:', e);
+	}
+}
+
+/**
+ * Creates a store for managing favorited stops and routes.
+ * Persists to localStorage, following the recentTripsStore pattern.
+ */
+function createFavoritesStore() {
+	let initialFavorites = [];
+
+	if (browser) {
+		try {
+			const stored = localStorage.getItem(STORAGE_KEY);
+			if (stored) {
+				const parsed = JSON.parse(stored);
+				if (Array.isArray(parsed)) {
+					initialFavorites = parsed.map(normalizeFavorite).filter(Boolean);
+				}
+			}
+		} catch (e) {
+			console.warn('Failed to load favorites from localStorage:', e);
+		}
+	}
+
+	const { subscribe, update, set } = writable(initialFavorites);
+
+	return {
+		subscribe,
+
+		/**
+		 * Add a favorite. Deduplicates on type+id; newest first; capped at MAX_FAVORITES.
+		 * @param {Object} entry
+		 */
+		add: (entry) => {
+			const normalized = normalizeFavorite({ ...entry, savedAt: Date.now() });
+			if (!normalized) return;
+
+			update((favorites) => {
+				const filtered = favorites.filter(
+					(f) => !(f.type === normalized.type && f.id === normalized.id)
+				);
+				const updated = [normalized, ...filtered].slice(0, MAX_FAVORITES);
+				persist(updated);
+				return updated;
+			});
+		},
+
+		/**
+		 * Remove a favorite by type and id.
+		 * @param {'stop'|'route'} type
+		 * @param {string} id
+		 */
+		remove: (type, id) => {
+			update((favorites) => {
+				const updated = favorites.filter((f) => !(f.type === type && f.id === id));
+				persist(updated);
+				return updated;
+			});
+		},
+
+		/**
+		 * Toggle a favorite on/off.
+		 * @param {Object} entry
+		 */
+		toggle: (entry) => {
+			const type = entry?.type;
+			const id = entry?.id;
+			if ((type !== 'stop' && type !== 'route') || typeof id !== 'string' || !id) {
+				return;
+			}
+
+			update((favorites) => {
+				const exists = favorites.some((f) => f.type === type && f.id === id);
+				let updated;
+				if (exists) {
+					updated = favorites.filter((f) => !(f.type === type && f.id === id));
+				} else {
+					const normalized = normalizeFavorite({ ...entry, savedAt: Date.now() });
+					if (!normalized) return favorites;
+					updated = [normalized, ...favorites].slice(0, MAX_FAVORITES);
+				}
+				persist(updated);
+				return updated;
+			});
+		},
+
+		/**
+		 * Clear all favorites.
+		 */
+		clearAll: () => {
+			if (browser) {
+				try {
+					localStorage.removeItem(STORAGE_KEY);
+				} catch (e) {
+					console.warn('Failed to remove favorites from localStorage:', e);
+				}
+			}
+			set([]);
+		}
+	};
+}
+
+export const favorites = createFavoritesStore();
+
+/** Set of `${type}:${id}` keys for O(1) membership checks in components. */
+export const favoriteKeys = derived(
+	favorites,
+	($favorites) => new Set($favorites.map((f) => `${f.type}:${f.id}`))
+);

--- a/src/stores/notificationStore.js
+++ b/src/stores/notificationStore.js
@@ -1,7 +1,7 @@
 import { writable, get } from 'svelte/store';
 import { browser } from '$app/environment';
 
-/** @typedef {'error' | 'warning'} NotificationVariant */
+/** @typedef {'error' | 'warning' | 'success'} NotificationVariant */
 
 /**
  * @typedef {Object} Notification


### PR DESCRIPTION
## Summary
Adds local favorites (bookmarks) for stops and routes so riders can re-open everyday places without searching again.

## What changed
- **Store** — `favoritesStore` persists a capped list (max 50) in `localStorage`, with dedupe, validation (stops need finite lat/lon), and add / remove / toggle / clearAll
- **Star toggle** — `FavoriteToggle` on the stop bottom sheet, standalone stop pages, and the route sheet header
- **Floating control** — map FAB opens a favorites panel (`FavoritesFloatingControl` + `FavoritesList`). Mobile: below the search pane. Desktop: top-right on the map
- **Feedback** — short success toasts on save/remove (“Saved to favorites.” / “Removed from favorites.”)
- **i18n** — English keys under `favorites.*` and `notifications.favorite_*`

## How it works
- Favorites are denormalized snapshots (name, code, coords / shortName, etc.) so the list renders with no API call
- Selecting a favorite stop flies the map and opens the stop sheet; selecting a route reuses the existing `routeSelectedFromModal` path
- Item open and remove are sibling buttons (no nested interactive controls

Closes #581 

## Working Screenshots
<img width="1463" height="737" alt="image" src="https://github.com/user-attachments/assets/59511b2d-2d36-4288-8263-3d3cc5cfb6e4" />
<img width="1458" height="734" alt="image" src="https://github.com/user-attachments/assets/b3257b80-ec42-4458-a841-13ee271e1048" />
<img width="343" height="689" alt="image" src="https://github.com/user-attachments/assets/5f0714d6-3dbc-441c-80d6-e2f961109548" />

<img width="1447" height="731" alt="image" src="https://github.com/user-attachments/assets/456e9a2d-8ea8-47d0-9fbf-71e6c2f7ba6e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent favorites for stops and routes.
  * Added favorite buttons to stop and route views.
  * Added a map favorites panel with counts, selection, removal, and clear-all actions.
  * Added success notifications when favorites are saved or removed.

* **Bug Fixes**
  * Improved notification styling, including success messages.
  * Adjusted the route legend position to avoid overlapping map controls.

* **Tests**
  * Added comprehensive coverage for favorites, notifications, and related controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->