### PR TITLE
fix: hexToRgb() to support 8-digit hex

### DIFF
--- a/src/lib/colorUtils.js
+++ b/src/lib/colorUtils.js
@@ -7,7 +7,7 @@ import { COLORS } from './colors.js';
 
 /**
  * Converts a hex color string to RGB object
- * Supports both 3-digit (#fff) and 6-digit (#ffffff) hex formats
+ * Supports 3-digit (#fff), 6-digit (#ffffff) and 8-digit (#ffffffff) hex formats
  * @param {string} hex - Hex color string (with or without #)
  * @returns {{r: number, g: number, b: number} | null} RGB object or null if invalid
  */
@@ -21,6 +21,11 @@ export function hexToRgb(hex) {
 			.map((c) => c + c)
 			.join('');
 	}
+	// ignore alpha channel in 8-digit hex
+	if (hex.length === 8) {
+		hex = hex.slice(0, 6);
+	}
+
 	const result = /^([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
 	return result
 		? {

--- a/src/lib/colorUtils.js
+++ b/src/lib/colorUtils.js
@@ -108,7 +108,7 @@ export function generatePalette(baseHex, fallbackHex = '#486621') {
 	// 600 is slightly darker, 900 is very dark
 	const darkWeights = { 600: 0.15, 700: 0.3, 800: 0.45, 900: 0.6 };
 
-	const palette = { 500: baseHex };
+	const palette = { 500: rgbToHex(base.r, base.g, base.b) };
 
 	for (const [shade, weight] of Object.entries(lightWeights)) {
 		const mixed = mixColors(base, white, weight);

--- a/src/tests/lib/colorUtils.test.js
+++ b/src/tests/lib/colorUtils.test.js
@@ -220,7 +220,7 @@ describe('colorUtils', () => {
 
 		test('works with shorthand hex', () => {
 			const palette = generatePalette('#f00');
-			expect(palette['500']).toBe('#f00');
+			expect(palette['500']).toBe('#ff0000');
 			expect(Object.keys(palette).length).toBe(10);
 		});
 

--- a/src/tests/lib/colorUtils.test.js
+++ b/src/tests/lib/colorUtils.test.js
@@ -43,6 +43,7 @@ describe('colorUtils', () => {
 			expect(hexToRgb('#AABBCC')).toEqual({ r: 170, g: 187, b: 204 });
 			expect(hexToRgb('#aAbBcC')).toEqual({ r: 170, g: 187, b: 204 });
 			expect(hexToRgb('#ABC')).toEqual({ r: 170, g: 187, b: 204 });
+			expect(hexToRgb('#486621FF')).toEqual({ r: 72, g: 102, b: 33 });
 		});
 
 		test('returns null for invalid input', () => {
@@ -58,6 +59,11 @@ describe('colorUtils', () => {
 			expect(hexToRgb(undefined)).toBeNull();
 			expect(hexToRgb(123456)).toBeNull();
 			expect(hexToRgb({})).toBeNull();
+		});
+
+		test('converts 8-digit hex by ignoring alpha channel', () => {
+			expect(hexToRgb('#486621ff')).toEqual({ r: 72, g: 102, b: 33 });
+			expect(hexToRgb('#48662180')).toEqual({ r: 72, g: 102, b: 33 });
 		});
 	});
 
@@ -343,6 +349,10 @@ describe('colorUtils', () => {
 			const hover = darkenColor(process.env.COLOR_BRAND_ACCENT, 0.15);
 
 			expect(contrastRatio('#ffffff', hover)).toBeGreaterThanOrEqual(4.5);
+		});
+
+		test('should accept 8-digit hex colors', () => {
+			expect(darkenColor('#486621ff', 0.15)).toBe('#3d571c');
 		});
 	});
 


### PR DESCRIPTION
### Summary
This PR is a follow-up to #584.
It addresses the third follow-up item from #529 by resolving the `validate-env / hexToRgb` 8-digit hex mismatch. 

### Changes
- Updated `hexToRgb()` method to support 8-digit hex colors (#RRGGBBAA).
- Added condition to ignore the alpha channel in 8-digit hex colors while parsing before regex 
- Added tests to verify the 8-digit hex parsing and to verify that `darkenColor` correctly accepts it. 

Closes: #529 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for 8-digit hexadecimal color values.
  * Alpha channels are ignored when converting or darkening colors.
  * Support includes uppercase and lowercase hexadecimal formats.

* **Bug Fixes**
  * Color palettes now consistently output normalized six-digit hexadecimal values.

* **Tests**
  * Added coverage for 8-digit color parsing and darkening behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->