### PR TITLE
Fix short-line route schedules

### DIFF
--- a/src/components/schedule-for-stop/RouteScheduleTable.svelte
+++ b/src/components/schedule-for-stop/RouteScheduleTable.svelte
@@ -16,15 +16,19 @@
 	);
 
 	function renderScheduleTable(schedule) {
+		const stopTimes = Object.entries(schedule.stopTimes);
+
+		const amTimes = stopTimes.filter(([hour]) => +hour < 12);
+		const pmTimes = stopTimes.filter(([hour]) => +hour >= 12);
+
 		return {
-			times: Object.entries(schedule.stopTimes).sort(
-				([firstHour], [secondHour]) => Number(firstHour) - Number(secondHour)
-			)
+			amTimes,
+			pmTimes
 		};
 	}
 
 	function extractMinutes(arrivalTime) {
-		return arrivalTime.replace(/[AP]M/i, '').split(':')[1];
+		return arrivalTime.replace(/[AP]M/, '').split(':')[1];
 	}
 </script>
 
@@ -65,25 +69,86 @@
 			</tr>
 		</thead>
 		<tbody>
-			{#if scheduleData.times.length === 0}
+			<tr class="bg-gray-50 hover:bg-gray-100 dark:hover:bg-gray-600">
+				<th
+					colspan="2"
+					scope="rowgroup"
+					class="px-6 py-3 text-left font-semibold text-gray-700 dark:bg-gray-800 dark:text-white"
+					>AM</th
+				>
+			</tr>
+			{#if scheduleData.amTimes.length === 0}
 				<tr>
 					<td colspan="2" class="border px-6 py-3 text-center text-gray-500 dark:border-gray-700">
-						{$isLoading ? '' : $t('schedule_for_stop.no_schedules_available')}
+						{$isLoading ? '' : $t('schedule_for_stop.no_am_schedules_available')}
 					</td>
 				</tr>
 			{:else}
-				{#each scheduleData.times as [hour, times]}
-					<tr class="hover:bg-gray-100 dark:hover:bg-gray-800">
-						<th
-							scope="row"
+				{#each scheduleData.amTimes as [hour, times]}
+					<tr class="hover:bg-gray-100 dark:hover:bg-gray-900">
+						<td
 							class="border px-6 py-3 text-center text-lg font-semibold dark:border-gray-700 dark:text-white"
 							title="Full Time: {hour}:{extractMinutes(times[0].arrivalTime)}"
 						>
 							{convert24HourTo12Hour(hour)}
-							<span class="text-sm text-gray-600 dark:text-gray-100"
-								>{Number(hour) < 12 ? 'AM' : 'PM'}</span
-							>
-						</th>
+							<span class="text-sm text-gray-600 dark:text-gray-100">AM</span>
+						</td>
+						<td
+							class="flex items-start gap-3 border px-6 py-3 text-lg dark:border-gray-700 dark:text-white"
+						>
+							{#each times as stopTime, index (index)}
+								{#if stopTime.isShortLine}
+									<span
+										class="inline-flex items-center gap-1.5 rounded-md border border-amber-300 bg-amber-50 px-2 py-1 text-sm font-semibold text-amber-950 shadow-sm dark:border-amber-700 dark:bg-amber-950/50 dark:text-amber-100"
+										data-short-line="true"
+									>
+										<span>{extractMinutes(stopTime.arrivalTime)}</span>
+										<span
+											class="border-l border-amber-300 pl-1.5 text-xs font-medium dark:border-amber-700"
+										>
+											{$isLoading
+												? ''
+												: $t('schedule_for_stop.short_line_to', {
+														values: { destination: stopTime.destination }
+													})}
+										</span>
+									</span>
+								{:else}
+									<span class="rounded bg-gray-50 px-2 py-1 dark:bg-gray-800">
+										{extractMinutes(stopTime.arrivalTime)}
+									</span>
+								{/if}
+							{/each}
+						</td>
+					</tr>
+				{/each}
+			{/if}
+		</tbody>
+		<tbody>
+			<tr class="bg-gray-50 hover:bg-gray-100 dark:hover:bg-gray-900">
+				<th
+					colspan="2"
+					scope="rowgroup"
+					class="px-6 py-3 text-left font-semibold text-gray-700 dark:bg-gray-800 dark:text-white"
+					>PM</th
+				>
+			</tr>
+			{#if scheduleData.pmTimes.length === 0}
+				<tr>
+					<td colspan="2" class="border px-6 py-3 text-center text-gray-500">
+						{$isLoading ? '' : $t('schedule_for_stop.no_pm_schedules_available')}
+					</td>
+				</tr>
+			{:else}
+				{#each scheduleData.pmTimes as [hour, times]}
+					<tr class="hover:bg-gray-100 dark:hover:bg-gray-800">
+						<td
+							class="border px-6 py-3 text-center text-lg font-semibold dark:border-gray-700 dark:text-white"
+							title="Full Time: {hour}:{extractMinutes(times[0].arrivalTime)}"
+						>
+							{convert24HourTo12Hour(hour)}
+							<span class="text-sm text-gray-600 dark:text-gray-100">PM</span>
+						</td>
 						<td
 							class="flex items-start gap-3 border px-6 py-3 text-lg dark:border-gray-700 dark:text-white"
 						>

--- a/src/components/schedule-for-stop/RouteScheduleTable.svelte
+++ b/src/components/schedule-for-stop/RouteScheduleTable.svelte
@@ -16,14 +16,10 @@
 	);
 
 	function renderScheduleTable(schedule) {
-		const stopTimes = Object.entries(schedule.stopTimes);
-
-		const amTimes = stopTimes.filter(([hour]) => +hour < 12);
-		const pmTimes = stopTimes.filter(([hour]) => +hour >= 12);
-
 		return {
-			amTimes,
-			pmTimes
+			times: Object.entries(schedule.stopTimes).sort(
+				([firstHour], [secondHour]) => Number(firstHour) - Number(secondHour)
+			)
 		};
 	}
 
@@ -69,86 +65,25 @@
 			</tr>
 		</thead>
 		<tbody>
-			<tr class="bg-gray-50 hover:bg-gray-100 dark:hover:bg-gray-600">
-				<th
-					colspan="2"
-					scope="rowgroup"
-					class="px-6 py-3 text-left font-semibold text-gray-700 dark:bg-gray-800 dark:text-white"
-					>AM</th
-				>
-			</tr>
-			{#if scheduleData.amTimes.length === 0}
+			{#if scheduleData.times.length === 0}
 				<tr>
 					<td colspan="2" class="border px-6 py-3 text-center text-gray-500 dark:border-gray-700">
-						{$isLoading ? '' : $t('schedule_for_stop.no_am_schedules_available')}
+						{$isLoading ? '' : $t('schedule_for_stop.no_schedules_available')}
 					</td>
 				</tr>
 			{:else}
-				{#each scheduleData.amTimes as [hour, times]}
-					<tr class="hover:bg-gray-100 dark:hover:bg-gray-900">
-						<td
-							class="border px-6 py-3 text-center text-lg font-semibold dark:border-gray-700 dark:text-white"
-							title="Full Time: {hour}:{extractMinutes(times[0].arrivalTime)}"
-						>
-							{convert24HourTo12Hour(hour)}
-							<span class="text-sm text-gray-600 dark:text-gray-100">AM</span>
-						</td>
-						<td
-							class="flex items-start gap-3 border px-6 py-3 text-lg dark:border-gray-700 dark:text-white"
-						>
-							{#each times as stopTime, index (index)}
-								{#if stopTime.isShortLine}
-									<span
-										class="inline-flex items-center gap-1.5 rounded-md border border-amber-300 bg-amber-50 px-2 py-1 text-sm font-semibold text-amber-950 shadow-sm dark:border-amber-700 dark:bg-amber-950/50 dark:text-amber-100"
-										data-short-line="true"
-									>
-										<span>{extractMinutes(stopTime.arrivalTime)}</span>
-										<span
-											class="border-l border-amber-300 pl-1.5 text-xs font-medium dark:border-amber-700"
-										>
-											{$isLoading
-												? ''
-												: $t('schedule_for_stop.short_line_to', {
-														values: { destination: stopTime.destination }
-													})}
-										</span>
-									</span>
-								{:else}
-									<span class="rounded bg-gray-50 px-2 py-1 dark:bg-gray-800">
-										{extractMinutes(stopTime.arrivalTime)}
-									</span>
-								{/if}
-							{/each}
-						</td>
-					</tr>
-				{/each}
-			{/if}
-		</tbody>
-		<tbody>
-			<tr class="bg-gray-50 hover:bg-gray-100 dark:hover:bg-gray-900">
-				<th
-					colspan="2"
-					scope="rowgroup"
-					class="px-6 py-3 text-left font-semibold text-gray-700 dark:bg-gray-800 dark:text-white"
-					>PM</th
-				>
-			</tr>
-			{#if scheduleData.pmTimes.length === 0}
-				<tr>
-					<td colspan="2" class="border px-6 py-3 text-center text-gray-500">
-						{$isLoading ? '' : $t('schedule_for_stop.no_pm_schedules_available')}
-					</td>
-				</tr>
-			{:else}
-				{#each scheduleData.pmTimes as [hour, times]}
+				{#each scheduleData.times as [hour, times]}
 					<tr class="hover:bg-gray-100 dark:hover:bg-gray-800">
-						<td
+						<th
+							scope="row"
 							class="border px-6 py-3 text-center text-lg font-semibold dark:border-gray-700 dark:text-white"
 							title="Full Time: {hour}:{extractMinutes(times[0].arrivalTime)}"
 						>
 							{convert24HourTo12Hour(hour)}
-							<span class="text-sm text-gray-600 dark:text-gray-100">PM</span>
-						</td>
+							<span class="text-sm text-gray-600 dark:text-gray-100"
+								>{Number(hour) < 12 ? 'AM' : 'PM'}</span
+							>
+						</th>
 						<td
 							class="flex items-start gap-3 border px-6 py-3 text-lg dark:border-gray-700 dark:text-white"
 						>

--- a/src/components/schedule-for-stop/RouteScheduleTable.svelte
+++ b/src/components/schedule-for-stop/RouteScheduleTable.svelte
@@ -28,7 +28,7 @@
 	}
 
 	function extractMinutes(arrivalTime) {
-		return arrivalTime.replace(/[AP]M/, '').split(':')[1];
+		return arrivalTime.replace(/[AP]M/i, '').split(':')[1];
 	}
 </script>
 

--- a/src/components/schedule-for-stop/RouteScheduleTable.svelte
+++ b/src/components/schedule-for-stop/RouteScheduleTable.svelte
@@ -9,6 +9,11 @@
 	const captionId = `schedule-table-caption-${crypto.randomUUID()}`;
 
 	let scheduleData = $derived(renderScheduleTable(schedule));
+	let hasShortLines = $derived(
+		Object.values(schedule.stopTimes).some((times) =>
+			times.some((stopTime) => stopTime.isShortLine)
+		)
+	);
 
 	function renderScheduleTable(schedule) {
 		const stopTimes = Object.entries(schedule.stopTimes);
@@ -31,6 +36,18 @@
 	scrollable schedule table; role="region" + aria-labelledby name it via the caption. -->
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <div role="region" tabindex="0" aria-labelledby={captionId} class="overflow-x-auto dark:bg-black">
+	{#if hasShortLines}
+		<p
+			class="mt-4 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-100"
+		>
+			<span
+				class="mt-0.5 shrink-0 rounded bg-amber-200 px-1.5 py-0.5 text-xs font-bold uppercase tracking-wide text-amber-950 dark:bg-amber-800 dark:text-amber-50"
+			>
+				{$isLoading ? '' : $t('schedule_for_stop.short_line')}
+			</span>
+			<span>{$isLoading ? '' : $t('schedule_for_stop.short_line_notice')}</span>
+		</p>
+	{/if}
 	<table
 		class="mt-4 w-full table-auto rounded-lg border border-gray-200 shadow-lg dark:border-gray-700 dark:bg-black"
 	>
@@ -80,9 +97,27 @@
 							class="flex items-start gap-3 border px-6 py-3 text-lg dark:border-gray-700 dark:text-white"
 						>
 							{#each times as stopTime, index (index)}
-								<span class="rounded bg-gray-50 px-2 dark:bg-gray-800">
-									{extractMinutes(stopTime.arrivalTime)}
-								</span>
+								{#if stopTime.isShortLine}
+									<span
+										class="inline-flex items-center gap-1.5 rounded-md border border-amber-300 bg-amber-50 px-2 py-1 text-sm font-semibold text-amber-950 shadow-sm dark:border-amber-700 dark:bg-amber-950/50 dark:text-amber-100"
+										data-short-line="true"
+									>
+										<span>{extractMinutes(stopTime.arrivalTime)}</span>
+										<span
+											class="border-l border-amber-300 pl-1.5 text-xs font-medium dark:border-amber-700"
+										>
+											{$isLoading
+												? ''
+												: $t('schedule_for_stop.short_line_to', {
+														values: { destination: stopTime.destination }
+													})}
+										</span>
+									</span>
+								{:else}
+									<span class="rounded bg-gray-50 px-2 py-1 dark:bg-gray-800">
+										{extractMinutes(stopTime.arrivalTime)}
+									</span>
+								{/if}
 							{/each}
 						</td>
 					</tr>
@@ -118,9 +153,27 @@
 							class="flex items-start gap-3 border px-6 py-3 text-lg dark:border-gray-700 dark:text-white"
 						>
 							{#each times as stopTime, index (index)}
-								<span class="rounded bg-gray-50 px-2 dark:bg-gray-800">
-									{extractMinutes(stopTime.arrivalTime)}
-								</span>
+								{#if stopTime.isShortLine}
+									<span
+										class="inline-flex items-center gap-1.5 rounded-md border border-amber-300 bg-amber-50 px-2 py-1 text-sm font-semibold text-amber-950 shadow-sm dark:border-amber-700 dark:bg-amber-950/50 dark:text-amber-100"
+										data-short-line="true"
+									>
+										<span>{extractMinutes(stopTime.arrivalTime)}</span>
+										<span
+											class="border-l border-amber-300 pl-1.5 text-xs font-medium dark:border-amber-700"
+										>
+											{$isLoading
+												? ''
+												: $t('schedule_for_stop.short_line_to', {
+														values: { destination: stopTime.destination }
+													})}
+										</span>
+									</span>
+								{:else}
+									<span class="rounded bg-gray-50 px-2 py-1 dark:bg-gray-800">
+										{extractMinutes(stopTime.arrivalTime)}
+									</span>
+								{/if}
 							{/each}
 						</td>
 					</tr>

--- a/src/components/schedule-for-stop/__tests__/RouteScheduleTable.test.js
+++ b/src/components/schedule-for-stop/__tests__/RouteScheduleTable.test.js
@@ -89,16 +89,11 @@ describe('RouteScheduleTable accessibility', () => {
 		expect(secondRegion).toHaveAttribute('aria-labelledby', secondCaption.id);
 	});
 
-	test('uses each hour as its row header without redundant AM and PM section rows', () => {
+	test('groups schedules into AM and PM row groups', () => {
 		render(RouteScheduleTable, { props: { schedule } });
 
-		const amHour = screen.getByRole('rowheader', { name: '8 AM' });
-		const pmHour = screen.getByRole('rowheader', { name: '3 PM' });
-
-		expect(amHour).toHaveAttribute('scope', 'row');
-		expect(pmHour).toHaveAttribute('scope', 'row');
-		expect(screen.queryByRole('rowheader', { name: 'AM' })).not.toBeInTheDocument();
-		expect(screen.queryByRole('rowheader', { name: 'PM' })).not.toBeInTheDocument();
+		expect(screen.getByRole('rowheader', { name: 'AM' })).toHaveAttribute('scope', 'rowgroup');
+		expect(screen.getByRole('rowheader', { name: 'PM' })).toHaveAttribute('scope', 'rowgroup');
 	});
 
 	test('column headers use scope="col"', () => {
@@ -116,7 +111,8 @@ describe('RouteScheduleTable accessibility', () => {
 			props: { schedule: { tripHeadsign: 'Empty Route', stopTimes: {} } }
 		});
 
-		expect(screen.getByText('No schedules available for the selected date.')).toBeInTheDocument();
+		expect(screen.getByText('No AM schedules available')).toBeInTheDocument();
+		expect(screen.getByText('No PM schedules available')).toBeInTheDocument();
 	});
 });
 
@@ -165,25 +161,6 @@ describe('RouteScheduleTable content', () => {
 		expect(pmMinutesCell).toHaveTextContent('10');
 	});
 
-	test('removes lowercase am and pm suffixes from minute chips', () => {
-		render(RouteScheduleTable, {
-			props: {
-				schedule: {
-					tripHeadsign: 'Lowercase meridiem',
-					stopTimes: {
-						8: [{ arrivalTime: '8:05am' }],
-						15: [{ arrivalTime: '3:10pm' }]
-					}
-				}
-			}
-		});
-
-		expect(screen.getByTitle('Full Time: 8:05')).toHaveTextContent('8');
-		expect(screen.getByTitle('Full Time: 15:10')).toHaveTextContent('3');
-		expect(screen.queryByText(/05 am/i)).not.toBeInTheDocument();
-		expect(screen.queryByText(/10 pm/i)).not.toBeInTheDocument();
-	});
-
 	test('clearly identifies short-line trips with their destination', () => {
 		render(RouteScheduleTable, {
 			props: {
@@ -209,6 +186,5 @@ describe('RouteScheduleTable content', () => {
 		const shortLine = screen.getByText('Short line to Fashion Valley').closest('[data-short-line]');
 		expect(shortLine).toHaveTextContent('25');
 		expect(shortLine).toHaveAttribute('data-short-line', 'true');
-		expect(screen.queryByText('Short line to Kearny Mesa')).not.toBeInTheDocument();
 	});
 });

--- a/src/components/schedule-for-stop/__tests__/RouteScheduleTable.test.js
+++ b/src/components/schedule-for-stop/__tests__/RouteScheduleTable.test.js
@@ -14,6 +14,8 @@ vi.mock('svelte-i18n', () => ({
 					'schedule_for_stop.minutes': 'Minutes',
 					'schedule_for_stop.no_am_schedules_available': 'No AM schedules available',
 					'schedule_for_stop.no_pm_schedules_available': 'No PM schedules available',
+					'schedule_for_stop.no_schedules_available':
+						'No schedules available for the selected date.',
 					'schedule_for_stop.schedule_table_caption': `Departure times for ${options?.values?.route ?? ''}`,
 					'schedule_for_stop.short_line': 'Short line',
 					'schedule_for_stop.short_line_to': `Short line to ${options?.values?.destination ?? ''}`,
@@ -87,16 +89,16 @@ describe('RouteScheduleTable accessibility', () => {
 		expect(secondRegion).toHaveAttribute('aria-labelledby', secondCaption.id);
 	});
 
-	test('AM and PM section rows are header cells with rowgroup scope', () => {
+	test('uses each hour as its row header without redundant AM and PM section rows', () => {
 		render(RouteScheduleTable, { props: { schedule } });
 
-		const amHeader = screen.getByRole('rowheader', { name: 'AM' });
-		const pmHeader = screen.getByRole('rowheader', { name: 'PM' });
+		const amHour = screen.getByRole('rowheader', { name: '8 AM' });
+		const pmHour = screen.getByRole('rowheader', { name: '3 PM' });
 
-		expect(amHeader.tagName).toBe('TH');
-		expect(amHeader).toHaveAttribute('scope', 'rowgroup');
-		expect(pmHeader.tagName).toBe('TH');
-		expect(pmHeader).toHaveAttribute('scope', 'rowgroup');
+		expect(amHour).toHaveAttribute('scope', 'row');
+		expect(pmHour).toHaveAttribute('scope', 'row');
+		expect(screen.queryByRole('rowheader', { name: 'AM' })).not.toBeInTheDocument();
+		expect(screen.queryByRole('rowheader', { name: 'PM' })).not.toBeInTheDocument();
 	});
 
 	test('column headers use scope="col"', () => {
@@ -109,13 +111,12 @@ describe('RouteScheduleTable accessibility', () => {
 		expect(minutesHeader).toHaveAttribute('scope', 'col');
 	});
 
-	test('renders empty-state messaging when a section has no times', () => {
+	test('renders empty-state messaging when no times are available', () => {
 		render(RouteScheduleTable, {
 			props: { schedule: { tripHeadsign: 'Empty Route', stopTimes: {} } }
 		});
 
-		expect(screen.getByText('No AM schedules available')).toBeInTheDocument();
-		expect(screen.getByText('No PM schedules available')).toBeInTheDocument();
+		expect(screen.getByText('No schedules available for the selected date.')).toBeInTheDocument();
 	});
 });
 

--- a/src/components/schedule-for-stop/__tests__/RouteScheduleTable.test.js
+++ b/src/components/schedule-for-stop/__tests__/RouteScheduleTable.test.js
@@ -164,6 +164,25 @@ describe('RouteScheduleTable content', () => {
 		expect(pmMinutesCell).toHaveTextContent('10');
 	});
 
+	test('removes lowercase am and pm suffixes from minute chips', () => {
+		render(RouteScheduleTable, {
+			props: {
+				schedule: {
+					tripHeadsign: 'Lowercase meridiem',
+					stopTimes: {
+						8: [{ arrivalTime: '8:05am' }],
+						15: [{ arrivalTime: '3:10pm' }]
+					}
+				}
+			}
+		});
+
+		expect(screen.getByTitle('Full Time: 8:05')).toHaveTextContent('8');
+		expect(screen.getByTitle('Full Time: 15:10')).toHaveTextContent('3');
+		expect(screen.queryByText(/05 am/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/10 pm/i)).not.toBeInTheDocument();
+	});
+
 	test('clearly identifies short-line trips with their destination', () => {
 		render(RouteScheduleTable, {
 			props: {

--- a/src/components/schedule-for-stop/__tests__/RouteScheduleTable.test.js
+++ b/src/components/schedule-for-stop/__tests__/RouteScheduleTable.test.js
@@ -14,7 +14,11 @@ vi.mock('svelte-i18n', () => ({
 					'schedule_for_stop.minutes': 'Minutes',
 					'schedule_for_stop.no_am_schedules_available': 'No AM schedules available',
 					'schedule_for_stop.no_pm_schedules_available': 'No PM schedules available',
-					'schedule_for_stop.schedule_table_caption': `Departure times for ${options?.values?.route ?? ''}`
+					'schedule_for_stop.schedule_table_caption': `Departure times for ${options?.values?.route ?? ''}`,
+					'schedule_for_stop.short_line': 'Short line',
+					'schedule_for_stop.short_line_to': `Short line to ${options?.values?.destination ?? ''}`,
+					'schedule_for_stop.short_line_notice':
+						'Trips marked Short line end before the route’s usual destination.'
 				};
 				return translations[key] ?? key;
 			});
@@ -158,5 +162,33 @@ describe('RouteScheduleTable content', () => {
 
 		const pmMinutesCell = pmHourCell.closest('tr')?.querySelector('td:last-child');
 		expect(pmMinutesCell).toHaveTextContent('10');
+	});
+
+	test('clearly identifies short-line trips with their destination', () => {
+		render(RouteScheduleTable, {
+			props: {
+				schedule: {
+					tripHeadsign: '120 - Kearny Mesa',
+					stopTimes: {
+						8: [
+							{ arrivalTime: '8:05AM' },
+							{
+								arrivalTime: '8:25AM',
+								isShortLine: true,
+								destination: 'Fashion Valley'
+							}
+						]
+					}
+				}
+			}
+		});
+
+		expect(
+			screen.getByText('Trips marked Short line end before the route’s usual destination.')
+		).toBeInTheDocument();
+		const shortLine = screen.getByText('Short line to Fashion Valley').closest('[data-short-line]');
+		expect(shortLine).toHaveTextContent('25');
+		expect(shortLine).toHaveAttribute('data-short-line', 'true');
+		expect(screen.queryByText('Short line to Kearny Mesa')).not.toBeInTheDocument();
 	});
 });

--- a/src/components/schedule-for-stop/__tests__/RouteScheduleTable.test.js
+++ b/src/components/schedule-for-stop/__tests__/RouteScheduleTable.test.js
@@ -92,8 +92,12 @@ describe('RouteScheduleTable accessibility', () => {
 	test('groups schedules into AM and PM row groups', () => {
 		render(RouteScheduleTable, { props: { schedule } });
 
-		expect(screen.getByRole('rowheader', { name: 'AM' })).toHaveAttribute('scope', 'rowgroup');
-		expect(screen.getByRole('rowheader', { name: 'PM' })).toHaveAttribute('scope', 'rowgroup');
+		const amHeader = screen.getByRole('rowheader', { name: 'AM' });
+		const pmHeader = screen.getByRole('rowheader', { name: 'PM' });
+		expect(amHeader.tagName).toBe('TH');
+		expect(pmHeader.tagName).toBe('TH');
+		expect(amHeader).toHaveAttribute('scope', 'rowgroup');
+		expect(pmHeader).toHaveAttribute('scope', 'rowgroup');
 	});
 
 	test('column headers use scope="col"', () => {

--- a/src/lib/__tests__/scheduleForStop.test.js
+++ b/src/lib/__tests__/scheduleForStop.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { groupStopTimesByHour } from '$lib/scheduleForStop.js';
+
+describe('groupStopTimesByHour', () => {
+	it('uses the per-trip headsign when schedule-for-stop omits stopHeadsign', () => {
+		const grouped = groupStopTimesByHour(
+			[
+				{
+					arrivalTime: new Date('2026-08-24T08:05:00').getTime(),
+					stopHeadsign: '',
+					tripHeadsign: 'Kearny Mesa'
+				},
+				{
+					arrivalTime: new Date('2026-08-24T08:25:00').getTime(),
+					stopHeadsign: '',
+					tripHeadsign: 'Fashion Valley'
+				}
+			],
+			'Kearny Mesa'
+		);
+
+		expect(grouped[8]).toEqual([
+			{ arrivalTime: '8:05 AM', destination: 'Kearny Mesa', isShortLine: false },
+			{ arrivalTime: '8:25 AM', destination: 'Fashion Valley', isShortLine: true }
+		]);
+	});
+
+	it('does not mark a trip as short when its per-trip headsign matches the direction', () => {
+		const grouped = groupStopTimesByHour(
+			[
+				{
+					arrivalTime: new Date('2026-08-24T08:05:00').getTime(),
+					tripHeadsign: 'Kearny Mesa'
+				}
+			],
+			'Kearny Mesa'
+		);
+
+		expect(grouped[8][0]).toMatchObject({ isShortLine: false, destination: 'Kearny Mesa' });
+	});
+});

--- a/src/lib/scheduleForStop.js
+++ b/src/lib/scheduleForStop.js
@@ -1,0 +1,25 @@
+import { msToTimeString } from '$lib/dateTimeFormat.js';
+
+/**
+ * Arrange a direction's stop times for the schedule table and flag trips that
+ * end before the direction's normal destination.
+ *
+ * `stopHeadsign` is not populated by OBA's schedule-for-stop endpoint. The
+ * route handler adds the per-trip `tripHeadsign` from schedule-for-route.
+ */
+export function groupStopTimesByHour(stopTimes, directionHeadsign) {
+	const grouped = {};
+	for (const stopTime of stopTimes) {
+		const hour = new Date(stopTime.arrivalTime).getHours();
+		if (!grouped[hour]) grouped[hour] = [];
+
+		const destination = stopTime.tripHeadsign?.trim() || directionHeadsign;
+		grouped[hour].push({
+			arrivalTime: msToTimeString(stopTime.arrivalTime),
+			destination,
+			isShortLine: destination !== directionHeadsign
+		});
+	}
+
+	return grouped;
+}

--- a/src/lib/server/tripHeadsigns.js
+++ b/src/lib/server/tripHeadsigns.js
@@ -6,8 +6,8 @@ const CACHE_TTL = 24 * 60 * 60 * 1000;
 const MAX_CACHE_ENTRIES = 100;
 const cache = new Map();
 
-async function fetchTripHeadsigns(routeId, queryParams) {
-	const response = await oba.scheduleForRoute.retrieve(routeId, queryParams);
+async function fetchTripHeadsigns(routeId, date) {
+	const response = await oba.scheduleForRoute.retrieve(routeId, { date });
 	const trips = response?.data?.references?.trips;
 	if (response?.code !== 200 || !Array.isArray(trips)) {
 		throw new Error('Invalid schedule-for-route response');
@@ -22,12 +22,11 @@ async function fetchTripHeadsigns(routeId, queryParams) {
 	);
 }
 
-export function getTripHeadsigns(routeId, queryParams, scheduleDate) {
-	// Use the upstream service date for requests without an explicit date, never
-	// a persistent "today" key that could return yesterday's trips after midnight.
-	const date = queryParams.date || scheduleDate;
-	if (date == null) return fetchTripHeadsigns(routeId, queryParams);
-
+/**
+ * Reuse route headsigns for the explicit YYYY-MM-DD service date used by the
+ * stop request. The caller resolves undated requests in the region's timezone.
+ */
+export function getTripHeadsigns(routeId, date) {
 	const key = JSON.stringify([routeId, date]);
 	const now = Date.now();
 	for (const [cacheKey, entry] of cache) {
@@ -43,7 +42,7 @@ export function getTripHeadsigns(routeId, queryParams, scheduleDate) {
 	while (cache.size >= MAX_CACHE_ENTRIES) cache.delete(cache.keys().next().value);
 	const entry = { expiresAt: now + CACHE_TTL, promise: null };
 	// Cache the promise too, so simultaneous requests for nearby stops share work.
-	entry.promise = fetchTripHeadsigns(routeId, queryParams).catch((error) => {
+	entry.promise = fetchTripHeadsigns(routeId, date).catch((error) => {
 		if (cache.get(key) === entry) cache.delete(key);
 		throw error;
 	});

--- a/src/lib/server/tripHeadsigns.js
+++ b/src/lib/server/tripHeadsigns.js
@@ -1,0 +1,52 @@
+import oba from '$lib/obaSdk';
+
+// Per-process cache: keep only headsigns, not the multi-megabyte route schedules.
+// A service day's schedule is static; expiry also allows feed corrections through.
+const CACHE_TTL = 24 * 60 * 60 * 1000;
+const MAX_CACHE_ENTRIES = 100;
+const cache = new Map();
+
+async function fetchTripHeadsigns(routeId, queryParams) {
+	const response = await oba.scheduleForRoute.retrieve(routeId, queryParams);
+	const trips = response?.data?.references?.trips;
+	if (response?.code !== 200 || !Array.isArray(trips)) {
+		throw new Error('Invalid schedule-for-route response');
+	}
+
+	return new Map(
+		trips.flatMap((trip) =>
+			trip?.id && typeof trip.tripHeadsign === 'string' && trip.tripHeadsign.trim()
+				? [[trip.id, trip.tripHeadsign.trim()]]
+				: []
+		)
+	);
+}
+
+export function getTripHeadsigns(routeId, queryParams, scheduleDate) {
+	// Use the upstream service date for requests without an explicit date, never
+	// a persistent "today" key that could return yesterday's trips after midnight.
+	const date = queryParams.date || scheduleDate;
+	if (date == null) return fetchTripHeadsigns(routeId, queryParams);
+
+	const key = JSON.stringify([routeId, date]);
+	const now = Date.now();
+	for (const [cacheKey, entry] of cache) {
+		if (entry.expiresAt <= now) cache.delete(cacheKey);
+	}
+	const cached = cache.get(key);
+	if (cached) {
+		cache.delete(key);
+		cache.set(key, cached);
+		return cached.promise;
+	}
+
+	while (cache.size >= MAX_CACHE_ENTRIES) cache.delete(cache.keys().next().value);
+	const entry = { expiresAt: now + CACHE_TTL, promise: null };
+	// Cache the promise too, so simultaneous requests for nearby stops share work.
+	entry.promise = fetchTripHeadsigns(routeId, queryParams).catch((error) => {
+		if (cache.get(key) === entry) cache.delete(key);
+		throw error;
+	});
+	cache.set(key, entry);
+	return entry.promise;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -192,9 +192,7 @@
 		"schedule_table_caption": "Departure times for {route}",
 		"short_line": "Short line",
 		"short_line_to": "Short line to {destination}",
-		"short_line_notice": "Trips marked Short line end before the route's usual destination.",
-		"unable_to_load_schedule": "We couldn't load this schedule. Please try again.",
-		"retry": "Try again"
+		"short_line_notice": "Trips marked Short line end before the route's usual destination."
 	},
 	"direction": {
 		"N": "North",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -189,7 +189,12 @@
 		"no_schedules_available": "No schedules available for the selected date.",
 		"stop_id": "Stop ID",
 		"direction": "Direction",
-		"schedule_table_caption": "Departure times for {route}"
+		"schedule_table_caption": "Departure times for {route}",
+		"short_line": "Short line",
+		"short_line_to": "Short line to {destination}",
+		"short_line_notice": "Trips marked Short line end before the route's usual destination.",
+		"unable_to_load_schedule": "We couldn't load this schedule. Please try again.",
+		"retry": "Try again"
 	},
 	"direction": {
 		"N": "North",

--- a/src/routes/api/oba/schedule-for-stop/[stopId]/+server.js
+++ b/src/routes/api/oba/schedule-for-stop/[stopId]/+server.js
@@ -13,7 +13,7 @@ export async function GET({ url, params }) {
 
 	const response = await oba.scheduleForStop.retrieve(stopId, queryParams);
 
-	if (response.data?.entry?.stopRouteSchedules) {
+	if (response?.data?.entry?.stopRouteSchedules) {
 		response.data.entry.stopRouteSchedules = filterByRouteId(
 			response.data.entry.stopRouteSchedules,
 			getAgencyFilter()

--- a/src/routes/api/oba/schedule-for-stop/[stopId]/+server.js
+++ b/src/routes/api/oba/schedule-for-stop/[stopId]/+server.js
@@ -13,12 +13,51 @@ export async function GET({ url, params }) {
 
 	const response = await oba.scheduleForStop.retrieve(stopId, queryParams);
 
-	if (response?.data?.entry?.stopRouteSchedules) {
-		response.data.entry.stopRouteSchedules = filterByRouteId(
+	if (response.data?.entry?.stopRouteSchedules) {
+		const routeSchedules = filterByRouteId(
 			response.data.entry.stopRouteSchedules,
 			getAgencyFilter()
 		);
+		response.data.entry.stopRouteSchedules = routeSchedules;
+		await addTripHeadsigns(routeSchedules, queryParams);
 	}
 
 	return handleOBAResponse(response, 'stop-for-schedule');
+}
+
+async function addTripHeadsigns(routeSchedules, queryParams) {
+	const routeSchedulesWithMultipleTrips = routeSchedules.filter((routeSchedule) =>
+		routeSchedule.stopRouteDirectionSchedules.some(
+			(directionSchedule) =>
+				new Set(directionSchedule.scheduleStopTimes.map(({ tripId }) => tripId)).size > 1
+		)
+	);
+
+	const routeResponses = await Promise.all(
+		routeSchedulesWithMultipleTrips.map(async ({ routeId }) => {
+			try {
+				return await oba.scheduleForRoute.retrieve(routeId, queryParams);
+			} catch (error) {
+				console.error(`Unable to load trip headsigns for route ${routeId}:`, error);
+				return null;
+			}
+		})
+	);
+
+	const tripHeadsigns = new Map(
+		routeResponses.flatMap((routeResponse) =>
+			(routeResponse?.data?.entry?.trips ?? []).flatMap(({ id, tripHeadsign }) =>
+				tripHeadsign ? [[id, tripHeadsign]] : []
+			)
+		)
+	);
+
+	for (const routeSchedule of routeSchedulesWithMultipleTrips) {
+		for (const directionSchedule of routeSchedule.stopRouteDirectionSchedules) {
+			for (const stopTime of directionSchedule.scheduleStopTimes) {
+				const tripHeadsign = tripHeadsigns.get(stopTime.tripId);
+				if (tripHeadsign) stopTime.tripHeadsign = tripHeadsign;
+			}
+		}
+	}
 }

--- a/src/routes/api/oba/schedule-for-stop/[stopId]/+server.js
+++ b/src/routes/api/oba/schedule-for-stop/[stopId]/+server.js
@@ -1,3 +1,5 @@
+import { env } from '$env/dynamic/public';
+import { getTodayDateForInput } from '$lib/dateTimeInput.js';
 import oba, { handleOBAResponse } from '$lib/obaSdk';
 import { getTripHeadsigns } from '$lib/server/tripHeadsigns.js';
 import { getAgencyFilter, filterByRouteId } from '$lib/agencyFilter.js';
@@ -5,12 +7,10 @@ import { getAgencyFilter, filterByRouteId } from '$lib/agencyFilter.js';
 /** @type {import('./$types').RequestHandler} */
 export async function GET({ url, params }) {
 	const stopId = params.stopId;
-	const date = url.searchParams.get('date');
-
-	let queryParams = {};
-	if (date) {
-		queryParams.date = date;
-	}
+	// Resolve once before either upstream call, including requests crossing midnight.
+	// An undated stop response's entry.date is wall-clock time, not a service-day key.
+	const date = url.searchParams.get('date') || getTodayDateForInput(env.PUBLIC_OBA_TIMEZONE);
+	const queryParams = { date };
 
 	const response = await oba.scheduleForStop.retrieve(stopId, queryParams);
 
@@ -20,13 +20,13 @@ export async function GET({ url, params }) {
 			getAgencyFilter()
 		);
 		response.data.entry.stopRouteSchedules = routeSchedules;
-		await addTripHeadsigns(routeSchedules, queryParams, response.data.entry.scheduleDate);
+		await addTripHeadsigns(routeSchedules, date);
 	}
 
 	return handleOBAResponse(response, 'stop-for-schedule');
 }
 
-async function addTripHeadsigns(routeSchedules, queryParams, scheduleDate) {
+async function addTripHeadsigns(routeSchedules, date) {
 	await Promise.all(
 		routeSchedules.map(async (routeSchedule) => {
 			const directions = routeSchedule?.stopRouteDirectionSchedules;
@@ -43,11 +43,7 @@ async function addTripHeadsigns(routeSchedules, queryParams, scheduleDate) {
 			}
 
 			try {
-				const tripHeadsigns = await getTripHeadsigns(
-					routeSchedule.routeId,
-					queryParams,
-					scheduleDate
-				);
+				const tripHeadsigns = await getTripHeadsigns(routeSchedule.routeId, date);
 				for (const stopTime of stopTimesByDirection.flat()) {
 					const tripHeadsign = tripHeadsigns.get(stopTime.tripId);
 					if (tripHeadsign) stopTime.tripHeadsign = tripHeadsign;

--- a/src/routes/api/oba/schedule-for-stop/[stopId]/+server.js
+++ b/src/routes/api/oba/schedule-for-stop/[stopId]/+server.js
@@ -1,4 +1,5 @@
 import oba, { handleOBAResponse } from '$lib/obaSdk';
+import { getTripHeadsigns } from '$lib/server/tripHeadsigns.js';
 import { getAgencyFilter, filterByRouteId } from '$lib/agencyFilter.js';
 
 /** @type {import('./$types').RequestHandler} */
@@ -19,45 +20,41 @@ export async function GET({ url, params }) {
 			getAgencyFilter()
 		);
 		response.data.entry.stopRouteSchedules = routeSchedules;
-		await addTripHeadsigns(routeSchedules, queryParams);
+		await addTripHeadsigns(routeSchedules, queryParams, response.data.entry.scheduleDate);
 	}
 
 	return handleOBAResponse(response, 'stop-for-schedule');
 }
 
-async function addTripHeadsigns(routeSchedules, queryParams) {
-	const routeSchedulesWithMultipleTrips = routeSchedules.filter((routeSchedule) =>
-		routeSchedule.stopRouteDirectionSchedules.some(
-			(directionSchedule) =>
-				new Set(directionSchedule.scheduleStopTimes.map(({ tripId }) => tripId)).size > 1
-		)
-	);
+async function addTripHeadsigns(routeSchedules, queryParams, scheduleDate) {
+	await Promise.all(
+		routeSchedules.map(async (routeSchedule) => {
+			const directions = routeSchedule?.stopRouteDirectionSchedules;
+			if (!routeSchedule?.routeId || !Array.isArray(directions)) return;
+			const stopTimesByDirection = directions.map((direction) =>
+				Array.isArray(direction?.scheduleStopTimes)
+					? direction.scheduleStopTimes.filter((stopTime) => stopTime?.tripId)
+					: []
+			);
+			if (
+				!stopTimesByDirection.some((times) => new Set(times.map((time) => time.tripId)).size > 1)
+			) {
+				return;
+			}
 
-	const routeResponses = await Promise.all(
-		routeSchedulesWithMultipleTrips.map(async ({ routeId }) => {
 			try {
-				return await oba.scheduleForRoute.retrieve(routeId, queryParams);
+				const tripHeadsigns = await getTripHeadsigns(
+					routeSchedule.routeId,
+					queryParams,
+					scheduleDate
+				);
+				for (const stopTime of stopTimesByDirection.flat()) {
+					const tripHeadsign = tripHeadsigns.get(stopTime.tripId);
+					if (tripHeadsign) stopTime.tripHeadsign = tripHeadsign;
+				}
 			} catch (error) {
-				console.error(`Unable to load trip headsigns for route ${routeId}:`, error);
-				return null;
+				console.error(`Unable to load trip headsigns for route ${routeSchedule.routeId}:`, error);
 			}
 		})
 	);
-
-	const tripHeadsigns = new Map(
-		routeResponses.flatMap((routeResponse) =>
-			(routeResponse?.data?.entry?.trips ?? []).flatMap(({ id, tripHeadsign }) =>
-				tripHeadsign ? [[id, tripHeadsign]] : []
-			)
-		)
-	);
-
-	for (const routeSchedule of routeSchedulesWithMultipleTrips) {
-		for (const directionSchedule of routeSchedule.stopRouteDirectionSchedules) {
-			for (const stopTime of directionSchedule.scheduleStopTimes) {
-				const tripHeadsign = tripHeadsigns.get(stopTime.tripId);
-				if (tripHeadsign) stopTime.tripHeadsign = tripHeadsign;
-			}
-		}
-	}
 }

--- a/src/routes/stops/[stopID]/schedule/+page.svelte
+++ b/src/routes/stops/[stopID]/schedule/+page.svelte
@@ -3,7 +3,7 @@
 	import RouteScheduleTable from '$components/schedule-for-stop/RouteScheduleTable.svelte';
 	import StopPageHeader from '$components/stops/StopPageHeader.svelte';
 	import StandalonePage from '$components/StandalonePage.svelte';
-	import { msToTimeString } from '$lib/dateTimeFormat.js';
+	import { groupStopTimesByHour } from '$lib/scheduleForStop.js';
 	import Accordion from '$components/containers/Accordion.svelte';
 	import AccordionItem from '$components/containers/AccordionItem.svelte';
 	import { Datepicker } from 'flowbite-svelte';
@@ -14,7 +14,6 @@
 	let selectedDate = $state(new Date());
 	let prevSelectedDate = $state(null);
 	let emptySchedules = $state(false);
-	let scheduleError = $state(false);
 	let schedules = $state([]);
 	let stopName = $state('');
 	let stopId = $state('');
@@ -31,21 +30,12 @@
 	async function fetchScheduleForStop(stopId, date) {
 		try {
 			emptySchedules = false;
-			scheduleError = false;
 			const response = await fetch(`/api/oba/schedule-for-stop/${stopId}?date=${date}`);
 			if (!response.ok) throw new Error('Failed to fetch schedule for stop');
 			const scheduleForStop = await response.json();
 			handleScheduleForStopResponse(scheduleForStop.data);
 		} catch (error) {
 			console.error('Error fetching schedules:', error);
-			schedules = [];
-			scheduleError = true;
-		}
-	}
-
-	function retryScheduleFetch() {
-		if (stopId && selectedDate) {
-			fetchScheduleForStop(stopId, selectedDate.toISOString().split('T')[0]);
 		}
 	}
 
@@ -101,25 +91,6 @@
 	function getRouteName(routeId, tripHeadsign) {
 		const route = routeReference.get(routeId);
 		return `${route.shortName ?? route.longName} - ${tripHeadsign}`;
-	}
-
-	function groupStopTimesByHour(stopTimes, directionHeadsign) {
-		const grouped = {};
-		for (let stopTime of stopTimes) {
-			const date = new Date(stopTime.arrivalTime);
-			const hour = date.getHours();
-			if (!grouped[hour]) grouped[hour] = [];
-
-			// The direction headsign describes the route's usual destination. A stop-specific
-			// headsign is supplied for trips that take a different path or terminate early.
-			const destination = stopTime.stopHeadsign?.trim() || directionHeadsign;
-			grouped[hour].push({
-				arrivalTime: msToTimeString(stopTime.arrivalTime),
-				destination,
-				isShortLine: destination !== directionHeadsign
-			});
-		}
-		return grouped;
 	}
 
 	function toggleAllRoutes() {
@@ -198,19 +169,7 @@
 			<div
 				class="flex-1 rounded-lg border border-gray-200 bg-white p-2 dark:border-gray-700 dark:bg-black"
 			>
-				{#if scheduleError}
-					<div
-						role="alert"
-						class="mx-auto flex max-w-lg flex-col items-center gap-3 px-4 py-10 text-center"
-					>
-						<p class="text-gray-700 dark:text-gray-300">
-							{$isLoading ? '' : $t('schedule_for_stop.unable_to_load_schedule')}
-						</p>
-						<button class="button" onclick={retryScheduleFetch}>
-							{$isLoading ? '' : $t('schedule_for_stop.retry')}
-						</button>
-					</div>
-				{:else if emptySchedules}
+				{#if emptySchedules}
 					<p class="text-center text-gray-700 dark:text-gray-400">
 						{$isLoading ? '' : $t('schedule_for_stop.no_schedules_available')}
 					</p>

--- a/src/routes/stops/[stopID]/schedule/+page.svelte
+++ b/src/routes/stops/[stopID]/schedule/+page.svelte
@@ -14,6 +14,7 @@
 	let selectedDate = $state(new Date());
 	let prevSelectedDate = $state(null);
 	let emptySchedules = $state(false);
+	let scheduleError = $state(false);
 	let schedules = $state([]);
 	let stopName = $state('');
 	let stopId = $state('');
@@ -30,12 +31,21 @@
 	async function fetchScheduleForStop(stopId, date) {
 		try {
 			emptySchedules = false;
+			scheduleError = false;
 			const response = await fetch(`/api/oba/schedule-for-stop/${stopId}?date=${date}`);
 			if (!response.ok) throw new Error('Failed to fetch schedule for stop');
 			const scheduleForStop = await response.json();
 			handleScheduleForStopResponse(scheduleForStop.data);
 		} catch (error) {
 			console.error('Error fetching schedules:', error);
+			schedules = [];
+			scheduleError = true;
+		}
+	}
+
+	function retryScheduleFetch() {
+		if (stopId && selectedDate) {
+			fetchScheduleForStop(stopId, selectedDate.toISOString().split('T')[0]);
 		}
 	}
 
@@ -74,7 +84,10 @@
 			let stopRouteDirectionSchedules = routeSchedule.stopRouteDirectionSchedules;
 
 			stopRouteDirectionSchedules.forEach((directionSchedule) => {
-				const stopTimesGroupedByHour = groupStopTimesByHour(directionSchedule.scheduleStopTimes);
+				const stopTimesGroupedByHour = groupStopTimesByHour(
+					directionSchedule.scheduleStopTimes,
+					directionSchedule.tripHeadsign
+				);
 				const routeName = getRouteName(routeId, directionSchedule.tripHeadsign);
 
 				schedulesMap.set(routeName, {
@@ -90,14 +103,20 @@
 		return `${route.shortName ?? route.longName} - ${tripHeadsign}`;
 	}
 
-	function groupStopTimesByHour(stopTimes) {
+	function groupStopTimesByHour(stopTimes, directionHeadsign) {
 		const grouped = {};
 		for (let stopTime of stopTimes) {
 			const date = new Date(stopTime.arrivalTime);
 			const hour = date.getHours();
 			if (!grouped[hour]) grouped[hour] = [];
+
+			// The direction headsign describes the route's usual destination. A stop-specific
+			// headsign is supplied for trips that take a different path or terminate early.
+			const destination = stopTime.stopHeadsign?.trim() || directionHeadsign;
 			grouped[hour].push({
-				arrivalTime: msToTimeString(stopTime.arrivalTime)
+				arrivalTime: msToTimeString(stopTime.arrivalTime),
+				destination,
+				isShortLine: destination !== directionHeadsign
 			});
 		}
 		return grouped;
@@ -179,7 +198,19 @@
 			<div
 				class="flex-1 rounded-lg border border-gray-200 bg-white p-2 dark:border-gray-700 dark:bg-black"
 			>
-				{#if emptySchedules}
+				{#if scheduleError}
+					<div
+						role="alert"
+						class="mx-auto flex max-w-lg flex-col items-center gap-3 px-4 py-10 text-center"
+					>
+						<p class="text-gray-700 dark:text-gray-300">
+							{$isLoading ? '' : $t('schedule_for_stop.unable_to_load_schedule')}
+						</p>
+						<button class="button" onclick={retryScheduleFetch}>
+							{$isLoading ? '' : $t('schedule_for_stop.retry')}
+						</button>
+					</div>
+				{:else if emptySchedules}
 					<p class="text-center text-gray-700 dark:text-gray-400">
 						{$isLoading ? '' : $t('schedule_for_stop.no_schedules_available')}
 					</p>

--- a/src/tests/api/schedule-for-stop.test.js
+++ b/src/tests/api/schedule-for-stop.test.js
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRetrieve = vi.hoisted(() => vi.fn());
+const mockHandleOBAResponse = vi.hoisted(() => vi.fn());
+const mockFilterByRouteId = vi.hoisted(() => vi.fn((schedules) => schedules));
+const mockGetAgencyFilter = vi.hoisted(() => vi.fn(() => null));
+
+vi.mock('$lib/obaSdk', () => ({
+	default: { scheduleForStop: { retrieve: mockRetrieve } },
+	handleOBAResponse: mockHandleOBAResponse
+}));
+
+vi.mock('$lib/agencyFilter.js', () => ({
+	filterByRouteId: mockFilterByRouteId,
+	getAgencyFilter: mockGetAgencyFilter
+}));
+
+const { GET } = await import('../../routes/api/oba/schedule-for-stop/[stopId]/+server.js');
+
+describe('GET /api/oba/schedule-for-stop/[stopId]', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockHandleOBAResponse.mockImplementation((response) => response);
+	});
+
+	it('passes an unavailable upstream response to the shared error handler', async () => {
+		mockRetrieve.mockResolvedValue(null);
+
+		const response = await GET({
+			params: { stopId: '12434' },
+			url: new URL('http://localhost/api/oba/schedule-for-stop/12434?date=2026-08-24')
+		});
+
+		expect(mockHandleOBAResponse).toHaveBeenCalledWith(null, 'stop-for-schedule');
+		expect(mockFilterByRouteId).not.toHaveBeenCalled();
+		expect(response).toBeNull();
+	});
+
+	it('filters a valid schedule response before returning it', async () => {
+		const upstreamResponse = {
+			data: { entry: { stopRouteSchedules: [{ routeId: '11_120' }] } }
+		};
+		mockRetrieve.mockResolvedValue(upstreamResponse);
+
+		await GET({
+			params: { stopId: '12434' },
+			url: new URL('http://localhost/api/oba/schedule-for-stop/12434')
+		});
+
+		expect(mockRetrieve).toHaveBeenCalledWith('12434', {});
+		expect(mockFilterByRouteId).toHaveBeenCalledWith(
+			upstreamResponse.data.entry.stopRouteSchedules,
+			null
+		);
+		expect(mockHandleOBAResponse).toHaveBeenCalledWith(upstreamResponse, 'stop-for-schedule');
+	});
+});

--- a/src/tests/api/schedule-for-stop.test.js
+++ b/src/tests/api/schedule-for-stop.test.js
@@ -1,12 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockRetrieve = vi.hoisted(() => vi.fn());
+const mockScheduleForRouteRetrieve = vi.hoisted(() => vi.fn());
 const mockHandleOBAResponse = vi.hoisted(() => vi.fn());
 const mockFilterByRouteId = vi.hoisted(() => vi.fn((schedules) => schedules));
 const mockGetAgencyFilter = vi.hoisted(() => vi.fn(() => null));
 
 vi.mock('$lib/obaSdk', () => ({
-	default: { scheduleForStop: { retrieve: mockRetrieve } },
+	default: {
+		scheduleForStop: { retrieve: mockRetrieve },
+		scheduleForRoute: { retrieve: mockScheduleForRouteRetrieve }
+	},
 	handleOBAResponse: mockHandleOBAResponse
 }));
 
@@ -23,35 +27,78 @@ describe('GET /api/oba/schedule-for-stop/[stopId]', () => {
 		mockHandleOBAResponse.mockImplementation((response) => response);
 	});
 
-	it('passes an unavailable upstream response to the shared error handler', async () => {
-		mockRetrieve.mockResolvedValue(null);
+	it('adds per-trip headsigns from schedule-for-route before returning the stop schedule', async () => {
+		const upstreamResponse = {
+			data: {
+				entry: {
+					stopRouteSchedules: [
+						{
+							routeId: 'MTS_120',
+							stopRouteDirectionSchedules: [
+								{
+									tripHeadsign: 'Kearny Mesa',
+									scheduleStopTimes: [
+										{ tripId: 'MTS_full', stopHeadsign: '' },
+										{ tripId: 'MTS_short', stopHeadsign: '' }
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		};
+		mockRetrieve.mockResolvedValue(upstreamResponse);
+		mockScheduleForRouteRetrieve.mockResolvedValue({
+			data: {
+				entry: {
+					trips: [
+						{ id: 'MTS_full', tripHeadsign: 'Kearny Mesa' },
+						{ id: 'MTS_short', tripHeadsign: 'Fashion Valley' }
+					]
+				}
+			}
+		});
 
-		const response = await GET({
+		await GET({
 			params: { stopId: '12434' },
 			url: new URL('http://localhost/api/oba/schedule-for-stop/12434?date=2026-08-24')
 		});
 
-		expect(mockHandleOBAResponse).toHaveBeenCalledWith(null, 'stop-for-schedule');
-		expect(mockFilterByRouteId).not.toHaveBeenCalled();
-		expect(response).toBeNull();
+		expect(mockRetrieve).toHaveBeenCalledWith('12434', { date: '2026-08-24' });
+		expect(mockFilterByRouteId).toHaveBeenCalledWith(expect.any(Array), null);
+		expect(mockScheduleForRouteRetrieve).toHaveBeenCalledWith('MTS_120', {
+			date: '2026-08-24'
+		});
+		expect(
+			upstreamResponse.data.entry.stopRouteSchedules[0].stopRouteDirectionSchedules[0]
+				.scheduleStopTimes
+		).toEqual([
+			{ tripId: 'MTS_full', stopHeadsign: '', tripHeadsign: 'Kearny Mesa' },
+			{ tripId: 'MTS_short', stopHeadsign: '', tripHeadsign: 'Fashion Valley' }
+		]);
+		expect(mockHandleOBAResponse).toHaveBeenCalledWith(upstreamResponse, 'stop-for-schedule');
 	});
 
-	it('filters a valid schedule response before returning it', async () => {
-		const upstreamResponse = {
-			data: { entry: { stopRouteSchedules: [{ routeId: '11_120' }] } }
-		};
-		mockRetrieve.mockResolvedValue(upstreamResponse);
+	it('does not fetch a route schedule when a direction has only one trip', async () => {
+		mockRetrieve.mockResolvedValue({
+			data: {
+				entry: {
+					stopRouteSchedules: [
+						{
+							routeId: 'MTS_3',
+							stopRouteDirectionSchedules: [{ scheduleStopTimes: [{ tripId: 'MTS_only' }] }]
+						}
+					]
+				}
+			}
+		});
 
 		await GET({
 			params: { stopId: '12434' },
 			url: new URL('http://localhost/api/oba/schedule-for-stop/12434')
 		});
 
-		expect(mockRetrieve).toHaveBeenCalledWith('12434', {});
-		expect(mockFilterByRouteId).toHaveBeenCalledWith(
-			upstreamResponse.data.entry.stopRouteSchedules,
-			null
-		);
-		expect(mockHandleOBAResponse).toHaveBeenCalledWith(upstreamResponse, 'stop-for-schedule');
+		expect(mockScheduleForRouteRetrieve).not.toHaveBeenCalled();
 	});
 });

--- a/src/tests/api/schedule-for-stop.test.js
+++ b/src/tests/api/schedule-for-stop.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockRetrieve = vi.hoisted(() => vi.fn());
 const mockScheduleForRouteRetrieve = vi.hoisted(() => vi.fn());
@@ -19,65 +19,242 @@ vi.mock('$lib/agencyFilter.js', () => ({
 	getAgencyFilter: mockGetAgencyFilter
 }));
 
-const { GET } = await import('../../routes/api/oba/schedule-for-stop/[stopId]/+server.js');
+import { groupStopTimesByHour } from '$lib/scheduleForStop.js';
+
+let GET;
+
+function stopResponse(routeId = 'MTS_120', scheduleDate = 1787554800000) {
+	return {
+		code: 200,
+		data: {
+			entry: {
+				scheduleDate,
+				stopRouteSchedules: [
+					{
+						routeId,
+						stopRouteDirectionSchedules: [
+							{
+								tripHeadsign: 'Kearny Mesa',
+								scheduleStopTimes: [
+									{
+										tripId: 'MTS_full',
+										stopHeadsign: '',
+										arrivalTime: new Date('2026-08-24T08:05:00').getTime()
+									},
+									{
+										tripId: 'MTS_short',
+										stopHeadsign: '',
+										arrivalTime: new Date('2026-08-24T08:25:00').getTime()
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			references: { trips: [] }
+		}
+	};
+}
+
+// Real OBA envelope: entry contains groupings; per-trip metadata is in references.
+function routeResponse() {
+	return {
+		code: 200,
+		data: {
+			entry: {
+				routeId: 'MTS_120',
+				scheduleDate: 1787554800000,
+				serviceIds: [],
+				stopTripGroupings: []
+			},
+			references: {
+				trips: [
+					{ id: 'MTS_full', tripHeadsign: 'Kearny Mesa' },
+					{ id: 'MTS_short', tripHeadsign: 'Fashion Valley' }
+				]
+			}
+		}
+	};
+}
+
+function request(date = '2026-08-24', stopId = 'MTS_12434') {
+	return GET({
+		params: { stopId },
+		url: new URL(
+			`http://localhost/api/oba/schedule-for-stop/${stopId}${date ? `?date=${date}` : ''}`
+		)
+	});
+}
 
 describe('GET /api/oba/schedule-for-stop/[stopId]', () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
+	beforeEach(async () => {
+		vi.resetModules();
+		vi.resetAllMocks();
+		({ GET } = await import('../../routes/api/oba/schedule-for-stop/[stopId]/+server.js'));
+		mockFilterByRouteId.mockImplementation((schedules) => schedules);
+		mockGetAgencyFilter.mockReturnValue(null);
 		mockHandleOBAResponse.mockImplementation((response) => response);
 	});
 
-	it('adds per-trip headsigns from schedule-for-route before returning the stop schedule', async () => {
-		const upstreamResponse = {
-			data: {
-				entry: {
-					stopRouteSchedules: [
-						{
-							routeId: 'MTS_120',
-							stopRouteDirectionSchedules: [
-								{
-									tripHeadsign: 'Kearny Mesa',
-									scheduleStopTimes: [
-										{ tripId: 'MTS_full', stopHeadsign: '' },
-										{ tripId: 'MTS_short', stopHeadsign: '' }
-									]
-								}
-							]
-						}
-					]
-				}
-			}
-		};
-		mockRetrieve.mockResolvedValue(upstreamResponse);
-		mockScheduleForRouteRetrieve.mockResolvedValue({
-			data: {
-				entry: {
-					trips: [
-						{ id: 'MTS_full', tripHeadsign: 'Kearny Mesa' },
-						{ id: 'MTS_short', tripHeadsign: 'Fashion Valley' }
-					]
-				}
-			}
-		});
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
 
-		await GET({
-			params: { stopId: '12434' },
-			url: new URL('http://localhost/api/oba/schedule-for-stop/12434?date=2026-08-24')
-		});
+	it('resolves real-envelope trip references through to short-line table data', async () => {
+		mockRetrieve.mockResolvedValue(stopResponse());
+		mockScheduleForRouteRetrieve.mockResolvedValue(routeResponse());
 
-		expect(mockRetrieve).toHaveBeenCalledWith('12434', { date: '2026-08-24' });
-		expect(mockFilterByRouteId).toHaveBeenCalledWith(expect.any(Array), null);
-		expect(mockScheduleForRouteRetrieve).toHaveBeenCalledWith('MTS_120', {
-			date: '2026-08-24'
-		});
-		expect(
-			upstreamResponse.data.entry.stopRouteSchedules[0].stopRouteDirectionSchedules[0]
-				.scheduleStopTimes
-		).toEqual([
-			{ tripId: 'MTS_full', stopHeadsign: '', tripHeadsign: 'Kearny Mesa' },
-			{ tripId: 'MTS_short', stopHeadsign: '', tripHeadsign: 'Fashion Valley' }
+		const response = await request();
+		const direction = response.data.entry.stopRouteSchedules[0].stopRouteDirectionSchedules[0];
+		expect(groupStopTimesByHour(direction.scheduleStopTimes, direction.tripHeadsign)[8]).toEqual([
+			{ arrivalTime: '8:05 AM', destination: 'Kearny Mesa', isShortLine: false },
+			{ arrivalTime: '8:25 AM', destination: 'Fashion Valley', isShortLine: true }
 		]);
-		expect(mockHandleOBAResponse).toHaveBeenCalledWith(upstreamResponse, 'stop-for-schedule');
+		expect(mockRetrieve).toHaveBeenCalledWith('MTS_12434', { date: '2026-08-24' });
+		expect(mockFilterByRouteId).toHaveBeenCalledWith(expect.any(Array), null);
+		expect(mockScheduleForRouteRetrieve).toHaveBeenCalledWith('MTS_120', { date: '2026-08-24' });
+		expect(mockHandleOBAResponse).toHaveBeenCalledWith(response, 'stop-for-schedule');
+	});
+
+	it('reuses headsigns across stops and when returning to a previously selected date', async () => {
+		mockRetrieve.mockImplementation(() => Promise.resolve(stopResponse()));
+		mockScheduleForRouteRetrieve.mockResolvedValue(routeResponse());
+		await request();
+		await request('2026-08-25');
+		const response = await request('2026-08-24', 'MTS_other');
+		expect(mockScheduleForRouteRetrieve).toHaveBeenCalledTimes(2);
+		expect(
+			response.data.entry.stopRouteSchedules[0].stopRouteDirectionSchedules[0].scheduleStopTimes[1]
+				.tripHeadsign
+		).toBe('Fashion Valley');
+	});
+
+	it('shares an in-flight route lookup between concurrent stop requests', async () => {
+		mockRetrieve.mockImplementation(() => Promise.resolve(stopResponse()));
+		let resolveRoute;
+		mockScheduleForRouteRetrieve.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolveRoute = resolve;
+				})
+		);
+		const requests = [request(), request('2026-08-24', 'MTS_other')];
+		await vi.waitFor(() => expect(mockScheduleForRouteRetrieve).toHaveBeenCalledTimes(1));
+		resolveRoute(routeResponse());
+		const responses = await Promise.all(requests);
+		for (const response of responses) {
+			expect(
+				response.data.entry.stopRouteSchedules[0].stopRouteDirectionSchedules[0]
+					.scheduleStopTimes[1].tripHeadsign
+			).toBe('Fashion Valley');
+		}
+	});
+
+	it('separates routes and uses the upstream service day for undated requests', async () => {
+		mockScheduleForRouteRetrieve.mockResolvedValue(routeResponse());
+		mockRetrieve.mockImplementation(() => Promise.resolve(stopResponse()));
+		await request(null);
+		await request(null);
+		mockRetrieve.mockResolvedValueOnce(stopResponse('MTS_3'));
+		await request(null);
+		mockRetrieve.mockResolvedValueOnce(stopResponse('MTS_120', 1787641200000));
+		await request(null);
+		expect(mockScheduleForRouteRetrieve.mock.calls).toEqual([
+			['MTS_120', {}],
+			['MTS_3', {}],
+			['MTS_120', {}]
+		]);
+	});
+
+	it('does not cache an undated response with no service date', async () => {
+		mockRetrieve.mockImplementation(() => Promise.resolve(stopResponse('MTS_120', null)));
+		mockScheduleForRouteRetrieve.mockResolvedValue(routeResponse());
+		await request(null);
+		await request(null);
+		expect(mockScheduleForRouteRetrieve).toHaveBeenCalledTimes(2);
+	});
+
+	it('refreshes cached headsigns after 24 hours', async () => {
+		vi.useFakeTimers();
+		mockRetrieve.mockImplementation(() => Promise.resolve(stopResponse()));
+		mockScheduleForRouteRetrieve.mockResolvedValue(routeResponse());
+		await request();
+		vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+		await request();
+		expect(mockScheduleForRouteRetrieve).toHaveBeenCalledTimes(2);
+	});
+
+	it('evicts the least recently used route when the 100-entry bound is reached', async () => {
+		mockScheduleForRouteRetrieve.mockResolvedValue(routeResponse());
+		for (let index = 0; index < 100; index++) {
+			mockRetrieve.mockResolvedValueOnce(stopResponse(`MTS_${index}`));
+			await request();
+		}
+		for (const routeId of ['MTS_0', 'MTS_100', 'MTS_0', 'MTS_1']) {
+			mockRetrieve.mockResolvedValueOnce(stopResponse(routeId));
+			await request();
+		}
+		expect(mockScheduleForRouteRetrieve).toHaveBeenCalledTimes(102);
+		expect(mockScheduleForRouteRetrieve).toHaveBeenLastCalledWith('MTS_1', { date: '2026-08-24' });
+	});
+
+	it.each(['rejected', 'missing references', 'error envelope'])(
+		'preserves the stop schedule and retries enrichment after a %s route response',
+		async (failure) => {
+			vi.spyOn(console, 'error').mockImplementation(() => {});
+			mockRetrieve.mockImplementation(() => Promise.resolve(stopResponse()));
+			if (failure === 'rejected')
+				mockScheduleForRouteRetrieve.mockRejectedValueOnce(new Error('unavailable'));
+			else
+				mockScheduleForRouteRetrieve.mockResolvedValueOnce(
+					failure === 'missing references'
+						? { code: 200, data: { entry: {} } }
+						: { ...routeResponse(), code: 500 }
+				);
+			mockScheduleForRouteRetrieve.mockResolvedValueOnce(routeResponse());
+			const response = await request();
+			const direction = response.data.entry.stopRouteSchedules[0].stopRouteDirectionSchedules[0];
+			expect(
+				groupStopTimesByHour(direction.scheduleStopTimes, direction.tripHeadsign)[8].every(
+					(time) => !time.isShortLine
+				)
+			).toBe(true);
+			const retried = await request();
+			expect(mockScheduleForRouteRetrieve).toHaveBeenCalledTimes(2);
+			expect(
+				retried.data.entry.stopRouteSchedules[0].stopRouteDirectionSchedules[0].scheduleStopTimes[1]
+					.tripHeadsign
+			).toBe('Fashion Valley');
+		}
+	);
+
+	it('skips malformed nested entries while enriching healthy directions', async () => {
+		const response = stopResponse();
+		response.data.entry.stopRouteSchedules.push(
+			null,
+			{ routeId: 'missing' },
+			{ routeId: 'invalid', stopRouteDirectionSchedules: {} }
+		);
+		response.data.entry.stopRouteSchedules[0].stopRouteDirectionSchedules.push(
+			null,
+			{},
+			{ scheduleStopTimes: null },
+			{ scheduleStopTimes: {} }
+		);
+		response.data.entry.stopRouteSchedules[0].stopRouteDirectionSchedules[0].scheduleStopTimes.push(
+			null,
+			{}
+		);
+		mockRetrieve.mockResolvedValue(response);
+		mockScheduleForRouteRetrieve.mockResolvedValue(routeResponse());
+		expect(await request()).toBe(response);
+		expect(mockScheduleForRouteRetrieve).toHaveBeenCalledTimes(1);
+		expect(
+			response.data.entry.stopRouteSchedules[0].stopRouteDirectionSchedules[0].scheduleStopTimes[1]
+				.tripHeadsign
+		).toBe('Fashion Valley');
 	});
 
 	it('does not fetch a route schedule when a direction has only one trip', async () => {

--- a/src/tests/api/schedule-for-stop.test.js
+++ b/src/tests/api/schedule-for-stop.test.js
@@ -21,14 +21,25 @@ vi.mock('$lib/agencyFilter.js', () => ({
 
 import { groupStopTimesByHour } from '$lib/scheduleForStop.js';
 
+const region = vi.hoisted(() => ({ timeZone: 'America/Los_Angeles' }));
+vi.mock('$env/dynamic/public', () => ({
+	env: {
+		get PUBLIC_OBA_TIMEZONE() {
+			return region.timeZone;
+		}
+	}
+}));
+
 let GET;
 
-function stopResponse(routeId = 'MTS_120', scheduleDate = 1787554800000) {
+// schedule-for-stop uses entry.date, never schedule-for-route's entry.scheduleDate.
+function stopResponse(routeId = 'MTS_120', date = 1787554800000) {
 	return {
 		code: 200,
 		data: {
 			entry: {
-				scheduleDate,
+				date,
+				stopId: 'MTS_12434',
 				stopRouteSchedules: [
 					{
 						routeId,
@@ -91,6 +102,9 @@ describe('GET /api/oba/schedule-for-stop/[stopId]', () => {
 	beforeEach(async () => {
 		vi.resetModules();
 		vi.resetAllMocks();
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-24T15:00:00Z'));
+		region.timeZone = 'America/Los_Angeles';
 		({ GET } = await import('../../routes/api/oba/schedule-for-stop/[stopId]/+server.js'));
 		mockFilterByRouteId.mockImplementation((schedules) => schedules);
 		mockGetAgencyFilter.mockReturnValue(null);
@@ -152,28 +166,103 @@ describe('GET /api/oba/schedule-for-stop/[stopId]', () => {
 		}
 	});
 
-	it('separates routes and uses the upstream service day for undated requests', async () => {
+	it('reuses undated headsigns despite changing wall-clock entry.date values', async () => {
+		mockRetrieve.mockImplementation(() => Promise.resolve(stopResponse('MTS_120', Date.now())));
 		mockScheduleForRouteRetrieve.mockResolvedValue(routeResponse());
-		mockRetrieve.mockImplementation(() => Promise.resolve(stopResponse()));
 		await request(null);
-		await request(null);
-		mockRetrieve.mockResolvedValueOnce(stopResponse('MTS_3'));
-		await request(null);
-		mockRetrieve.mockResolvedValueOnce(stopResponse('MTS_120', 1787641200000));
-		await request(null);
-		expect(mockScheduleForRouteRetrieve.mock.calls).toEqual([
-			['MTS_120', {}],
-			['MTS_3', {}],
-			['MTS_120', {}]
+		vi.setSystemTime(new Date('2026-08-24T16:17:30Z'));
+		await request(null, 'MTS_other');
+		await request('2026-08-24');
+		expect(mockScheduleForRouteRetrieve).toHaveBeenCalledTimes(1);
+		expect(mockScheduleForRouteRetrieve).toHaveBeenCalledWith('MTS_120', { date: '2026-08-24' });
+		expect(mockRetrieve.mock.calls.map(([, params]) => params)).toEqual([
+			{ date: '2026-08-24' },
+			{ date: '2026-08-24' },
+			{ date: '2026-08-24' }
 		]);
 	});
 
-	it('does not cache an undated response with no service date', async () => {
-		mockRetrieve.mockImplementation(() => Promise.resolve(stopResponse('MTS_120', null)));
+	it('separates routes and rolls the undated cache over at region midnight, not UTC midnight', async () => {
+		mockScheduleForRouteRetrieve.mockResolvedValue(routeResponse());
+		mockRetrieve.mockImplementation(() => Promise.resolve(stopResponse()));
+		vi.setSystemTime(new Date('2026-08-25T00:00:00Z'));
+		await request(null);
+		vi.setSystemTime(new Date('2026-08-25T06:59:59Z'));
+		await request(null);
+		mockRetrieve.mockResolvedValueOnce(stopResponse('MTS_3'));
+		await request(null);
+		vi.setSystemTime(new Date('2026-08-25T07:00:00Z'));
+		await request(null);
+		expect(mockScheduleForRouteRetrieve.mock.calls).toEqual([
+			['MTS_120', { date: '2026-08-24' }],
+			['MTS_3', { date: '2026-08-24' }],
+			['MTS_120', { date: '2026-08-25' }]
+		]);
+	});
+
+	it.each([
+		[
+			'2026-03-08T09:59:59Z',
+			'2026-03-08T10:00:00Z',
+			'2026-03-09T07:00:00Z',
+			'2026-03-08',
+			'2026-03-09'
+		],
+		[
+			'2026-11-01T08:59:59Z',
+			'2026-11-01T09:00:00Z',
+			'2026-11-02T08:00:00Z',
+			'2026-11-01',
+			'2026-11-02'
+		]
+	])(
+		'keeps the service date stable across DST at %s',
+		async (before, after, nextMidnight, date, nextDate) => {
+			mockRetrieve.mockImplementation(() => Promise.resolve(stopResponse()));
+			mockScheduleForRouteRetrieve.mockResolvedValue(routeResponse());
+			for (const now of [before, after, nextMidnight]) {
+				vi.setSystemTime(new Date(now));
+				await request(null);
+			}
+			expect(mockScheduleForRouteRetrieve.mock.calls).toEqual([
+				['MTS_120', { date }],
+				['MTS_120', { date: nextDate }]
+			]);
+		}
+	);
+
+	it('uses the configured region date east of UTC', async () => {
+		region.timeZone = 'Asia/Kolkata';
+		vi.setSystemTime(new Date('2026-08-24T18:30:00Z'));
+		mockRetrieve.mockResolvedValue(stopResponse());
+		mockScheduleForRouteRetrieve.mockResolvedValue(routeResponse());
+		await request(null);
+		expect(mockRetrieve).toHaveBeenCalledWith('MTS_12434', { date: '2026-08-25' });
+		expect(mockScheduleForRouteRetrieve).toHaveBeenCalledWith('MTS_120', { date: '2026-08-25' });
+	});
+
+	it('pins both upstream requests to the same date when the stop lookup crosses midnight', async () => {
+		vi.setSystemTime(new Date('2026-08-25T06:59:59Z'));
+		mockRetrieve.mockImplementation(async () => {
+			vi.setSystemTime(new Date('2026-08-25T07:00:01Z'));
+			return stopResponse();
+		});
+		mockScheduleForRouteRetrieve.mockResolvedValue(routeResponse());
+		await request(null);
+		expect(mockRetrieve).toHaveBeenCalledWith('MTS_12434', { date: '2026-08-24' });
+		expect(mockScheduleForRouteRetrieve).toHaveBeenCalledWith('MTS_120', { date: '2026-08-24' });
+	});
+
+	it('caches undated requests even when the upstream date field is absent', async () => {
+		mockRetrieve.mockImplementation(() => {
+			const response = stopResponse();
+			delete response.data.entry.date;
+			return Promise.resolve(response);
+		});
 		mockScheduleForRouteRetrieve.mockResolvedValue(routeResponse());
 		await request(null);
 		await request(null);
-		expect(mockScheduleForRouteRetrieve).toHaveBeenCalledTimes(2);
+		expect(mockScheduleForRouteRetrieve).toHaveBeenCalledTimes(1);
 	});
 
 	it('refreshes cached headsigns after 24 hours', async () => {


### PR DESCRIPTION
## Summary

- Label short-line departures using per-trip headsigns from `schedule-for-route` references.
- Cache only trip headsigns by route and service date, with a 24-hour TTL, a 100-entry limit, and shared in-flight lookups.
- Resolve undated requests once in `PUBLIC_OBA_TIMEZONE` and send the same explicit date to both OBA endpoints and the cache.

## Design

<img width="1074" height="838" alt="image" src="https://github.com/user-attachments/assets/2502c491-fad8-4b7c-8b45-8b99ddf45257" />

## Testing

- All 1,814 tests passed; 93.94% line coverage.
- `npm run lint` and `npm run build` passed.
- Verified live OBA stop/route response shapes with HTTP 200 responses.
- Added regressions for changing `entry.date` timestamps, region midnight, DST transitions, and upstream requests crossing midnight. The corrected tests fail against the previous implementation.

Fixes #251


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Short-line trips are now identified in stop schedules with highlighted times and destination labels.
  * A notice appears when short-line service is present in the schedule.
  * Trip destinations are shown more accurately when they differ from the route direction.

* **Bug Fixes**
  * Stop schedules now consistently use the correct service date, including timezone and daylight-saving transitions.
  * Schedule information remains available when individual destination lookups fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->