### PR TITLE
fix(analytics): handle missing event envelope

### DIFF
--- a/src/lib/Insights/adapters/PlausibleAdapter.js
+++ b/src/lib/Insights/adapters/PlausibleAdapter.js
@@ -25,7 +25,9 @@ export class PlausibleAdapter {
 		return `${this.env.PUBLIC_ANALYTICS_API_HOST}/api/event`;
 	}
 
-	async forwardEvent(envelope, requestContext) {
+	async forwardEvent(envelope = {}, requestContext) {
+		// Disabled analytics intentionally ignores malformed events so local development
+		// and tests without a complete analytics configuration remain quiet.
 		if (!this.isEnabled()) {
 			return { status: 'analytics disabled' };
 		}

--- a/src/tests/lib/Insights/adapters/PlausibleAdapter.test.js
+++ b/src/tests/lib/Insights/adapters/PlausibleAdapter.test.js
@@ -102,6 +102,12 @@ describe('PlausibleAdapter.forwardEvent', () => {
 		).rejects.toThrow('forwardEvent requires name and url');
 	});
 
+	it('throws a clear validation error when called without an envelope', async () => {
+		await expect(new PlausibleAdapter(fullEnv).forwardEvent()).rejects.toThrow(
+			'forwardEvent requires name and url'
+		);
+	});
+
 	it('POSTs to {apiHost}/api/event', async () => {
 		await new PlausibleAdapter(fullEnv).forwardEvent(envelope, ctx);
 		expect(global.fetch).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- default Plausible event envelopes to an empty object
- return the existing clear validation error for no-argument calls
- document the intentional disabled-before-validation behavior

## Testing
- npm test -- --run src/tests/lib/Insights/adapters/PlausibleAdapter.test.js src/tests/api/events.test.js
- npx prettier --check src/lib/Insights/adapters/PlausibleAdapter.js src/tests/lib/Insights/adapters/PlausibleAdapter.test.js

Closes #333