### PR TITLE
Fix vehicle marker contrast on route lines

### DIFF
--- a/src/components/map/RouteMap.svelte
+++ b/src/components/map/RouteMap.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { calculateMidpoint } from '$lib/mathUtils';
-	import { clearVehicleMarkersMap, fetchAndUpdateVehicles } from '$lib/vehicleUtils';
+	import { clearVehicleMarkersMap, fetchAndUpdateVehiclesForRoutes } from '$lib/vehicleUtils';
 	import { mapContrastColor } from '$lib/colorUtils';
 	import { onMount, onDestroy } from 'svelte';
 	import { notifyRouteLoadFailed, notifyRouteShapeFailed } from '$lib/routeNotifications';
@@ -17,11 +17,32 @@
 	// used to clear interval api calls
 	let currentIntervalId = null;
 	let loadRouteDataPromise = null;
+	let dark = false;
+	let routeId = null;
+	let rawRouteColor = null;
+	let polyline = null;
+	let refreshVehicles = null;
+	const routeColors = new Map();
 
-	onMount(async () => {
+	onMount(() => {
+		dark = document.documentElement.classList.contains('dark');
+		window.addEventListener('themeChange', handleThemeChange);
 		loadRouteDataPromise = loadRouteData();
-		await loadRouteDataPromise;
+		return () => window.removeEventListener('themeChange', handleThemeChange);
 	});
+
+	function updateRouteColors() {
+		if (!isMounted || !routeId) return;
+		const color = mapContrastColor(rawRouteColor, { dark });
+		routeColors.set(routeId, { line: color ?? undefined });
+		if (polyline) mapProvider.setPolylineColor(polyline, color);
+		refreshVehicles?.();
+	}
+
+	function handleThemeChange(event) {
+		dark = event.detail.darkMode;
+		updateRouteColors();
+	}
 
 	// A retry restarts the load, so it has to become the promise onDestroy
 	// awaits — otherwise teardown races an in-flight retry and the retry's
@@ -70,6 +91,9 @@
 		}
 
 		try {
+			clearInterval(currentIntervalId);
+			refreshVehicles = null;
+			polyline = null;
 			mapProvider.clearAllPolylines();
 			mapProvider.removeStopMarkers();
 
@@ -83,16 +107,15 @@
 			const moreTripData = tripReferences?.find((t) => t.id == tripId);
 
 			shapeId = moreTripData?.shapeId;
-			const routeId = moreTripData?.routeId;
+			routeId = moreTripData?.routeId;
 
 			const route = tripData?.data?.references?.routes?.find((r) => r.id === routeId);
-			const dark = document.documentElement.classList.contains('dark');
-			const routeColor = mapContrastColor(route?.color, { dark });
+			rawRouteColor = route?.color;
+			updateRouteColors();
 
 			if (shapeId && isMounted) {
 				// Scoped to its own try so a shape failure still leaves the stops and
 				// vehicles below to render — the trip is usable without the line.
-				let polyline = null;
 				try {
 					const shapeResponse = await fetch(`/api/oba/shape/${shapeId}`);
 					if (!shapeResponse.ok) {
@@ -102,7 +125,9 @@
 					const shapePoints = shapeData?.data?.entry?.points;
 					// createPolyline returns null when the encoded shape fails to decode.
 					polyline = shapePoints
-						? await mapProvider.createPolyline(shapePoints, { color: routeColor })
+						? await mapProvider.createPolyline(shapePoints, {
+								color: routeColors.get(routeId)?.line
+							})
 						: null;
 				} catch (error) {
 					console.error(`Error drawing route shape for trip ${tripId}:`, error);
@@ -112,6 +137,9 @@
 				// while the shape was in flight, in which case onDestroy has already
 				// run and a toast raised now would have no owner to dismiss it.
 				if (!isMounted) return;
+				// A theme event may have arrived while createPolyline awaited its
+				// provider library. Apply the latest color to the completed line.
+				updateRouteColors();
 
 				// This component draws one polyline for the whole trip, so no polyline
 				// means no route line at all — a total failure worth a retry, not the
@@ -153,13 +181,12 @@
 			if (routeId && isMounted) {
 				// Highlight the vehicle serving the trip the user clicked, while still
 				// showing the other vehicles running this route.
-				currentIntervalId = await fetchAndUpdateVehicles(
-					routeId,
-					mapProvider,
-					undefined,
-					tripId,
-					routeColor ?? undefined
-				);
+				const poll = await fetchAndUpdateVehiclesForRoutes([{ id: routeId }], mapProvider, {
+					highlightedTripId: tripId,
+					colorsByRouteId: routeColors
+				});
+				currentIntervalId = poll.intervalId;
+				refreshVehicles = poll.refresh;
 			}
 		} catch (error) {
 			console.error(`Error loading route data for trip ${tripId}:`, error);

--- a/src/components/map/__tests__/RouteMap.test.js
+++ b/src/components/map/__tests__/RouteMap.test.js
@@ -1,10 +1,12 @@
 import { render } from '@testing-library/svelte';
-import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import RouteMap from '../RouteMap.svelte';
+import { fetchAndUpdateVehiclesForRoutes } from '$lib/vehicleUtils';
+import { mapContrastColor } from '$lib/colorUtils';
 
 vi.mock('$lib/vehicleUtils', () => ({
 	clearVehicleMarkersMap: vi.fn(),
-	fetchAndUpdateVehicles: vi.fn().mockResolvedValue(null)
+	fetchAndUpdateVehiclesForRoutes: vi.fn().mockResolvedValue({ intervalId: null, refresh: vi.fn() })
 }));
 
 function makeProvider() {
@@ -15,6 +17,7 @@ function makeProvider() {
 		clearVehicleMarkers: vi.fn(),
 		createPolyline: vi.fn().mockResolvedValue(undefined),
 		addStopRouteMarker: vi.fn(),
+		setPolylineColor: vi.fn(),
 		fitToPolylines: vi.fn().mockResolvedValue(true),
 		flyTo: vi.fn()
 	};
@@ -24,7 +27,10 @@ describe('RouteMap', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		global.fetch = vi.fn();
+		document.documentElement.classList.remove('dark');
 	});
+
+	afterEach(() => document.documentElement.classList.remove('dark'));
 
 	// Regression test for the transient-mount crash: MapExperience's framing
 	// effect nulls selectedTrip one render tick *after* the DOM re-renders, so
@@ -84,5 +90,82 @@ describe('RouteMap', () => {
 
 		unmount();
 		await vi.waitFor(() => expect(mapProvider.flyTo).toHaveBeenCalledWith(1, 2, 18));
+	});
+	function mockTrip() {
+		global.fetch = vi.fn(async (url) => ({
+			ok: true,
+			json: async () =>
+				url.includes('/trip-details/')
+					? {
+							data: {
+								entry: { schedule: { stopTimes: [] } },
+								references: {
+									trips: [{ id: 'trip_1', routeId: 'route_1', shapeId: 'shape_1' }],
+									routes: [{ id: 'route_1', color: '#003366' }]
+								}
+							}
+						}
+					: { data: { entry: { points: 'encoded-shape' } } }
+		}));
+	}
+
+	function switchTheme(darkMode) {
+		document.documentElement.classList.toggle('dark', darkMode);
+		window.dispatchEvent(new CustomEvent('themeChange', { detail: { darkMode } }));
+	}
+
+	test.each([false, true])(
+		'recolors the line and cached vehicles together (initial dark=%s)',
+		async (initialDark) => {
+			mockTrip();
+			document.documentElement.classList.toggle('dark', initialDark);
+			const mapProvider = makeProvider();
+			const polyline = {};
+			mapProvider.createPolyline.mockResolvedValue(polyline);
+			const { unmount } = render(RouteMap, { props: { mapProvider, tripId: 'trip_1' } });
+			await vi.waitFor(() => expect(fetchAndUpdateVehiclesForRoutes).toHaveBeenCalledOnce());
+			const { colorsByRouteId } = fetchAndUpdateVehiclesForRoutes.mock.calls[0][2];
+			const { refresh } = await fetchAndUpdateVehiclesForRoutes.mock.results[0].value;
+			await Promise.resolve();
+			for (const dark of [!initialDark, initialDark]) {
+				refresh.mockClear();
+				switchTheme(dark);
+				const expected = mapContrastColor('#003366', { dark });
+				expect(mapProvider.setPolylineColor).toHaveBeenLastCalledWith(polyline, expected);
+				expect(colorsByRouteId.get('route_1').line).toBe(expected);
+				expect(refresh).toHaveBeenCalledOnce();
+			}
+			expect(global.fetch).toHaveBeenCalledTimes(2);
+			expect(mapProvider.createPolyline).toHaveBeenCalledOnce();
+			expect(mapProvider.fitToPolylines).toHaveBeenCalledOnce();
+			expect(fetchAndUpdateVehiclesForRoutes).toHaveBeenCalledOnce();
+			unmount();
+			mapProvider.setPolylineColor.mockClear();
+			switchTheme(!initialDark);
+			expect(mapProvider.setPolylineColor).not.toHaveBeenCalled();
+		}
+	);
+
+	test('uses the latest theme when the polyline finishes loading', async () => {
+		mockTrip();
+		const mapProvider = makeProvider();
+		let finishPolyline;
+		mapProvider.createPolyline.mockReturnValue(
+			new Promise((resolve) => {
+				finishPolyline = resolve;
+			})
+		);
+		const { unmount } = render(RouteMap, { props: { mapProvider, tripId: 'trip_1' } });
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledOnce());
+		switchTheme(true);
+		const polyline = {};
+		finishPolyline(polyline);
+		await vi.waitFor(() => expect(fetchAndUpdateVehiclesForRoutes).toHaveBeenCalledOnce());
+		const expected = mapContrastColor('#003366', { dark: true });
+		expect(mapProvider.setPolylineColor).toHaveBeenLastCalledWith(polyline, expected);
+		expect(
+			fetchAndUpdateVehiclesForRoutes.mock.calls[0][2].colorsByRouteId.get('route_1').line
+		).toBe(expected);
+		unmount();
 	});
 });

--- a/src/lib/MapHelpers/__tests__/generateVehicleIcon.test.js
+++ b/src/lib/MapHelpers/__tests__/generateVehicleIcon.test.js
@@ -4,7 +4,10 @@ vi.mock('$env/dynamic/public', () => ({
 	env: {}
 }));
 
-import { createVehicleIconSvg } from '$lib/MapHelpers/generateVehicleIcon.js';
+import {
+	createVehicleIconSvg,
+	getVehicleMarkerContrastColor
+} from '$lib/MapHelpers/generateVehicleIcon.js';
 
 describe('createVehicleIconSvg', () => {
 	it('renders no highlight glow by default', () => {
@@ -28,5 +31,19 @@ describe('createVehicleIconSvg', () => {
 	it('always produces a valid <svg> element', () => {
 		expect(createVehicleIconSvg(90, '#007BFF', undefined, true)).toContain('<svg');
 		expect(createVehicleIconSvg(90)).toContain('<svg');
+	});
+
+	it('uses the most contrasting neutral backing for the route colour', () => {
+		expect(getVehicleMarkerContrastColor('#000000')).toBe('#ffffff');
+		expect(getVehicleMarkerContrastColor('#ffffff')).toBe('#000000');
+		expect(getVehicleMarkerContrastColor('#007BFF')).toBe('#000000');
+	});
+
+	it('adds a contrasting backing and arrow outline for a same-colour route', () => {
+		const svg = createVehicleIconSvg(0, '#000000');
+
+		expect(svg).toContain('<circle cx="0" cy="0" r="16" fill="#ffffff"/>');
+		expect(svg).toContain('stroke="#ffffff" stroke-width="6"');
+		expect(svg).toContain('stroke="#000000" stroke-width="2"');
 	});
 });

--- a/src/lib/MapHelpers/__tests__/generateVehicleIcon.test.js
+++ b/src/lib/MapHelpers/__tests__/generateVehicleIcon.test.js
@@ -39,6 +39,15 @@ describe('createVehicleIconSvg', () => {
 		expect(getVehicleMarkerContrastColor('#007BFF')).toBe('#000000');
 	});
 
+	it('keeps a light backing for lightened route colours on a dark basemap', () => {
+		expect(getVehicleMarkerContrastColor('#808080', true)).toBe('#ffffff');
+		expect(getVehicleMarkerContrastColor('#59A9FF', true)).toBe('#ffffff');
+
+		const svg = createVehicleIconSvg(0, '#59A9FF', undefined, false, true);
+		expect(svg).toContain('<circle cx="0" cy="0" r="16" fill="#ffffff"/>');
+		expect(svg).toContain('stroke="#ffffff" stroke-width="6"');
+	});
+
 	it('adds a contrasting backing and arrow outline for a same-colour route', () => {
 		const svg = createVehicleIconSvg(0, '#000000');
 

--- a/src/lib/MapHelpers/__tests__/generateVehicleIcon.test.js
+++ b/src/lib/MapHelpers/__tests__/generateVehicleIcon.test.js
@@ -8,6 +8,30 @@ import {
 	createVehicleIconSvg,
 	getVehicleMarkerContrastColor
 } from '$lib/MapHelpers/generateVehicleIcon.js';
+import { contrastRatio, mapContrastColor, rgbToHex } from '$lib/colorUtils.js';
+
+describe('getVehicleMarkerContrastColor', () => {
+	it.each(['#003366', '#4B0082', '#800000', '#2E2E2E'])(
+		'keeps dark route %s readable in light mode',
+		(color) => {
+			const routeColor = mapContrastColor(color);
+			expect(routeColor.toLowerCase()).toBe(color.toLowerCase());
+			expect(getVehicleMarkerContrastColor(routeColor)).toBe('#ffffff');
+		}
+	);
+
+	it('maintains at least 4.5:1 glyph contrast across the colour gamut', () => {
+		for (let r = 0; r <= 255; r += 17) {
+			for (let g = 0; g <= 255; g += 17) {
+				for (let b = 0; b <= 255; b += 17) {
+					const color = rgbToHex(r, g, b);
+					const backing = getVehicleMarkerContrastColor(color);
+					expect(contrastRatio(color, backing), color).toBeGreaterThanOrEqual(4.5);
+				}
+			}
+		}
+	});
+});
 
 describe('createVehicleIconSvg', () => {
 	it('renders no highlight glow by default', () => {
@@ -39,13 +63,38 @@ describe('createVehicleIconSvg', () => {
 		expect(getVehicleMarkerContrastColor('#007BFF')).toBe('#000000');
 	});
 
-	it('keeps a light backing for lightened route colours on a dark basemap', () => {
-		expect(getVehicleMarkerContrastColor('#808080', true)).toBe('#ffffff');
-		expect(getVehicleMarkerContrastColor('#59A9FF', true)).toBe('#ffffff');
-
-		const svg = createVehicleIconSvg(0, '#59A9FF', undefined, false, true);
-		expect(svg).toContain('<circle cx="0" cy="0" r="16" fill="#ffffff"/>');
-		expect(svg).toContain('stroke="#ffffff" stroke-width="6"');
+	it.each([false, true])('keeps glyphs readable and a visible silhouette (dark=%s)', (dark) => {
+		for (const raw of [
+			'#000000',
+			'#003366',
+			'#007BFF',
+			'#808080',
+			'#aaaaaa',
+			'#cccccc',
+			'#dddddd',
+			'#eeeeee',
+			'#ffffff',
+			'#ffff00'
+		]) {
+			const color = mapContrastColor(raw, { dark });
+			const svg = new DOMParser().parseFromString(
+				createVehicleIconSvg(90, color, undefined, false, dark),
+				'image/svg+xml'
+			);
+			const body = svg.querySelector('circle[r="13"]').getAttribute('fill');
+			const halo = svg.querySelector('circle[r="16"]').getAttribute('fill');
+			const arrows = [...svg.querySelectorAll('polygon')];
+			expect(contrastRatio(color, body), raw).toBeGreaterThanOrEqual(4.5);
+			expect(arrows.at(-1).getAttribute('fill')).toBe(color);
+			expect(
+				contrastRatio(color, arrows.at(-2).getAttribute('stroke')),
+				raw
+			).toBeGreaterThanOrEqual(4.5);
+			if (dark) {
+				expect(halo).toBe('#ffffff');
+				expect(arrows[0].getAttribute('stroke')).toBe('#ffffff');
+			}
+		}
 	});
 
 	it('adds a contrasting backing and arrow outline for a same-colour route', () => {
@@ -55,4 +104,24 @@ describe('createVehicleIconSvg', () => {
 		expect(svg).toContain('stroke="#ffffff" stroke-width="6"');
 		expect(svg).toContain('stroke="#000000" stroke-width="2"');
 	});
+
+	it.each(['#003366', '#4B0082', '#800000', '#2E2E2E'])(
+		'renders a white backing and arrow outline for dark route %s in light mode',
+		(color) => {
+			const svg = new DOMParser().parseFromString(createVehicleIconSvg(90, color), 'image/svg+xml');
+			const backing = svg.querySelector('circle[r="16"]');
+			const ring = svg.querySelector('circle[r="13"]');
+			const arrows = svg.querySelectorAll('polygon');
+
+			expect(backing.getAttribute('fill')).toBe('#ffffff');
+			expect(ring.getAttribute('fill')).toBe('#ffffff');
+			expect(ring.parentElement.getAttribute('stroke')).toBe(color);
+			expect(arrows[0].getAttribute('stroke')).toBe('#ffffff');
+			expect(arrows[1].getAttribute('fill')).toBe(color);
+			expect(svg.querySelector('path').closest('g').getAttribute('fill')).toBe(color);
+			// The filled ring masks the arrow shaft before the glyph is painted.
+			expect(ring.previousElementSibling).toBe(arrows[1]);
+			expect(ring.nextElementSibling.tagName).toBe('svg');
+		}
+	);
 });

--- a/src/lib/MapHelpers/generateVehicleIcon.js
+++ b/src/lib/MapHelpers/generateVehicleIcon.js
@@ -1,4 +1,5 @@
 import { env } from '$env/dynamic/public';
+import { contrastRatio } from '$lib/colorUtils.js';
 import { toDirection } from '$lib/mathUtils';
 import { generateRouteTypeSvgForDisplay, RouteType } from '$config/routeConfig';
 
@@ -28,6 +29,19 @@ function getDirectionFromOrientation(orientation) {
 // match it to their theme instead of the hardcoded amber.
 const HIGHLIGHT_GLOW_COLOR = env.PUBLIC_COLOR_VEHICLE_HIGHLIGHT || '#FACC15';
 
+/**
+ * Returns the neutral colour that has the strongest contrast against the
+ * vehicle/route colour. The vehicle marker deliberately keeps the route colour
+ * for recognition, but this backing prevents it from disappearing into a
+ * same-colour route polyline.
+ *
+ * @param {string} color
+ * @returns {'#ffffff' | '#000000'}
+ */
+function getVehicleMarkerContrastColor(color) {
+	return contrastRatio(color, '#ffffff') >= contrastRatio(color, '#000000') ? '#ffffff' : '#000000';
+}
+
 function createVehicleIconSvg(
 	orientation,
 	color = '#007BFF',
@@ -36,10 +50,16 @@ function createVehicleIconSvg(
 ) {
 	const direction = getDirectionFromOrientation(toDirection(orientation));
 	const angle = DIRECTIONS.find((d) => d.icon === direction).angle;
+	const contrastColor = getVehicleMarkerContrastColor(color);
 
+	// Draw the directional arrow twice: a broad neutral stroke first, then the
+	// route-coloured arrow. This makes the direction indicator legible even
+	// when it lies directly over a route of the same colour.
 	const arrowPath = `
-    <line x1="0" y1="0" x2="0" y2="-15" stroke-width="2" transform="rotate(${angle})"/>
-    <polygon points="0,-25 5,-15 -5, -15" stroke="white" stroke-width="1" transform="rotate(${angle})"/>
+    <line x1="0" y1="0" x2="0" y2="-15" stroke="${contrastColor}" stroke-width="6" stroke-linecap="round" transform="rotate(${angle})"/>
+    <polygon points="0,-25 5,-15 -5,-15" fill="${contrastColor}" stroke="${contrastColor}" stroke-width="4" stroke-linejoin="round" transform="rotate(${angle})"/>
+    <line x1="0" y1="0" x2="0" y2="-15" stroke="${color}" stroke-width="2" stroke-linecap="round" transform="rotate(${angle})"/>
+    <polygon points="0,-25 5,-15 -5,-15" fill="${color}" stroke="${color}" stroke-width="1" stroke-linejoin="round" transform="rotate(${angle})"/>
 `;
 
 	// A soft blurred halo behind the marker for the selected trip. Drawn first so
@@ -59,15 +79,18 @@ function createVehicleIconSvg(
 	return `
         <svg width="${iconWidth}" height="${iconHeight}" viewBox="-28 -28 56 56" xmlns="http://www.w3.org/2000/svg">
             ${highlightDefs}
-            <g stroke="${color}" fill="${color}">
-                <!-- Highlight glow for the selected vehicle (behind everything) -->
-                ${highlightGlow}
+            <!-- Highlight glow for the selected vehicle (behind everything) -->
+            ${highlightGlow}
 
+            <!-- Mask the route under the vehicle with a contrasting backing. -->
+            <circle cx="0" cy="0" r="16" fill="${contrastColor}"/>
+
+            <g stroke="${color}" fill="${color}">
                 <!-- Directional arrow -->
                 ${arrowPath}
 
                 <!-- Circle background -->
-                <circle cx="0" cy="0" r="13" stroke-width="2" fill="white"/>
+                <circle cx="0" cy="0" r="13" stroke-width="2" fill="${contrastColor}"/>
 
                 <!-- vehicle icon inside the circle -->
                 ${vehicleSvg}
@@ -75,4 +98,4 @@ function createVehicleIconSvg(
         </svg>`;
 }
 
-export { createVehicleIconSvg, iconWidth, iconHeight };
+export { createVehicleIconSvg, getVehicleMarkerContrastColor, iconWidth, iconHeight };

--- a/src/lib/MapHelpers/generateVehicleIcon.js
+++ b/src/lib/MapHelpers/generateVehicleIcon.js
@@ -30,27 +30,47 @@ function getDirectionFromOrientation(orientation) {
 const HIGHLIGHT_GLOW_COLOR = env.PUBLIC_COLOR_VEHICLE_HIGHLIGHT || '#FACC15';
 
 /**
- * Returns the neutral colour that has the strongest contrast against the
- * vehicle/route colour. The vehicle marker deliberately keeps the route colour
- * for recognition, but this backing prevents it from disappearing into a
- * same-colour route polyline.
+ * Returns the neutral colour with the strongest worst-case contrast against
+ * both the vehicle/route colour and the current basemap. The vehicle marker
+ * deliberately keeps the route colour for recognition, but this backing keeps
+ * it visible where it crosses its route without letting it sink into a dark
+ * basemap.
  *
  * @param {string} color
+ * @param {boolean} [dark=false]
  * @returns {'#ffffff' | '#000000'}
  */
-function getVehicleMarkerContrastColor(color) {
-	return contrastRatio(color, '#ffffff') >= contrastRatio(color, '#000000') ? '#ffffff' : '#000000';
+function getVehicleMarkerContrastColor(color, dark = false) {
+	// These are representative neutral basemap colours for the two map themes.
+	// Score each candidate by its weaker contrast: a backing that only contrasts
+	// with the route but blends into the map is not useful.
+	const basemapColor = dark ? '#1a1a1a' : '#ffffff';
+	const contrastScore = (candidate) =>
+		Math.min(contrastRatio(color, candidate), contrastRatio(basemapColor, candidate));
+
+	return contrastScore('#ffffff') >= contrastScore('#000000') ? '#ffffff' : '#000000';
 }
 
+/**
+ * Creates the SVG used for a live vehicle marker.
+ *
+ * @param {number} orientation
+ * @param {string} [color='#007BFF']
+ * @param {number} [routeType=RouteType.BUS]
+ * @param {boolean} [highlighted=false]
+ * @param {boolean} [dark=false]
+ * @returns {string}
+ */
 function createVehicleIconSvg(
 	orientation,
 	color = '#007BFF',
 	routeType = RouteType.BUS,
-	highlighted = false
+	highlighted = false,
+	dark = false
 ) {
 	const direction = getDirectionFromOrientation(toDirection(orientation));
 	const angle = DIRECTIONS.find((d) => d.icon === direction).angle;
-	const contrastColor = getVehicleMarkerContrastColor(color);
+	const contrastColor = getVehicleMarkerContrastColor(color, dark);
 
 	// Draw the directional arrow twice: a broad neutral stroke first, then the
 	// route-coloured arrow. This makes the direction indicator legible even
@@ -68,10 +88,10 @@ function createVehicleIconSvg(
 	const highlightDefs = highlighted
 		? `<defs><filter id="vehicle-highlight-blur" x="-100%" y="-100%" width="300%" height="300%"><feGaussianBlur stdDeviation="2.5"/></filter></defs>`
 		: '';
-	// A solid halo ring sized well beyond the white circle so it's clearly
+	// A solid halo ring sized well beyond the marker backing so it remains clearly
 	// visible, softened with a blur. Drawn behind so the arrow/icon stay crisp.
 	const highlightGlow = highlighted
-		? `<circle cx="0" cy="0" r="20" fill="${HIGHLIGHT_GLOW_COLOR}" stroke="none" opacity="0.95" filter="url(#vehicle-highlight-blur)"/>`
+		? `<circle cx="0" cy="0" r="23" fill="${HIGHLIGHT_GLOW_COLOR}" stroke="none" opacity="0.95" filter="url(#vehicle-highlight-blur)"/>`
 		: '';
 
 	const vehicleSvg = generateRouteTypeSvgForDisplay(routeType);
@@ -89,7 +109,7 @@ function createVehicleIconSvg(
                 <!-- Directional arrow -->
                 ${arrowPath}
 
-                <!-- Circle background -->
+				<!-- Contrasting marker backing -->
                 <circle cx="0" cy="0" r="13" stroke-width="2" fill="${contrastColor}"/>
 
                 <!-- vehicle icon inside the circle -->

--- a/src/lib/MapHelpers/generateVehicleIcon.js
+++ b/src/lib/MapHelpers/generateVehicleIcon.js
@@ -30,25 +30,14 @@ function getDirectionFromOrientation(orientation) {
 const HIGHLIGHT_GLOW_COLOR = env.PUBLIC_COLOR_VEHICLE_HIGHLIGHT || '#FACC15';
 
 /**
- * Returns the neutral colour with the strongest worst-case contrast against
- * both the vehicle/route colour and the current basemap. The vehicle marker
- * deliberately keeps the route colour for recognition, but this backing keeps
- * it visible where it crosses its route without letting it sink into a dark
- * basemap.
+ * Returns the neutral backing with the strongest contrast against the glyph
+ * and arrow. The outer halo handles basemap contrast separately.
  *
  * @param {string} color
- * @param {boolean} [dark=false]
  * @returns {'#ffffff' | '#000000'}
  */
-function getVehicleMarkerContrastColor(color, dark = false) {
-	// These are representative neutral basemap colours for the two map themes.
-	// Score each candidate by its weaker contrast: a backing that only contrasts
-	// with the route but blends into the map is not useful.
-	const basemapColor = dark ? '#1a1a1a' : '#ffffff';
-	const contrastScore = (candidate) =>
-		Math.min(contrastRatio(color, candidate), contrastRatio(basemapColor, candidate));
-
-	return contrastScore('#ffffff') >= contrastScore('#000000') ? '#ffffff' : '#000000';
+function getVehicleMarkerContrastColor(color) {
+	return contrastRatio(color, '#ffffff') >= contrastRatio(color, '#000000') ? '#ffffff' : '#000000';
 }
 
 /**
@@ -70,12 +59,20 @@ function createVehicleIconSvg(
 ) {
 	const direction = getDirectionFromOrientation(toDirection(orientation));
 	const angle = DIRECTIONS.find((d) => d.icon === direction).angle;
-	const contrastColor = getVehicleMarkerContrastColor(color, dark);
+	const contrastColor = getVehicleMarkerContrastColor(color);
+	// Keep a light silhouette on dark tiles without forcing pale glyphs onto
+	// white. In light mode the route-coloured ring supplies the silhouette.
+	const haloColor = dark ? '#ffffff' : contrastColor;
+	const arrowHalo =
+		haloColor !== contrastColor
+			? `<line x1="0" y1="0" x2="0" y2="-15" stroke="${haloColor}" stroke-width="8" stroke-linecap="round" transform="rotate(${angle})"/>
+    <polygon points="0,-25 5,-15 -5,-15" fill="${haloColor}" stroke="${haloColor}" stroke-width="6" stroke-linejoin="round" transform="rotate(${angle})"/>`
+			: '';
 
-	// Draw the directional arrow twice: a broad neutral stroke first, then the
-	// route-coloured arrow. This makes the direction indicator legible even
-	// when it lies directly over a route of the same colour.
+	// Draw the route-coloured arrow over a contrasting outline, with an extra
+	// outer halo when needed to distinguish that outline from the basemap.
 	const arrowPath = `
+    ${arrowHalo}
     <line x1="0" y1="0" x2="0" y2="-15" stroke="${contrastColor}" stroke-width="6" stroke-linecap="round" transform="rotate(${angle})"/>
     <polygon points="0,-25 5,-15 -5,-15" fill="${contrastColor}" stroke="${contrastColor}" stroke-width="4" stroke-linejoin="round" transform="rotate(${angle})"/>
     <line x1="0" y1="0" x2="0" y2="-15" stroke="${color}" stroke-width="2" stroke-linecap="round" transform="rotate(${angle})"/>
@@ -103,13 +100,13 @@ function createVehicleIconSvg(
             ${highlightGlow}
 
             <!-- Mask the route under the vehicle with a contrasting backing. -->
-            <circle cx="0" cy="0" r="16" fill="${contrastColor}"/>
+            <circle cx="0" cy="0" r="16" fill="${haloColor}"/>
 
             <g stroke="${color}" fill="${color}">
                 <!-- Directional arrow -->
                 ${arrowPath}
 
-				<!-- Contrasting marker backing -->
+                <!-- Route-coloured ring; the fill masks the arrow shaft beneath the glyph. -->
                 <circle cx="0" cy="0" r="13" stroke-width="2" fill="${contrastColor}"/>
 
                 <!-- vehicle icon inside the circle -->

--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -427,6 +427,12 @@ export default class GoogleMapProvider {
 		});
 
 		this.vehicleMarkers.push(marker);
+		marker.vehicleIconOptions = {
+			orientation: vehicle?.orientation,
+			color,
+			routeType,
+			isHighlighted
+		};
 
 		const vehicleData = $state(buildVehiclePopupData(vehicle, activeTrip, this.stopsMap));
 
@@ -473,24 +479,43 @@ export default class GoogleMapProvider {
 			color = COLORS.VEHICLE_REAL_TIME_OFF;
 		}
 
-		const updatedIcon = createVehicleIconSvg(
-			vehicleStatus.orientation,
+		marker.vehicleIconOptions = {
+			orientation: vehicleStatus.orientation,
 			color,
 			routeType,
-			isHighlighted,
-			this._darkTheme
-		);
-		marker.setIcon({
-			url: `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(updatedIcon)}`,
-			scaledSize: new google.maps.Size(iconWidth, iconHeight),
-			anchor: new google.maps.Point(iconWidth / 2, iconHeight / 2)
-		});
+			isHighlighted
+		};
+		this._setVehicleMarkerIcon(marker);
 		marker.setZIndex(isHighlighted ? 2000 : 1000);
 
 		Object.assign(
 			marker.vehicleData,
 			buildVehiclePopupData(vehicleStatus, activeTrip, this.stopsMap)
 		);
+	}
+
+	_setVehicleMarkerIcon(marker) {
+		const { orientation, color, routeType, isHighlighted } = marker.vehicleIconOptions;
+		const vehicleIconSvg = createVehicleIconSvg(
+			orientation,
+			color,
+			routeType,
+			isHighlighted,
+			this._darkTheme
+		);
+		marker.setIcon({
+			url: `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(vehicleIconSvg)}`,
+			scaledSize: new google.maps.Size(iconWidth, iconHeight),
+			anchor: new google.maps.Point(iconWidth / 2, iconHeight / 2)
+		});
+	}
+
+	_refreshVehicleMarkerIcons() {
+		for (const marker of this.vehicleMarkers) {
+			if (marker.vehicleIconOptions) {
+				this._setVehicleMarkerIcon(marker);
+			}
+		}
 	}
 
 	removeVehicleMarker(marker) {
@@ -587,6 +612,7 @@ export default class GoogleMapProvider {
 	setTheme(theme) {
 		this._darkTheme = theme === 'dark';
 		this._applyStyles();
+		this._refreshVehicleMarkerIcons();
 	}
 
 	setBasemapDimmed(dimmed) {

--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -410,7 +410,8 @@ export default class GoogleMapProvider {
 			vehicle?.orientation,
 			color,
 			routeType,
-			isHighlighted
+			isHighlighted,
+			this._darkTheme
 		);
 		const icon = {
 			url: `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(vehicleIconSvg)}`,
@@ -476,7 +477,8 @@ export default class GoogleMapProvider {
 			vehicleStatus.orientation,
 			color,
 			routeType,
-			isHighlighted
+			isHighlighted,
+			this._darkTheme
 		);
 		marker.setIcon({
 			url: `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(updatedIcon)}`,

--- a/src/lib/Provider/GoogleMapProvider.svelte.js
+++ b/src/lib/Provider/GoogleMapProvider.svelte.js
@@ -772,6 +772,17 @@ export default class GoogleMapProvider {
 		return polyline;
 	}
 
+	// Recolor in place so a theme switch preserves the camera, casing and reveal.
+	setPolylineColor(polyline, color) {
+		if (!polyline) return;
+		const icons = (polyline.get('icons') || []).map((entry) => {
+			const isArrow = entry.icon.path === google.maps.SymbolPath.FORWARD_CLOSED_ARROW;
+			const iconColor = isArrow ? polylineArrowColor(color) : color || COLORS.POLYLINE;
+			return { ...entry, icon: { ...entry.icon, strokeColor: iconColor, fillColor: iconColor } };
+		});
+		polyline.setOptions({ strokeColor: color || COLORS.POLYLINE, icons });
+	}
+
 	/**
 	 * Moves an already-drawn polyline to a different stacking layer — used to
 	 * promote the expanded arrival's route above its peers. Uniform in intent

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -476,6 +476,12 @@ export default class OpenStreetMapProvider {
 		});
 
 		this.vehicleMarkers.push(marker);
+		marker.vehicleIconOptions = {
+			orientation: vehicle?.orientation,
+			color,
+			routeType,
+			isHighlighted
+		};
 
 		const vehicleData = $state(buildVehiclePopupData(vehicle, activeTrip, this.stopsMap));
 
@@ -519,19 +525,12 @@ export default class OpenStreetMapProvider {
 			color = COLORS.VEHICLE_REAL_TIME_OFF;
 		}
 
-		const updatedIconSvg = createVehicleIconSvg(
-			vehicleStatus.orientation,
+		marker.vehicleIconOptions = {
+			orientation: vehicleStatus.orientation,
 			color,
 			routeType,
-			isHighlighted,
-			this._darkTheme
-		);
-		const updatedIcon = this.L.divIcon({
-			html: `<img alt="" src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(updatedIconSvg)}" />`,
-			iconSize: [iconWidth, iconHeight],
-			iconAnchor: [iconWidth / 2, iconHeight / 2],
-			className: ''
-		});
+			isHighlighted
+		};
 
 		const current = marker.getLatLng();
 		animateMarkerTo(
@@ -541,7 +540,7 @@ export default class OpenStreetMapProvider {
 			(lat, lng) => marker.setLatLng([lat, lng]),
 			{ routePaths: this._getRoutePaths() }
 		);
-		marker.setIcon(updatedIcon);
+		this._setVehicleMarkerIcon(marker);
 		// setIcon doesn't touch stacking order, so update the offset directly to
 		// reflect the current highlight state (divIcon ignores zIndexOffset).
 		marker.setZIndexOffset(isHighlighted ? 2000 : 1000);
@@ -559,6 +558,32 @@ export default class OpenStreetMapProvider {
 			marker.vehicleData,
 			buildVehiclePopupData(vehicleStatus, activeTrip, this.stopsMap)
 		);
+	}
+
+	_setVehicleMarkerIcon(marker) {
+		const { orientation, color, routeType, isHighlighted } = marker.vehicleIconOptions;
+		const vehicleIconSvg = createVehicleIconSvg(
+			orientation,
+			color,
+			routeType,
+			isHighlighted,
+			this._darkTheme
+		);
+		const icon = this.L.divIcon({
+			html: `<img alt="" src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(vehicleIconSvg)}" />`,
+			iconSize: [iconWidth, iconHeight],
+			iconAnchor: [iconWidth / 2, iconHeight / 2],
+			className: ''
+		});
+		marker.setIcon(icon);
+	}
+
+	_refreshVehicleMarkerIcons() {
+		for (const marker of this.vehicleMarkers) {
+			if (marker.vehicleIconOptions) {
+				this._setVehicleMarkerIcon(marker);
+			}
+		}
 	}
 	removeVehicleMarker(marker) {
 		if (marker) {
@@ -682,6 +707,7 @@ export default class OpenStreetMapProvider {
 	setTheme(theme) {
 		this._darkTheme = theme === 'dark';
 		if (!browser || !this.map) return;
+		this._refreshVehicleMarkerIcons();
 
 		let styleUrl;
 		if (theme === 'dark') {

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -77,6 +77,7 @@ export default class OpenStreetMapProvider {
 		this.contextMenuPopup = null;
 		this.contextMenuComponent = null;
 		this.userLocationMarker = null;
+		this._darkTheme = this.maplibreLayer === 'dark';
 		// Incremented on each fitToPolylines() so a superseded route load's
 		// pending reveal can detect it's stale and bail out.
 		this._fitToken = 0;
@@ -448,7 +449,8 @@ export default class OpenStreetMapProvider {
 			vehicle?.orientation,
 			color,
 			routeType,
-			isHighlighted
+			isHighlighted,
+			this._darkTheme
 		);
 		const zIndexOffset = isHighlighted ? 2000 : 1000;
 		const customIcon = this.L.divIcon({
@@ -521,7 +523,8 @@ export default class OpenStreetMapProvider {
 			vehicleStatus.orientation,
 			color,
 			routeType,
-			isHighlighted
+			isHighlighted,
+			this._darkTheme
 		);
 		const updatedIcon = this.L.divIcon({
 			html: `<img alt="" src="data:image/svg+xml;charset=UTF-8,${encodeURIComponent(updatedIconSvg)}" />`,
@@ -677,6 +680,7 @@ export default class OpenStreetMapProvider {
 	}
 
 	setTheme(theme) {
+		this._darkTheme = theme === 'dark';
 		if (!browser || !this.map) return;
 
 		let styleUrl;

--- a/src/lib/Provider/OpenStreetMapProvider.svelte.js
+++ b/src/lib/Provider/OpenStreetMapProvider.svelte.js
@@ -814,6 +814,31 @@ export default class OpenStreetMapProvider {
 		return polyline;
 	}
 
+	// Recolor in place so a theme switch preserves the camera, casing and reveal.
+	setPolylineColor(polyline, color) {
+		if (!polyline) return;
+		polyline.setStyle({ color: color || COLORS.POLYLINE });
+		if (polyline.arrowDecorator) {
+			const arrowColor = polylineArrowColor(color);
+			polyline.arrowDecorator.setPatterns([
+				{
+					offset: 0,
+					repeat: 125,
+					symbol: this.L.Symbol.arrowHead({
+						pixelSize: 12,
+						pathOptions: {
+							color: arrowColor,
+							fill: true,
+							fillColor: arrowColor,
+							fillOpacity: 0.85,
+							...(polyline.options.pane ? { pane: polyline.options.pane } : {})
+						}
+					})
+				}
+			]);
+		}
+	}
+
 	/**
 	 * Moves an already-drawn polyline to a different stacking pane — used to
 	 * promote the expanded arrival's route above its peers.

--- a/src/lib/__tests__/vehicleUtils.test.js
+++ b/src/lib/__tests__/vehicleUtils.test.js
@@ -74,6 +74,53 @@ describe('buildVehiclePopupData', () => {
 	});
 });
 
+test('refreshes cached vehicles with new colors without fetching, and retains them on later polls', async () => {
+	clearVehicleMarkersMap();
+	const provider = {
+		addVehicleMarker: vi.fn(() => ({})),
+		updateVehicleMarker: vi.fn(),
+		removeVehicleMarker: vi.fn()
+	};
+	const colors = new Map([['route-1', { line: '#003366' }]]);
+	const data = tripsResponse('route-1', [{ tripId: 'trip-1', vehicleId: 'v-1' }]);
+	vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => data }));
+	const poll = await fetchAndUpdateVehiclesForRoutes([{ id: 'route-1' }], provider, {
+		colorsByRouteId: colors,
+		highlightedTripId: 'trip-1'
+	});
+	try {
+		for (const color of ['#8099b3', '#003366']) {
+			colors.set('route-1', { line: color });
+			fetch.mockClear();
+			poll.refresh();
+			expect(fetch).not.toHaveBeenCalled();
+			expect(provider.updateVehicleMarker).toHaveBeenLastCalledWith(
+				provider.addVehicleMarker.mock.results[0].value,
+				expect.objectContaining({ predicted: true }),
+				expect.objectContaining({ id: 'trip-1' }),
+				undefined,
+				true,
+				color
+			);
+			await poll.tick();
+			expect(provider.updateVehicleMarker.mock.calls.at(-1)[5]).toBe(color);
+		}
+		// An empty successful poll must discard the old payload so refreshing
+		// after a theme change cannot resurrect vehicles that have left service.
+		fetch.mockResolvedValue({ ok: true, json: async () => tripsResponse('route-1', []) });
+		await poll.tick();
+		provider.addVehicleMarker.mockClear();
+		provider.updateVehicleMarker.mockClear();
+		poll.refresh();
+		expect(provider.addVehicleMarker).not.toHaveBeenCalled();
+		expect(provider.updateVehicleMarker).not.toHaveBeenCalled();
+	} finally {
+		clearInterval(poll.intervalId);
+		clearVehicleMarkersMap();
+		vi.unstubAllGlobals();
+	}
+});
+
 // This suite used to drive the now-deleted single-route `updateVehicleMarkers`
 // wrapper directly. That wrapper had zero production callers (SearchPane and
 // RouteMap both go through `fetchAndUpdateVehicles`) and only duplicated what

--- a/src/lib/__tests__/vehicleUtils.test.js
+++ b/src/lib/__tests__/vehicleUtils.test.js
@@ -121,6 +121,72 @@ test('refreshes cached vehicles with new colors without fetching, and retains th
 	}
 });
 
+test.each(['older first', 'newer first'])(
+	'ignores superseded polls and retains the latest positions for refresh (%s)',
+	async (completionOrder) => {
+		clearVehicleMarkersMap();
+		const provider = {
+			addVehicleMarker: vi.fn(() => ({})),
+			updateVehicleMarker: vi.fn(),
+			removeVehicleMarker: vi.fn()
+		};
+		const onCounts = vi.fn();
+		const olderData = tripsResponse('route-1', [{ tripId: 'trip-1', vehicleId: 'v-1' }]);
+		const newerData = tripsResponse('route-1', [
+			{ tripId: 'trip-1', vehicleId: 'v-1' },
+			{ tripId: 'trip-2', vehicleId: 'v-2' }
+		]);
+		newerData.data.list[0].status.position.lat = 48;
+		const response = (data) => ({ ok: true, json: async () => data });
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response(olderData)));
+		const poll = await fetchAndUpdateVehiclesForRoutes([{ id: 'route-1' }], provider, { onCounts });
+		try {
+			let finishOlder;
+			let finishNewer;
+			fetch.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						finishOlder = resolve;
+					})
+			);
+			fetch.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						finishNewer = resolve;
+					})
+			);
+			const older = poll.tick();
+			const newer = poll.tick();
+			const finishLatest = async () => {
+				finishNewer(response(newerData));
+				await newer;
+				expect(provider.updateVehicleMarker.mock.calls.at(-1)[1].position.lat).toBe(48);
+				expect(onCounts).toHaveBeenLastCalledWith(new Map([['route-1', 2]]));
+			};
+			if (completionOrder === 'newer first') await finishLatest();
+			provider.addVehicleMarker.mockClear();
+			provider.updateVehicleMarker.mockClear();
+			provider.removeVehicleMarker.mockClear();
+			onCounts.mockClear();
+			finishOlder(response(olderData));
+			await older;
+			expect(provider.addVehicleMarker).not.toHaveBeenCalled();
+			expect(provider.updateVehicleMarker).not.toHaveBeenCalled();
+			expect(provider.removeVehicleMarker).not.toHaveBeenCalled();
+			expect(onCounts).not.toHaveBeenCalled();
+			if (completionOrder === 'older first') await finishLatest();
+			provider.updateVehicleMarker.mockClear();
+			poll.refresh();
+			expect(provider.updateVehicleMarker).toHaveBeenCalledTimes(2);
+			expect(provider.updateVehicleMarker.mock.calls[0][1].position.lat).toBe(48);
+		} finally {
+			clearInterval(poll.intervalId);
+			clearVehicleMarkersMap();
+			vi.unstubAllGlobals();
+		}
+	}
+);
+
 // This suite used to drive the now-deleted single-route `updateVehicleMarkers`
 // wrapper directly. That wrapper had zero production callers (SearchPane and
 // RouteMap both go through `fetchAndUpdateVehicles`) and only duplicated what

--- a/src/lib/vehicleUtils.js
+++ b/src/lib/vehicleUtils.js
@@ -150,6 +150,7 @@ export async function fetchAndUpdateVehiclesForRoutes(
 	const resolveHighlightedTripId = () =>
 		typeof highlightedTripId === 'function' ? highlightedTripId() : highlightedTripId;
 	const lastData = new Map();
+	let tickGeneration = 0;
 	const refresh = () => {
 		for (const route of routes) {
 			const data = lastData.get(route.id);
@@ -167,6 +168,7 @@ export async function fetchAndUpdateVehiclesForRoutes(
 	};
 
 	const tick = async () => {
+		const generation = ++tickGeneration;
 		const results = await Promise.all(
 			routes.map((route) =>
 				fetchVehicles(route.id).catch((error) => {
@@ -175,6 +177,9 @@ export async function fetchAndUpdateVehiclesForRoutes(
 				})
 			)
 		);
+		// Interval and manual ticks can overlap. A superseded response must not
+		// move markers backwards, replace the refresh cache, or sweep newer data.
+		if (generation !== tickGeneration) return;
 
 		const activeKeys = new Set();
 		const polledRouteIds = new Set();

--- a/src/lib/vehicleUtils.js
+++ b/src/lib/vehicleUtils.js
@@ -135,10 +135,12 @@ const VEHICLE_POLL_INTERVAL_MS = 30000;
  * per route-set redraw, but the highlighted trip changes independently of
  * that redraw (see StopRoutesLayer's second effect), so a value captured at
  * start time would go stale until the next redraw.
- * @returns {Promise<{intervalId: number, tick: () => Promise<void>}>} the
+ * @returns {Promise<{intervalId: number, tick: () => Promise<void>, refresh: () => void}>} the
  * poll's interval id, plus `tick` so a caller can force an immediate refresh
  * (e.g. to move the highlight glow right away) instead of waiting up to
- * VEHICLE_POLL_INTERVAL_MS for the next scheduled one.
+ * VEHICLE_POLL_INTERVAL_MS for the next scheduled one. `refresh` reapplies the
+ * last successful data with the current colors/highlight without a network
+ * request, so theme changes remain immediate even when offline.
  */
 export async function fetchAndUpdateVehiclesForRoutes(
 	routes,
@@ -147,6 +149,22 @@ export async function fetchAndUpdateVehiclesForRoutes(
 ) {
 	const resolveHighlightedTripId = () =>
 		typeof highlightedTripId === 'function' ? highlightedTripId() : highlightedTripId;
+	const lastData = new Map();
+	const refresh = () => {
+		for (const route of routes) {
+			const data = lastData.get(route.id);
+			if (data) {
+				applyRouteVehicles(
+					data,
+					route.id,
+					mapProvider,
+					route.type,
+					resolveHighlightedTripId(),
+					colorsByRouteId.get(route.id)?.line
+				);
+			}
+		}
+	};
 
 	const tick = async () => {
 		const results = await Promise.all(
@@ -180,6 +198,7 @@ export async function fetchAndUpdateVehiclesForRoutes(
 					resolveHighlightedTripId(),
 					colorsByRouteId.get(route.id)?.line
 				);
+				lastData.set(route.id, data);
 				polledRouteIds.add(route.id);
 				routeKeys.forEach((key) => activeKeys.add(key));
 				counts.set(route.id, routeKeys.size);
@@ -208,17 +227,17 @@ export async function fetchAndUpdateVehiclesForRoutes(
 		});
 	}, VEHICLE_POLL_INTERVAL_MS);
 
-	return { intervalId, tick };
+	return { intervalId, tick, refresh };
 }
 
 /**
- * Single-route wrapper, kept so SearchPane and RouteMap run through the same
+ * Single-route wrapper, kept so SearchPane runs through the same
  * code path. Signature and behavior are unchanged: unlike
  * `fetchAndUpdateVehiclesForRoutes`, this still resolves to a bare interval
- * id — SearchPane.svelte and RouteMap.svelte both do
+ * id — SearchPane.svelte does
  * `currentIntervalId = await fetchAndUpdateVehicles(...)` and later
  * `clearInterval(currentIntervalId)`, so returning `{ intervalId, tick }`
- * here instead would silently break both.
+ * here instead would silently break that caller.
  */
 export async function fetchAndUpdateVehicles(
 	routeId,

--- a/src/tests/lib/GoogleMapProvider.test.js
+++ b/src/tests/lib/GoogleMapProvider.test.js
@@ -138,7 +138,7 @@ describe('addVehicleMarker — route color', () => {
 			false,
 			'#0a4ea2'
 		);
-		expect(createVehicleIconSvg).toHaveBeenCalledWith(90, '#0a4ea2', 3, false);
+		expect(createVehicleIconSvg).toHaveBeenCalledWith(90, '#0a4ea2', 3, false, false);
 	});
 
 	test('gray override still wins for a non-predicted vehicle', () => {
@@ -149,7 +149,7 @@ describe('addVehicleMarker — route color', () => {
 			false,
 			'#0a4ea2'
 		);
-		expect(createVehicleIconSvg).toHaveBeenCalledWith(90, '#808080', 3, false);
+		expect(createVehicleIconSvg).toHaveBeenCalledWith(90, '#808080', 3, false, false);
 	});
 
 	test('null route color falls back to the icon default (no null paint)', () => {
@@ -160,7 +160,17 @@ describe('addVehicleMarker — route color', () => {
 			false,
 			null
 		);
-		expect(createVehicleIconSvg).toHaveBeenCalledWith(90, undefined, 3, false);
+		expect(createVehicleIconSvg).toHaveBeenCalledWith(90, undefined, 3, false, false);
+	});
+
+	test('passes the current dark-map state to the icon', () => {
+		provider._darkTheme = true;
+		provider.addVehicleMarker(
+			{ position: { lat: 47.6, lon: -122.3 }, predicted: true, orientation: 90 },
+			{ tripHeadsign: 'Northgate' },
+			3
+		);
+		expect(createVehicleIconSvg).toHaveBeenCalledWith(90, undefined, 3, false, true);
 	});
 });
 

--- a/src/tests/lib/GoogleMapProvider.test.js
+++ b/src/tests/lib/GoogleMapProvider.test.js
@@ -451,6 +451,27 @@ describe('setBasemapDimmed / setTheme composition', () => {
 		expect(lastStyles.slice(0, base.length)).toEqual(base);
 		expect(lastStyles.at(-1).stylers.some((v) => 'saturation' in v)).toBe(true);
 	});
+
+	test('refreshes existing vehicle icons for the new theme', () => {
+		const provider = makeProvider();
+		provider.map = { setOptions: vi.fn() };
+		setupGoogleMaps(makeGoogleMarkerMock());
+		const marker = {
+			vehicleIconOptions: {
+				orientation: 90,
+				color: '#007BFF',
+				routeType: 3,
+				isHighlighted: false
+			},
+			setIcon: vi.fn()
+		};
+		provider.vehicleMarkers = [marker];
+
+		provider.setTheme('dark');
+
+		expect(createVehicleIconSvg).toHaveBeenLastCalledWith(90, '#007BFF', 3, false, true);
+		expect(marker.setIcon).toHaveBeenCalledOnce();
+	});
 });
 
 // Shared by both the createPolyline and setPolylineLayer suites below, since

--- a/src/tests/lib/GoogleMapProvider.test.js
+++ b/src/tests/lib/GoogleMapProvider.test.js
@@ -2,6 +2,7 @@ import { describe, test, expect, vi, beforeEach } from 'vitest';
 import GoogleMapProvider from '$lib/Provider/GoogleMapProvider.svelte.js';
 import { createVehicleIconSvg } from '$lib/MapHelpers/generateVehicleIcon';
 import { nightModeStyles } from '$lib/googleMaps';
+import { polylineArrowColor } from '$lib/colorUtils';
 
 vi.mock('$components/map/StopMarker.svelte', () => ({ default: {} }));
 vi.mock('$components/map/PopupContent.svelte', () => ({ default: {} }));
@@ -20,6 +21,33 @@ vi.mock('$lib/MapHelpers/animateMarker', () => ({
 vi.mock('$lib/vehicleUtils', () => ({
 	buildVehiclePopupData: vi.fn(() => ({}))
 }));
+
+test('recolors a Google route and its arrows without replacing its geometry', () => {
+	const provider = new GoogleMapProvider('test-key', vi.fn());
+	global.google = { maps: { SymbolPath: { FORWARD_CLOSED_ARROW: 'arrow' } } };
+	const icons = [
+		{ icon: { path: 'arrow', scale: 2 }, repeat: '50px' },
+		{ icon: { path: 'M 0,-1 0,1', scale: 5 }, repeat: '20px' }
+	];
+	const polyline = { get: vi.fn(() => icons), setOptions: vi.fn() };
+	for (const color of ['#8099b3', '#003366']) {
+		provider.setPolylineColor(polyline, color);
+		expect(polyline.setOptions).toHaveBeenLastCalledWith({
+			strokeColor: color,
+			icons: [
+				{
+					...icons[0],
+					icon: {
+						...icons[0].icon,
+						strokeColor: polylineArrowColor(color),
+						fillColor: polylineArrowColor(color)
+					}
+				},
+				{ ...icons[1], icon: { ...icons[1].icon, strokeColor: color, fillColor: color } }
+			]
+		});
+	}
+});
 // nightModeStyles is the real implementation (not stubbed to []): the
 // setBasemapDimmed/setTheme composition tests below need a genuinely
 // non-empty base theme to prove _applyStyles actually merges theme + dim,
@@ -452,25 +480,40 @@ describe('setBasemapDimmed / setTheme composition', () => {
 		expect(lastStyles.at(-1).stylers.some((v) => 'saturation' in v)).toBe(true);
 	});
 
-	test('refreshes existing vehicle icons for the new theme', () => {
+	test('refreshes the rendered vehicle SVG in both theme directions', async () => {
 		const provider = makeProvider();
 		provider.map = { setOptions: vi.fn() };
 		setupGoogleMaps(makeGoogleMarkerMock());
 		const marker = {
 			vehicleIconOptions: {
 				orientation: 90,
-				color: '#007BFF',
+				color: '#dddddd',
 				routeType: 3,
-				isHighlighted: false
+				isHighlighted: true
 			},
 			setIcon: vi.fn()
 		};
 		provider.vehicleMarkers = [marker];
 
-		provider.setTheme('dark');
-
-		expect(createVehicleIconSvg).toHaveBeenLastCalledWith(90, '#007BFF', 3, false, true);
-		expect(marker.setIcon).toHaveBeenCalledOnce();
+		const actual = await vi.importActual('$lib/MapHelpers/generateVehicleIcon');
+		createVehicleIconSvg.mockImplementation(actual.createVehicleIconSvg);
+		try {
+			for (const theme of ['dark', 'light']) {
+				provider.setTheme(theme);
+				const url = marker.setIcon.mock.calls.at(-1)[0].url;
+				const svg = new DOMParser().parseFromString(
+					decodeURIComponent(url.split(',')[1]),
+					'image/svg+xml'
+				);
+				expect(svg.querySelector('circle[r="13"]').getAttribute('fill')).toBe('#000000');
+				expect(svg.querySelector('circle[r="16"]').getAttribute('fill')).toBe(
+					theme === 'dark' ? '#ffffff' : '#000000'
+				);
+				expect(svg.querySelector('filter')).not.toBeNull();
+			}
+		} finally {
+			createVehicleIconSvg.mockImplementation(() => '<svg></svg>');
+		}
 	});
 });
 

--- a/src/tests/lib/OpenStreetMapProvider.test.js
+++ b/src/tests/lib/OpenStreetMapProvider.test.js
@@ -361,7 +361,7 @@ describe('addVehicleMarker — route color', () => {
 
 	test('passes the route color to the icon for a predicted vehicle', () => {
 		provider.addVehicleMarker(VEHICLE, { tripHeadsign: 'Northgate' }, 3, false, '#0a4ea2');
-		expect(createVehicleIconSvg).toHaveBeenCalledWith(90, '#0a4ea2', 3, false);
+		expect(createVehicleIconSvg).toHaveBeenCalledWith(90, '#0a4ea2', 3, false, false);
 	});
 
 	test('gray override still wins for a non-predicted vehicle', () => {
@@ -372,12 +372,18 @@ describe('addVehicleMarker — route color', () => {
 			false,
 			'#0a4ea2'
 		);
-		expect(createVehicleIconSvg).toHaveBeenCalledWith(90, '#808080', 3, false);
+		expect(createVehicleIconSvg).toHaveBeenCalledWith(90, '#808080', 3, false, false);
 	});
 
 	test('null route color falls back to the icon default', () => {
 		provider.addVehicleMarker(VEHICLE, { tripHeadsign: 'Northgate' }, 3, false, null);
-		expect(createVehicleIconSvg).toHaveBeenCalledWith(90, undefined, 3, false);
+		expect(createVehicleIconSvg).toHaveBeenCalledWith(90, undefined, 3, false, false);
+	});
+
+	test('passes the current dark-map state to the icon', () => {
+		provider._darkTheme = true;
+		provider.addVehicleMarker(VEHICLE, { tripHeadsign: 'Northgate' }, 3);
+		expect(createVehicleIconSvg).toHaveBeenCalledWith(90, undefined, 3, false, true);
 	});
 });
 

--- a/src/tests/lib/OpenStreetMapProvider.test.js
+++ b/src/tests/lib/OpenStreetMapProvider.test.js
@@ -436,6 +436,25 @@ describe('setTheme — avoids redundant layer rebuilds', () => {
 		expect(provider.L.maplibreGL).not.toHaveBeenCalled();
 	});
 
+	test('refreshes existing vehicle icons for the new theme', () => {
+		const marker = {
+			vehicleIconOptions: {
+				orientation: 90,
+				color: '#007BFF',
+				routeType: 3,
+				isHighlighted: false
+			},
+			setIcon: vi.fn()
+		};
+		provider.L.divIcon = vi.fn(() => ({}));
+		provider.vehicleMarkers = [marker];
+
+		provider.setTheme('dark');
+
+		expect(createVehicleIconSvg).toHaveBeenLastCalledWith(90, '#007BFF', 3, false, true);
+		expect(marker.setIcon).toHaveBeenCalledOnce();
+	});
+
 	test('bails out before the map is initialized', () => {
 		provider.map = null;
 		provider.setTheme('dark');

--- a/src/tests/lib/OpenStreetMapProvider.test.js
+++ b/src/tests/lib/OpenStreetMapProvider.test.js
@@ -3,6 +3,7 @@ import OpenStreetMapProvider, {
 	toLeafletPadding
 } from '$lib/Provider/OpenStreetMapProvider.svelte.js';
 import { createVehicleIconSvg } from '$lib/MapHelpers/generateVehicleIcon';
+import { polylineArrowColor } from '$lib/colorUtils';
 
 // Minimal Svelte component stubs — only imported by the module, never called
 // during these unit tests because we mock openStopMarker directly and never
@@ -25,6 +26,31 @@ vi.mock('$lib/MapHelpers/animateMarker', () => ({
 	animateMarkerTo: vi.fn(),
 	cancelMarkerAnimation: vi.fn()
 }));
+
+test('recolors a Leaflet route and its arrows while preserving the pane', () => {
+	const provider = new OpenStreetMapProvider(vi.fn());
+	provider.L = { Symbol: { arrowHead: vi.fn((options) => options) } };
+	const polyline = {
+		setStyle: vi.fn(),
+		options: { pane: 'promoted-route' },
+		arrowDecorator: { setPatterns: vi.fn() }
+	};
+	for (const color of ['#8099b3', '#003366']) {
+		provider.setPolylineColor(polyline, color);
+		expect(polyline.setStyle).toHaveBeenLastCalledWith({ color });
+		expect(polyline.arrowDecorator.setPatterns).toHaveBeenLastCalledWith([
+			expect.objectContaining({
+				symbol: expect.objectContaining({
+					pathOptions: expect.objectContaining({
+						color: polylineArrowColor(color),
+						fillColor: polylineArrowColor(color),
+						pane: 'promoted-route'
+					})
+				})
+			})
+		]);
+	}
+});
 
 vi.mock('polyline-encoded', () => ({
 	default: {
@@ -436,23 +462,42 @@ describe('setTheme — avoids redundant layer rebuilds', () => {
 		expect(provider.L.maplibreGL).not.toHaveBeenCalled();
 	});
 
-	test('refreshes existing vehicle icons for the new theme', () => {
+	test('refreshes the rendered vehicle SVG in both theme directions', async () => {
 		const marker = {
 			vehicleIconOptions: {
 				orientation: 90,
-				color: '#007BFF',
+				color: '#dddddd',
 				routeType: 3,
-				isHighlighted: false
+				isHighlighted: true
 			},
 			setIcon: vi.fn()
 		};
 		provider.L.divIcon = vi.fn(() => ({}));
 		provider.vehicleMarkers = [marker];
 
-		provider.setTheme('dark');
-
-		expect(createVehicleIconSvg).toHaveBeenLastCalledWith(90, '#007BFF', 3, false, true);
-		expect(marker.setIcon).toHaveBeenCalledOnce();
+		const actual = await vi.importActual('$lib/MapHelpers/generateVehicleIcon');
+		createVehicleIconSvg.mockImplementation(actual.createVehicleIconSvg);
+		try {
+			for (const theme of ['dark', 'light']) {
+				provider.setTheme(theme);
+				const html = provider.L.divIcon.mock.calls.at(-1)[0].html;
+				const url = new DOMParser()
+					.parseFromString(html, 'text/html')
+					.querySelector('img')
+					.getAttribute('src');
+				const svg = new DOMParser().parseFromString(
+					decodeURIComponent(url.split(',')[1]),
+					'image/svg+xml'
+				);
+				expect(svg.querySelector('circle[r="13"]').getAttribute('fill')).toBe('#000000');
+				expect(svg.querySelector('circle[r="16"]').getAttribute('fill')).toBe(
+					theme === 'dark' ? '#ffffff' : '#000000'
+				);
+				expect(svg.querySelector('filter')).not.toBeNull();
+			}
+		} finally {
+			createVehicleIconSvg.mockImplementation(() => '<svg></svg>');
+		}
 	});
 
 	test('bails out before the map is initialized', () => {


### PR DESCRIPTION
## Summary

- add a contrast-selected black or white backing behind vehicle markers
- outline directional arrows so they remain visible over matching route lines
- cover dark, light, and same-colour marker scenarios with regression tests

## Testing

- npm run lint
- all 1,796 tests passed; the four metrics tests were rerun with local port binding enabled

## Screenshots

<img width="764" height="504" alt="image" src="https://github.com/user-attachments/assets/1fe31d71-df72-4ef5-b692-09f51d190cc3" />


Closes #600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Routes now update their colors immediately when route colors or map themes change.
  * Existing vehicle markers refresh automatically when switching between light and dark map themes.
  * Vehicle markers use contrasting outlines, backing circles, and arrow styling for improved visibility across route colors and map themes.

* **Bug Fixes**
  * Improved directional arrow and marker legibility on dark maps and dark-colored routes.
  * Cached vehicle data now refreshes with updated route colors without requiring another network request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->