### PR TITLE
test: add unit tests for skipSurvey()

### DIFF
--- a/src/tests/lib/surveysUtils.test.js
+++ b/src/tests/lib/surveysUtils.test.js
@@ -15,7 +15,8 @@ beforeEach(() => {
 	vi.stubGlobal('localStorage', {
 		getItem: vi.fn((key) => store[key] || null),
 		setItem: vi.fn((key, value) => {
-			store[key] = value;
+			// Storage coerces on write, so getItem always hands back a string.
+			store[key] = String(value);
 		}),
 		removeItem: vi.fn((key) => {
 			delete store[key];
@@ -337,7 +338,7 @@ describe('skipSurvey', () => {
 
 		skipSurvey(survey);
 
-		expect(localStorage.getItem('survey_1_skipped_timestamp')).toBe(NOW);
+		expect(localStorage.getItem('survey_1_skipped_timestamp')).toBe(String(NOW));
 		expect(localStorage.getItem('survey_1_skipped')).toBeNull();
 	});
 
@@ -346,17 +347,17 @@ describe('skipSurvey', () => {
 
 		skipSurvey(survey);
 
-		expect(localStorage.getItem('survey_2_skipped')).toBe(true);
+		expect(localStorage.getItem('survey_2_skipped')).toBe('true');
 		expect(localStorage.getItem('survey_2_skipped_timestamp')).toBeNull();
 	});
 
 	it('should clear a stale permanent flag when skipping a recurring survey', () => {
 		const survey = { id: 3, allows_multiple_responses: true, always_visible: true };
-		localStorage.setItem('survey_3_skipped', true);
+		localStorage.setItem('survey_3_skipped', 'true');
 
 		skipSurvey(survey);
 
 		expect(localStorage.getItem('survey_3_skipped')).toBeNull();
-		expect(localStorage.getItem('survey_3_skipped_timestamp')).toBe(NOW);
+		expect(localStorage.getItem('survey_3_skipped_timestamp')).toBe(String(NOW));
 	});
 });

--- a/src/tests/lib/surveysUtils.test.js
+++ b/src/tests/lib/surveysUtils.test.js
@@ -6,7 +6,8 @@ import {
 	getMapSurvey,
 	submitHeroQuestion,
 	updateSurveyResponse,
-	getPrioritySurvey
+	getPrioritySurvey,
+	skipSurvey
 } from '../../lib/Surveys/surveyUtils';
 
 beforeEach(() => {
@@ -316,5 +317,46 @@ describe('Survey Visibility and Multiple Responses', () => {
 		const selectedSurvey = await getPrioritySurvey(surveys, null);
 
 		expect(selectedSurvey).toEqual(surveys[2]);
+	});
+});
+
+describe('skipSurvey', () => {
+	const NOW = 1787700000000;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(NOW);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('should only set the timestamp when skipping a recurring survey', () => {
+		const survey = { id: 1, allows_multiple_responses: true, always_visible: true };
+
+		skipSurvey(survey);
+
+		expect(localStorage.getItem('survey_1_skipped_timestamp')).toBe(NOW);
+		expect(localStorage.getItem('survey_1_skipped')).toBeNull();
+	});
+
+	it('should only set the permanent flag when skipping a one-time survey', () => {
+		const survey = { id: 2, allows_multiple_responses: false, always_visible: false };
+
+		skipSurvey(survey);
+
+		expect(localStorage.getItem('survey_2_skipped')).toBe(true);
+		expect(localStorage.getItem('survey_2_skipped_timestamp')).toBeNull();
+	});
+
+	it('should clear a stale permanent flag when skipping a recurring survey', () => {
+		const survey = { id: 3, allows_multiple_responses: true, always_visible: true };
+		localStorage.setItem('survey_3_skipped', true);
+
+		skipSurvey(survey);
+
+		expect(localStorage.getItem('survey_3_skipped')).toBeNull();
+		expect(localStorage.getItem('survey_3_skipped_timestamp')).toBe(NOW);
 	});
 });


### PR DESCRIPTION
Closes #444

`skipSurvey()` had no test coverage. #420 fixed recurring surveys being permanently skipped instead of skipped for one week, and nothing currently pins that behaviour.

Three cases, matching the issue body:

- **Recurring survey** (`allows_multiple_responses: true, always_visible: true`) sets only `survey_<id>_skipped_timestamp`, and `survey_<id>_skipped` stays absent.
- **One-time survey** sets only `survey_<id>_skipped`, and no timestamp.
- **Stale flag cleanup**: a recurring survey that already carries a `_skipped` flag from the old buggy behaviour has it removed.

Two notes on the approach:

Fake timers pin `Date.now()` so the timestamp assertion is an exact value rather than a not-null check, which would still pass if the code wrote something wrong.

I checked the third test actually earns its place: dropping the `localStorage.removeItem` line from `skipSurvey` fails it and leaves the other 23 green.

Test-only, no production changes. `prettier --check` and `eslint` both clean. 24 tests pass in `surveysUtils.test.js`, up from 21.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for skipping recurring and one-time surveys.
  * Verified timestamp-based skipping, permanent skip flags, and cleanup of stale skip settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->