### PR TITLE
fix(a11y): add trip planner combobox pattern

### DIFF
--- a/src/components/trip-planner/TripPlan.svelte
+++ b/src/components/trip-planner/TripPlan.svelte
@@ -73,8 +73,11 @@
 	const fetchLocationResults = debounce(async (query, isFrom, requestId) => {
 		if (!isCurrentAutocompleteRequest(isFrom, requestId)) return;
 
-		isLoadingFrom = isFrom;
-		isLoadingTo = !isFrom;
+		if (isFrom) {
+			isLoadingFrom = true;
+		} else {
+			isLoadingTo = true;
+		}
 
 		try {
 			const results = await fetchAutocompleteResults(query);
@@ -88,8 +91,11 @@
 			}
 		} finally {
 			if (isCurrentAutocompleteRequest(isFrom, requestId)) {
-				isLoadingFrom = false;
-				isLoadingTo = false;
+				if (isFrom) {
+					isLoadingFrom = false;
+				} else {
+					isLoadingTo = false;
+				}
 			}
 		}
 	}, 500);

--- a/src/components/trip-planner/TripPlan.svelte
+++ b/src/components/trip-planner/TripPlan.svelte
@@ -161,6 +161,14 @@
 		clearTripUrl();
 	}
 
+	function dismissSearchResults(isFrom) {
+		if (isFrom) {
+			fromResults = [];
+		} else {
+			toResults = [];
+		}
+	}
+
 	function swapLocations() {
 		const result = swapTripLocations({
 			fromPlace,
@@ -443,6 +451,7 @@
 						onInput={(query) => handleSearchInput(query, true)}
 						onClear={() => clearInput(true)}
 						onSelect={(location) => selectLocation(location, true)}
+						onDismiss={() => dismissSearchResults(true)}
 					/>
 				</div>
 			</div>
@@ -471,6 +480,7 @@
 						onInput={(query) => handleSearchInput(query, false)}
 						onClear={() => clearInput(false)}
 						onSelect={(location) => selectLocation(location, false)}
+						onDismiss={() => dismissSearchResults(false)}
 					/>
 				</div>
 			</div>

--- a/src/components/trip-planner/TripPlan.svelte
+++ b/src/components/trip-planner/TripPlan.svelte
@@ -41,6 +41,8 @@
 	let loading = $state(false);
 	let fromRequestId = 0;
 	let toRequestId = 0;
+	let fromAutocompleteRequestId = 0;
+	let toAutocompleteRequestId = 0;
 	// Recent trips stay behind a compact control so the plan form doesn't grow
 	// a tall history list under From/To (see #577).
 	let showRecentTrips = $state(false);
@@ -56,19 +58,39 @@
 		return data.suggestions;
 	}
 
-	const fetchLocationResults = debounce(async (query, isFrom) => {
+	function invalidateAutocompleteRequest(isFrom) {
+		if (isFrom) {
+			return ++fromAutocompleteRequestId;
+		}
+
+		return ++toAutocompleteRequestId;
+	}
+
+	function isCurrentAutocompleteRequest(isFrom, requestId) {
+		return isFrom ? requestId === fromAutocompleteRequestId : requestId === toAutocompleteRequestId;
+	}
+
+	const fetchLocationResults = debounce(async (query, isFrom, requestId) => {
+		if (!isCurrentAutocompleteRequest(isFrom, requestId)) return;
+
 		isLoadingFrom = isFrom;
 		isLoadingTo = !isFrom;
 
 		try {
 			const results = await fetchAutocompleteResults(query);
 
+			if (!isCurrentAutocompleteRequest(isFrom, requestId)) return;
+
 			isFrom ? (fromResults = results) : (toResults = results);
 		} catch (error) {
-			console.error('Error fetching location results:', error);
+			if (isCurrentAutocompleteRequest(isFrom, requestId)) {
+				console.error('Error fetching location results:', error);
+			}
 		} finally {
-			isLoadingFrom = false;
-			isLoadingTo = false;
+			if (isCurrentAutocompleteRequest(isFrom, requestId)) {
+				isLoadingFrom = false;
+				isLoadingTo = false;
+			}
 		}
 	}, 500);
 
@@ -91,12 +113,18 @@
 		// (and the parent's hasPlanned flag) instead of letting "No itineraries
 		// found" linger under the form while the rider edits.
 		clearTripItineraries();
+		const requestId = invalidateAutocompleteRequest(isFrom);
 		if (query.trim() === '') {
-			if (isFrom) fromResults = [];
-			else toResults = [];
+			if (isFrom) {
+				fromResults = [];
+				isLoadingFrom = false;
+			} else {
+				toResults = [];
+				isLoadingTo = false;
+			}
 			return;
 		}
-		await fetchLocationResults(query, isFrom);
+		await fetchLocationResults(query, isFrom, requestId);
 	}
 
 	async function selectLocation(suggestion, isFrom) {
@@ -140,9 +168,11 @@
 	}
 
 	function clearInput(isFrom) {
+		invalidateAutocompleteRequest(isFrom);
 		if (isFrom) {
 			fromPlace = '';
 			fromResults = [];
+			isLoadingFrom = false;
 			selectedFrom = null;
 			if (fromMarker) {
 				mapProvider.removePinMarker(fromMarker);
@@ -151,6 +181,7 @@
 		} else {
 			toPlace = '';
 			toResults = [];
+			isLoadingTo = false;
 			selectedTo = null;
 			if (toMarker) {
 				mapProvider.removePinMarker(toMarker);
@@ -162,10 +193,13 @@
 	}
 
 	function dismissSearchResults(isFrom) {
+		invalidateAutocompleteRequest(isFrom);
 		if (isFrom) {
 			fromResults = [];
+			isLoadingFrom = false;
 		} else {
 			toResults = [];
+			isLoadingTo = false;
 		}
 	}
 

--- a/src/components/trip-planner/TripPlanSearchField.svelte
+++ b/src/components/trip-planner/TripPlanSearchField.svelte
@@ -11,6 +11,7 @@
 	 * @property {(value: string) => void} onInput
 	 * @property {() => void} onClear
 	 * @property {any} onSelect
+	 * @property {() => void} [onDismiss]
 	 */
 
 	/** @type {Props} */
@@ -21,10 +22,16 @@
 		isLoading = false,
 		onInput,
 		onClear,
-		onSelect
+		onSelect,
+		onDismiss = () => {}
 	} = $props();
 
+	let activeIndex = $state(-1);
+	let listboxId = $derived(`${inputId}-listbox`);
+	let hasResults = $derived(!isLoading && Array.isArray(results) && results.length > 0);
+
 	function handleInput(event) {
+		activeIndex = -1;
 		onInput(event.target.value);
 	}
 
@@ -33,7 +40,37 @@
 	}
 
 	function handleSelect(result) {
+		activeIndex = -1;
 		onSelect(result);
+	}
+
+	function optionId(index) {
+		return `${listboxId}-option-${index}`;
+	}
+
+	function handleKeydown(event) {
+		if (!hasResults) return;
+
+		switch (event.key) {
+			case 'ArrowDown':
+				event.preventDefault();
+				activeIndex = activeIndex < results.length - 1 ? activeIndex + 1 : 0;
+				break;
+			case 'ArrowUp':
+				event.preventDefault();
+				activeIndex = activeIndex > 0 ? activeIndex - 1 : results.length - 1;
+				break;
+			case 'Enter':
+				if (activeIndex < 0) return;
+				event.preventDefault();
+				handleSelect(results[activeIndex]);
+				break;
+			case 'Escape':
+				event.preventDefault();
+				activeIndex = -1;
+				onDismiss();
+				break;
+		}
 	}
 </script>
 
@@ -43,6 +80,13 @@
 		type="text"
 		bind:value={place}
 		oninput={handleInput}
+		onkeydown={handleKeydown}
+		role="combobox"
+		aria-autocomplete="list"
+		aria-expanded={hasResults}
+		aria-haspopup="listbox"
+		aria-controls={hasResults ? listboxId : undefined}
+		aria-activedescendant={hasResults && activeIndex >= 0 ? optionId(activeIndex) : undefined}
 		placeholder="{$t('trip-planner.search_for_a_place')}..."
 		class="block w-full rounded-md border-gray-300 pr-10 text-sm text-black shadow-sm focus:border-blue-500 focus:ring-blue-500"
 	/>
@@ -58,18 +102,31 @@
 	{/if}
 	{#if isLoading}
 		<p
+			role="status"
 			class="absolute z-10 mt-1 w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-500 shadow-lg"
 		>
 			{$t('trip-planner.loading')}...
 		</p>
 	{:else if results && results.length > 0}
 		<ul
+			id={listboxId}
+			role="listbox"
 			class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md border border-gray-300 bg-white shadow-lg"
 		>
-			{#each results as result}
-				<li>
+			{#each results as result, index}
+				<li role="presentation">
 					<button
-						class="flex w-full cursor-pointer items-center px-4 py-2 text-left hover:bg-gray-100 dark:text-black"
+						id={optionId(index)}
+						type="button"
+						role="option"
+						tabindex="-1"
+						aria-selected={activeIndex === index}
+						aria-posinset={index + 1}
+						aria-setsize={results.length}
+						class="flex w-full cursor-pointer items-center px-4 py-2 text-left hover:bg-gray-100 dark:text-black {activeIndex ===
+						index
+							? 'bg-gray-100'
+							: ''}"
 						onclick={() => handleSelect(result)}
 					>
 						<FontAwesomeIcon icon={faMapMarkerAlt} class="mr-2 text-gray-400  " />

--- a/src/components/trip-planner/TripPlanSearchField.svelte
+++ b/src/components/trip-planner/TripPlanSearchField.svelte
@@ -49,6 +49,13 @@
 	}
 
 	function handleKeydown(event) {
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			activeIndex = -1;
+			onDismiss();
+			return;
+		}
+
 		if (!hasResults) return;
 
 		switch (event.key) {
@@ -64,11 +71,6 @@
 				if (activeIndex < 0) return;
 				event.preventDefault();
 				handleSelect(results[activeIndex]);
-				break;
-			case 'Escape':
-				event.preventDefault();
-				activeIndex = -1;
-				onDismiss();
 				break;
 		}
 	}

--- a/src/components/trip-planner/__tests__/TripPlan.test.js
+++ b/src/components/trip-planner/__tests__/TripPlan.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, waitFor } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
 import TripPlan from '../TripPlan.svelte';
@@ -95,6 +95,65 @@ describe('TripPlan pin cleanup', () => {
 		expect(mapProvider.removePinMarker).toHaveBeenCalledTimes(2);
 		expect(mapProvider.removePinMarker).toHaveBeenCalledWith(fromMarker);
 		expect(mapProvider.removePinMarker).toHaveBeenCalledWith(toMarker);
+	});
+});
+
+describe('TripPlan autocomplete dismissal', () => {
+	let mapProvider;
+	let props;
+
+	beforeEach(() => {
+		mapProvider = {
+			addPinMarker: vi.fn(),
+			removePinMarker: vi.fn(),
+			clearAllPolylines: vi.fn()
+		};
+		props = {
+			handleTripPlan: vi.fn(),
+			clearTripItineraries: vi.fn(),
+			mapProvider
+		};
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+		vi.useRealTimers();
+		delete global.fetch;
+	});
+
+	it('does not reopen results when a pending response resolves after Escape', async () => {
+		vi.useFakeTimers();
+		let resolveSuggestions;
+		global.fetch = vi.fn(
+			() =>
+				new Promise((resolve) => {
+					resolveSuggestions = () =>
+						resolve({
+							ok: true,
+							json: () =>
+								Promise.resolve({
+									suggestions: [{ displayText: 'Capitol Hill', name: 'Capitol Hill' }]
+								})
+						});
+				})
+		);
+		const { container, unmount } = render(TripPlan, { props });
+		const input = container.querySelector('#from-location-input');
+
+		await fireEvent.input(input, { target: { value: 'Capitol' } });
+		await vi.advanceTimersByTimeAsync(500);
+		expect(global.fetch).toHaveBeenCalledOnce();
+
+		await fireEvent.keyDown(input, { key: 'Escape' });
+		await tick();
+		expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+		resolveSuggestions();
+		await Promise.resolve();
+		await tick();
+
+		expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+		unmount();
 	});
 });
 

--- a/src/components/trip-planner/__tests__/TripPlan.test.js
+++ b/src/components/trip-planner/__tests__/TripPlan.test.js
@@ -158,6 +158,52 @@ describe('TripPlan autocomplete dismissal', () => {
 		expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
 		unmount();
 	});
+
+	it('keeps each field loading until its own request completes', async () => {
+		vi.useFakeTimers();
+		const resolveSuggestions = [];
+		global.fetch = vi.fn(
+			() =>
+				new Promise((resolve) => {
+					resolveSuggestions.push(() =>
+						resolve({
+							ok: true,
+							json: () => Promise.resolve({ suggestions: [] })
+						})
+					);
+				})
+		);
+		const { container, unmount } = render(TripPlan, { props });
+		const fromInput = container.querySelector('#from-location-input');
+		const toInput = container.querySelector('#to-location-input');
+
+		await fireEvent.input(fromInput, { target: { value: 'Capitol' } });
+		await vi.advanceTimersByTimeAsync(500);
+		await fireEvent.input(toInput, { target: { value: 'University' } });
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(global.fetch).toHaveBeenCalledTimes(2);
+		expect(screen.getAllByRole('status')).toHaveLength(2);
+
+		resolveSuggestions[0]();
+		await vi.advanceTimersByTimeAsync(0);
+		for (let i = 0; i < 4; i += 1) {
+			await Promise.resolve();
+		}
+		await tick();
+
+		expect(screen.getAllByRole('status')).toHaveLength(1);
+
+		resolveSuggestions[1]();
+		await vi.advanceTimersByTimeAsync(0);
+		for (let i = 0; i < 4; i += 1) {
+			await Promise.resolve();
+		}
+		await tick();
+
+		expect(screen.queryByRole('status')).not.toBeInTheDocument();
+		unmount();
+	});
 });
 
 describe('TripPlan shared URL round trip', () => {

--- a/src/components/trip-planner/__tests__/TripPlan.test.js
+++ b/src/components/trip-planner/__tests__/TripPlan.test.js
@@ -149,7 +149,10 @@ describe('TripPlan autocomplete dismissal', () => {
 		expect(screen.queryByRole('status')).not.toBeInTheDocument();
 
 		resolveSuggestions();
-		await Promise.resolve();
+		await vi.advanceTimersByTimeAsync(0);
+		for (let i = 0; i < 4; i += 1) {
+			await Promise.resolve();
+		}
 		await tick();
 
 		expect(screen.queryByRole('listbox')).not.toBeInTheDocument();

--- a/src/components/trip-planner/__tests__/TripPlanSearchField.test.js
+++ b/src/components/trip-planner/__tests__/TripPlanSearchField.test.js
@@ -200,6 +200,18 @@ describe('TripPlanSearchField', () => {
 			expect(onDismiss).toHaveBeenCalledOnce();
 			expect(input).not.toHaveAttribute('aria-activedescendant');
 		});
+
+		it('dismisses while autocomplete results are loading', async () => {
+			const onDismiss = vi.fn();
+			const props = { ...defaultProps, isLoading: true, onDismiss };
+			render(TripPlanSearchField, { props });
+
+			const input = screen.getByRole('combobox');
+			await user.click(input);
+			await user.keyboard('{Escape}');
+
+			expect(onDismiss).toHaveBeenCalledOnce();
+		});
 	});
 
 	describe('Accessibility', () => {

--- a/src/components/trip-planner/__tests__/TripPlanSearchField.test.js
+++ b/src/components/trip-planner/__tests__/TripPlanSearchField.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import TripPlanSearchField from '../TripPlanSearchField.svelte';
-import { renderWithUtils, a11yHelpers } from '../../../tests/helpers/test-utils.js';
+import { renderWithUtils } from '../../../tests/helpers/test-utils.js';
 // Mock FontAwesome icons
 vi.mock('@fortawesome/svelte-fontawesome', () => ({
 	FontAwesomeIcon: vi.fn(() => ({ $$: { component: 'div' } }))
@@ -149,7 +149,7 @@ describe('TripPlanSearchField', () => {
 			expect(mockOnSelect).toHaveBeenCalledWith(result);
 		});
 
-		it('result buttons are focusable', async () => {
+		it('keeps focus on the input while Arrow keys select an active result', async () => {
 			const results = [
 				{ displayText: 'Capitol Hill, Seattle, WA, USA', name: 'Capitol Hill' },
 				{ displayText: 'University District, Seattle, WA, USA', name: 'University District' }
@@ -157,19 +157,19 @@ describe('TripPlanSearchField', () => {
 			const props = { ...defaultProps, results };
 			render(TripPlanSearchField, { props });
 
-			const firstResult = screen.getByText('Capitol Hill, Seattle, WA, USA');
-			const secondResult = screen.getByText('University District, Seattle, WA, USA');
+			const input = screen.getByRole('combobox');
+			const options = screen.getAllByRole('option');
 
-			// Results should be focusable
-			expect(firstResult).toBeInTheDocument();
-			expect(secondResult).toBeInTheDocument();
+			await user.click(input);
+			await user.keyboard('{ArrowDown}');
 
-			// Should be able to focus on results
-			firstResult.focus();
-			expect(firstResult).toHaveFocus();
+			expect(input).toHaveFocus();
+			expect(input).toHaveAttribute('aria-activedescendant', options[0].id);
+			expect(options[0]).toHaveAttribute('aria-selected', 'true');
 
-			secondResult.focus();
-			expect(secondResult).toHaveFocus();
+			await user.keyboard('{ArrowUp}');
+			expect(input).toHaveAttribute('aria-activedescendant', options[1].id);
+			expect(options[1]).toHaveAttribute('aria-selected', 'true');
 		});
 
 		it('selects result with Enter key', async () => {
@@ -180,11 +180,25 @@ describe('TripPlanSearchField', () => {
 			const props = { ...defaultProps, results: [result] };
 			render(TripPlanSearchField, { props });
 
-			const resultButton = screen.getByText('Capitol Hill, Seattle, WA, USA');
-			resultButton.focus();
-			await user.keyboard('{Enter}');
+			const input = screen.getByRole('combobox');
+			await user.click(input);
+			await user.keyboard('{ArrowDown}{Enter}');
 
 			expect(mockOnSelect).toHaveBeenCalledWith(result);
+		});
+
+		it('dismisses the results with Escape', async () => {
+			const onDismiss = vi.fn();
+			const results = [{ displayText: 'Capitol Hill, Seattle, WA, USA', name: 'Capitol Hill' }];
+			const props = { ...defaultProps, results, onDismiss };
+			render(TripPlanSearchField, { props });
+
+			const input = screen.getByRole('combobox');
+			await user.click(input);
+			await user.keyboard('{ArrowDown}{Escape}');
+
+			expect(onDismiss).toHaveBeenCalledOnce();
+			expect(input).not.toHaveAttribute('aria-activedescendant');
 		});
 	});
 
@@ -207,13 +221,20 @@ describe('TripPlanSearchField', () => {
 			expect(clearButton).toHaveAttribute('type', 'button');
 		});
 
-		it('autocomplete results are keyboard accessible', () => {
+		it('exposes the full combobox/listbox relationship', () => {
 			const results = [{ displayText: 'Capitol Hill, Seattle, WA, USA', name: 'Capitol Hill' }];
 			const props = { ...defaultProps, results };
 			render(TripPlanSearchField, { props });
 
-			const resultButton = screen.getByText('Capitol Hill, Seattle, WA, USA');
-			expect(a11yHelpers.isFocusable(resultButton)).toBe(true);
+			const input = screen.getByRole('combobox');
+			const listbox = screen.getByRole('listbox');
+			const option = screen.getByRole('option');
+
+			expect(input).toHaveAttribute('aria-expanded', 'true');
+			expect(input).toHaveAttribute('aria-controls', listbox.id);
+			expect(input).toHaveAttribute('aria-autocomplete', 'list');
+			expect(option).toHaveAttribute('aria-posinset', '1');
+			expect(option).toHaveAttribute('aria-setsize', '1');
 		});
 
 		it('has proper semantic structure', () => {
@@ -224,13 +245,13 @@ describe('TripPlanSearchField', () => {
 			const props = { ...defaultProps, results };
 			render(TripPlanSearchField, { props });
 
-			// Results should be in a list
-			const resultsList = screen.getByRole('list', { hidden: true });
+			// Results should be in a listbox.
+			const resultsList = screen.getByRole('listbox');
 			expect(resultsList).toBeInTheDocument();
 
-			// Each result should be a button within the list
-			const resultButtons = screen.getAllByRole('button');
-			expect(resultButtons).toHaveLength(2); // Excluding clear button which is conditional
+			// Each result should be an option within the listbox.
+			const resultOptions = screen.getAllByRole('option');
+			expect(resultOptions).toHaveLength(2);
 		});
 
 		it('supports screen readers with proper labeling', () => {
@@ -248,7 +269,7 @@ describe('TripPlanSearchField', () => {
 			const props = { ...defaultProps, results: [] };
 			render(TripPlanSearchField, { props });
 
-			const resultsList = screen.queryByRole('list', { hidden: true });
+			const resultsList = screen.queryByRole('listbox');
 			expect(resultsList).not.toBeInTheDocument();
 		});
 

--- a/src/lib/keybinding.js
+++ b/src/lib/keybinding.js
@@ -22,6 +22,7 @@ export const keybinding = (node, params) => {
 		}
 
 		handler = (e) => {
+			if (e.defaultPrevented) return;
 			if (
 				!!currentParams.alt != e.altKey ||
 				!!currentParams.shift != e.shiftKey ||

--- a/src/tests/lib/keybinding.test.js
+++ b/src/tests/lib/keybinding.test.js
@@ -41,6 +41,7 @@ describe('keybinding action', () => {
 			shiftKey: keyParams.shift || false,
 			ctrlKey: keyParams.control || false,
 			metaKey: keyParams.control || false,
+			defaultPrevented: keyParams.defaultPrevented || false,
 			preventDefault: vi.fn()
 		};
 
@@ -85,6 +86,14 @@ describe('keybinding action', () => {
 
 		triggerKeydown({ code: 'KeyA' });
 		expect(node.click).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not respond to an event already handled by a child control', () => {
+		keybinding(node, { code: 'Escape' });
+
+		triggerKeydown({ code: 'Escape', defaultPrevented: true });
+
+		expect(node.click).not.toHaveBeenCalled();
 	});
 
 	it('responds to updated key code', () => {


### PR DESCRIPTION
## Summary
- add combobox and listbox semantics to trip-planner autocomplete
- support active-descendant Arrow-key navigation, Enter selection, and Escape dismissal
- cover ARIA relationships and keyboard behavior with component tests

## Testing
- npm test -- --run src/components/trip-planner/__tests__/TripPlanSearchField.test.js

Closes #527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added keyboard navigation for trip search suggestions using arrow keys.
  - Press Enter to select a highlighted suggestion.
  - Press Escape to dismiss autocomplete results or close the trip planner when no suggestions are open.
  - Improved accessibility with combobox and listbox semantics, active-option tracking, and clearer screen reader relationships.

- **Bug Fixes**
  - Prevented outdated autocomplete responses from replacing current results.
  - Preserved independent loading states for each location field.
  - Prevented handled keyboard events from triggering shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->