### PR TITLE
Rename Obaco/OneBusAway.co to Sidecar, deprecating the old env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ PRIVATE_OBA_GEOCODER_PROVIDER="google"
 # PRIVATE_OBACO_SHOW_TEST_ALERTS still work, but they are deprecated.
 # PRIVATE_SIDECAR_API_BASE_URL=https://sidecar.onebusaway.org/api/v1
 # PRIVATE_SIDECAR_REGION_ID=
-PRIVATE_SIDECAR_SHOW_TEST_ALERTS=false
+# PRIVATE_SIDECAR_SHOW_TEST_ALERTS=false
 
 # Comma-separated agency IDs to restrict this instance to.
 # Leave empty to show all agencies (default).

--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,16 @@ PRIVATE_OBA_API_KEY="test"
 PRIVATE_OBA_GEOCODER_API_KEY=""
 PRIVATE_OBA_GEOCODER_PROVIDER="google"
 
-PRIVATE_OBACO_API_BASE_URL=https://onebusaway.co/api/v1
-PRIVATE_REGION_ID=
-PRIVATE_OBACO_SHOW_TEST_ALERTS=false
+# Sidecar (formerly Obaco / OneBusAway.co) supplies service alerts and surveys.
+# It is optional; leave these unset to run without alerts and surveys.
+# Set the base URL and the region ID together — a base URL without a region ID
+# disables both features. A PRIVATE_SIDECAR_* value takes effect only when
+# non-empty, so leaving one blank keeps any pre-rename name you already have.
+# The pre-rename names PRIVATE_OBACO_API_BASE_URL, PRIVATE_REGION_ID, and
+# PRIVATE_OBACO_SHOW_TEST_ALERTS still work, but they are deprecated.
+# PRIVATE_SIDECAR_API_BASE_URL=https://sidecar.onebusaway.org/api/v1
+# PRIVATE_SIDECAR_REGION_ID=
+PRIVATE_SIDECAR_SHOW_TEST_ALERTS=false
 
 # Comma-separated agency IDs to restrict this instance to.
 # Leave empty to show all agencies (default).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ When writing tests, the setup file already mocks `$env/static/public`, `$env/sta
 
 ## Environment Variables
 
-`env-schema.json` defines every variable with its type, constraints, and whether it's required. Run `npm run validate-env` to check your `.env` file against the schema.
+`env-schema.json` defines every variable with its type, constraints, whether it's required, and any `deprecatedNames` (pre-rename aliases that `npm run validate-env` accepts with a warning) or `requiredWith` (a variable that becomes required once another is set). `deprecatedNames` is validation-only — the runtime fallback for an alias must be implemented separately, as in `src/lib/sidecarConfig.js`. Run `npm run validate-env` to check your `.env` file against the schema.
 
 See `.env.example` for full list. Key variables:
 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,17 @@ Use these in Tailwind classes: `bg-primary-500`, `text-primary-700`, `border-pri
 - `PUBLIC_OBA_REGION_CENTER_LAT` - float: (required) The region's center latitude.
 - `PUBLIC_OBA_REGION_CENTER_LNG` - float: (required) The region's center longitude.
 - `PRIVATE_OBA_API_KEY` - string: (required) Your OneBusAway REST API server key.
-- `PRIVATE_OBACO_API_BASE_URL` - string: (optional) Your OneBusAway.co server base URL, including the path prefix `/api/v1.
-- `PRIVATE_REGION_ID` - string: (required if OBACO_API_BASE_URL provided).
-- `PRIVATE_OBACO_SHOW_TEST_ALERTS` - boolean: (optional) Show test alerts on the website. Don't set this value in production.
 - `PRIVATE_OBA_AGENCY_FILTER` - string: (optional) Comma-separated agency IDs to restrict this instance to a subset of agencies. Leave empty to show all agencies (default). Affects search results, stop listings, arrivals, schedules, and alerts.
+
+### Sidecar
+
+Sidecar (formerly Obaco, or OneBusAway.co) supplies service alerts and rider surveys.
+
+- `PRIVATE_SIDECAR_API_BASE_URL` - string: (optional) Your Sidecar server base URL, including the path prefix `/api/v1`, e.g. `https://sidecar.onebusaway.org/api/v1`.
+- `PRIVATE_SIDECAR_REGION_ID` - string: (required if `PRIVATE_SIDECAR_API_BASE_URL` is provided). Without it the alerts endpoint returns 204 and the surveys endpoint returns an empty list; survey submission and updates still work, since they aren't region-scoped.
+- `PRIVATE_SIDECAR_SHOW_TEST_ALERTS` - boolean: (optional) Show test alerts on the website. Don't set this value in production.
+
+The pre-rename names `PRIVATE_OBACO_API_BASE_URL`, `PRIVATE_REGION_ID`, and `PRIVATE_OBACO_SHOW_TEST_ALERTS` are still honored as fallbacks, and each logs a deprecation warning on first use. They will be removed in a future release. A `PRIVATE_SIDECAR_*` variable takes precedence over its pre-rename name only when it holds a non-empty value — set to an empty string it counts as unset, and the pre-rename name still takes effect.
 
 ### Maps
 

--- a/env-schema.json
+++ b/env-schema.json
@@ -16,21 +16,25 @@
 		"enum": ["google"],
 		"description": "Geocoding provider (currently only 'google' is supported)"
 	},
-	"PRIVATE_OBACO_API_BASE_URL": {
+	"PRIVATE_SIDECAR_API_BASE_URL": {
 		"required": false,
 		"type": "url",
-		"description": "Base URL for the OneBusAway.co API"
+		"deprecatedNames": ["PRIVATE_OBACO_API_BASE_URL"],
+		"description": "Base URL for the Sidecar API"
 	},
-	"PRIVATE_REGION_ID": {
+	"PRIVATE_SIDECAR_REGION_ID": {
 		"required": false,
 		"type": "string",
 		"allowEmpty": true,
-		"description": "Region ID for OneBusAway.co API"
+		"requiredWith": "PRIVATE_SIDECAR_API_BASE_URL",
+		"deprecatedNames": ["PRIVATE_REGION_ID"],
+		"description": "Region ID for the Sidecar API"
 	},
-	"PRIVATE_OBACO_SHOW_TEST_ALERTS": {
+	"PRIVATE_SIDECAR_SHOW_TEST_ALERTS": {
 		"required": false,
 		"type": "boolean",
-		"description": "Whether to show test alerts from OneBusAway.co"
+		"deprecatedNames": ["PRIVATE_OBACO_SHOW_TEST_ALERTS"],
+		"description": "Whether to show test alerts from Sidecar"
 	},
 	"PRIVATE_OBA_AGENCY_FILTER": {
 		"required": false,

--- a/scripts/validate-env.js
+++ b/scripts/validate-env.js
@@ -39,22 +39,19 @@ for (const line of envContent.split('\n')) {
 const errors = [];
 const warnings = [];
 
-// Validate each schema entry
-for (const [name, rule] of Object.entries(schema)) {
-	const value = parsed[name];
-	const isPresent = name in parsed;
-
-	// Check required
-	if (rule.required && !isPresent) {
-		errors.push(`${name}: missing (required)`);
-		continue;
-	}
-
-	if (!isPresent) continue;
-
-	// Check empty values
+/**
+ * Checks one variable's value against a schema rule, reporting by pushing onto
+ * the module-level `errors` and `warnings` arrays. Deprecated aliases are
+ * checked against their replacement's rule, so a rule is written down once.
+ *
+ * @param {string} name variable name to report against
+ * @param {string} value the parsed value
+ * @param {object} rule the schema entry to check against
+ * @returns {void}
+ */
+function validateVariable(name, value, rule) {
 	if (value === '') {
-		if (rule.allowEmpty) continue;
+		if (rule.allowEmpty) return;
 
 		// Detect unquoted hex colors that dotenv treated as comments
 		const raw = rawLines.get(name) || '';
@@ -65,10 +62,9 @@ for (const [name, rule] of Object.entries(schema)) {
 		} else {
 			warnings.push(`${name}: present but empty (set allowEmpty or remove)`);
 		}
-		continue;
+		return;
 	}
 
-	// Type-specific validation
 	switch (rule.type) {
 		case 'url':
 			try {
@@ -128,10 +124,62 @@ for (const [name, rule] of Object.entries(schema)) {
 	}
 }
 
+// Validate each schema entry, plus any pre-rename aliases still in use
+const deprecatedNames = new Set();
+
+/** The value the app will actually read for `name`, counting empty as unset. */
+function effectiveValue(name) {
+	if (parsed[name]) return parsed[name];
+	for (const alias of schema[name]?.deprecatedNames ?? []) {
+		if (parsed[alias]) return parsed[alias];
+	}
+	return undefined;
+}
+
+for (const [name, rule] of Object.entries(schema)) {
+	for (const alias of rule.deprecatedNames ?? []) {
+		deprecatedNames.add(alias);
+
+		// An empty alias has no effect either way, so there is nothing to say.
+		if (!parsed[alias]) continue;
+
+		// `readSetting()` in src/lib/sidecarConfig.js prefers the current name only
+		// when it holds a non-empty value, so an empty replacement means the alias
+		// is still what takes effect. A superseded alias is not validated: a value
+		// the app never reads must not be able to fail the build.
+		if (parsed[name]) {
+			warnings.push(`${alias}: deprecated and ignored — ${name} is also set`);
+		} else {
+			warnings.push(`${alias}: deprecated, rename to ${name}`);
+			validateVariable(alias, parsed[alias], rule);
+		}
+	}
+
+	const isPresent = name in parsed;
+
+	if (rule.required && !isPresent && effectiveValue(name) === undefined) {
+		errors.push(`${name}: missing (required)`);
+		continue;
+	}
+
+	if (!isPresent) continue;
+
+	validateVariable(name, parsed[name], rule);
+}
+
+// Cross-field requirements, e.g. a region ID is meaningless without a base URL
+// but mandatory once one is set.
+for (const [name, rule] of Object.entries(schema)) {
+	if (!rule.requiredWith) continue;
+	if (effectiveValue(rule.requiredWith) && !effectiveValue(name)) {
+		errors.push(`${name}: required when ${rule.requiredWith} is set`);
+	}
+}
+
 // Warn on unknown variables
 const schemaKeys = new Set(Object.keys(schema));
 for (const name of Object.keys(parsed)) {
-	if (!schemaKeys.has(name)) {
+	if (!schemaKeys.has(name) && !deprecatedNames.has(name)) {
 		warnings.push(`${name}: not defined in env-schema.json`);
 	}
 }

--- a/src/lib/sidecarConfig.js
+++ b/src/lib/sidecarConfig.js
@@ -1,0 +1,113 @@
+import { env } from '$env/dynamic/private';
+
+/**
+ * Configuration for Sidecar, the OneBusAway service that supplies service
+ * alerts and rider surveys. Sidecar was formerly called Obaco / OneBusAway.co,
+ * and its environment variables were named after it. The old names still work
+ * so that existing deployments don't break, but each one warns once at first
+ * use and will be removed in a future release.
+ *
+ * `env-schema.json` records the same pairs as `deprecatedNames` so that
+ * `npm run validate-env` can flag them, and a test keeps the two in agreement.
+ * That schema field is validation-only: adding an alias there does not create a
+ * runtime fallback, which is hand-written here. One alias per variable — this
+ * map cannot express a second.
+ */
+export const DEPRECATED_ALIASES = {
+	PRIVATE_SIDECAR_API_BASE_URL: 'PRIVATE_OBACO_API_BASE_URL',
+	PRIVATE_SIDECAR_REGION_ID: 'PRIVATE_REGION_ID',
+	PRIVATE_SIDECAR_SHOW_TEST_ALERTS: 'PRIVATE_OBACO_SHOW_TEST_ALERTS'
+};
+
+const warned = new Set();
+
+/** Logs `message` the first time it is reported for `key`, then stays quiet. */
+function warnOnce(key, message) {
+	if (warned.has(key)) return;
+	warned.add(key);
+	console.warn(message);
+}
+
+/**
+ * Reads a Sidecar setting, falling back to its pre-rename name. A variable set
+ * to an empty string counts as unset, so an empty current name still lets the
+ * deprecated name take effect.
+ *
+ * @param {keyof typeof DEPRECATED_ALIASES} name
+ * @returns {string | undefined} the configured value, or undefined if neither
+ *   name holds a non-empty value
+ */
+function readSetting(name) {
+	const legacyName = DEPRECATED_ALIASES[name];
+	const legacyValue = env[legacyName];
+
+	if (env[name]) {
+		// Say so rather than letting a stale legacy value look like it's in use.
+		if (legacyValue) {
+			warnOnce(legacyName, `[sidecar] ${legacyName} is set but ignored; ${name} takes precedence.`);
+		}
+		return env[name];
+	}
+
+	if (!legacyValue) {
+		return undefined;
+	}
+
+	warnOnce(
+		legacyName,
+		`[sidecar] ${legacyName} is deprecated and will be removed in a future release. Rename it to ${name}.`
+	);
+
+	return legacyValue;
+}
+
+/**
+ * @returns {string | undefined} the configured Sidecar API base URL — by
+ *   convention including the `/api/v1` path prefix, though nothing enforces
+ *   that — or undefined when no base URL is set
+ */
+export function getSidecarBaseURL() {
+	return readSetting('PRIVATE_SIDECAR_API_BASE_URL');
+}
+
+/**
+ * @returns {string | undefined} the region-scoped path prefix, in the form
+ *   `regions/<id>/` with the trailing slash included so callers can append a
+ *   leaf directly, or undefined when no region ID is configured. Callers must
+ *   treat undefined as "Sidecar is unusable" rather than falling back to an
+ *   unprefixed path: the region-scoped endpoints (`alerts.pb`, `surveys.json`)
+ *   exist only under `regions/<id>/`.
+ */
+export function getSidecarRegionPath() {
+	const regionID = readSetting('PRIVATE_SIDECAR_REGION_ID');
+	return regionID ? `regions/${regionID}/` : undefined;
+}
+
+/**
+ * @returns {boolean} whether test alerts are enabled. The alerts route both
+ *   asks Sidecar for test alerts and returns the first entity unfiltered,
+ *   skipping the validity and agency-filter checks. Never enable this in
+ *   production; it surfaces alerts that aren't real.
+ */
+export function sidecarShowsTestAlerts() {
+	return readSetting('PRIVATE_SIDECAR_SHOW_TEST_ALERTS') === 'true';
+}
+
+/**
+ * Logs that a route is skipping Sidecar work, naming only the variables that
+ * are actually unset. Kept here so the variable names live in one module
+ * rather than in every route that reports them, and throttled because these
+ * routes are hit on every map load — an unbounded stream of identical warnings
+ * is one more way to hide a message.
+ *
+ * @param {string} context the route tag to prefix the message with
+ * @param {string[]} missing names of the unset environment variables
+ */
+export function warnSidecarNotConfigured(context, missing) {
+	warnOnce(
+		`not-configured:${context}:${missing.join(',')}`,
+		`[${context}] Sidecar is disabled: ${missing.join(', ')} ${
+			missing.length === 1 ? 'is' : 'are'
+		} not set.`
+	);
+}

--- a/src/routes/api/oba/alerts/+server.js
+++ b/src/routes/api/oba/alerts/+server.js
@@ -1,22 +1,32 @@
 import GtfsRealtimeBindings from 'gtfs-realtime-bindings';
-import { env } from '$env/dynamic/private';
 import { buildURL } from '$lib/urls.js';
 import { getAgencyFilter, alertBelongsToAgency } from '$lib/agencyFilter.js';
 import { isValidAlert } from '$lib/alerts.js';
-
-const REGION_PATH = `regions/${env.PRIVATE_REGION_ID}/`;
+import {
+	getSidecarBaseURL,
+	getSidecarRegionPath,
+	sidecarShowsTestAlerts,
+	warnSidecarNotConfigured
+} from '$lib/sidecarConfig.js';
 
 export async function GET() {
-	if (!env.PRIVATE_OBACO_API_BASE_URL) {
-		console.warn('[alerts] PRIVATE_OBACO_API_BASE_URL not configured, skipping alerts');
+	const baseURL = getSidecarBaseURL();
+	const regionPath = getSidecarRegionPath();
+	const missing = [];
+	if (!baseURL) missing.push('PRIVATE_SIDECAR_API_BASE_URL');
+	if (!regionPath) missing.push('PRIVATE_SIDECAR_REGION_ID');
+	if (missing.length > 0) {
+		warnSidecarNotConfigured('alerts', missing);
 		return new Response(null, { status: 204, headers: { 'Content-Type': 'application/json' } });
 	}
 
+	const showTestAlerts = sidecarShowsTestAlerts();
+
 	try {
 		const alertsURL = buildURL(
-			env.PRIVATE_OBACO_API_BASE_URL,
-			REGION_PATH + 'alerts.pb',
-			env.PRIVATE_OBACO_SHOW_TEST_ALERTS == 'true' ? { test: 1 } : {}
+			baseURL,
+			regionPath + 'alerts.pb',
+			showTestAlerts ? { test: 1 } : {}
 		);
 
 		const response = await fetch(alertsURL);
@@ -29,7 +39,7 @@ export async function GET() {
 		let validAlert = null;
 		for (const entity of feed.entity) {
 			// If we're in test mode, show the alert to test the UI
-			if (env.PRIVATE_OBACO_SHOW_TEST_ALERTS === 'true') {
+			if (showTestAlerts) {
 				validAlert = entity.alert;
 				break;
 			}

--- a/src/routes/api/oba/surveys/+server.js
+++ b/src/routes/api/oba/surveys/+server.js
@@ -1,19 +1,26 @@
 import { json } from '@sveltejs/kit';
-import { env } from '$env/dynamic/private';
 import { buildURL } from '$lib/urls.js';
-
-const REGION_PATH = `regions/${env.PRIVATE_REGION_ID}/`;
+import {
+	getSidecarBaseURL,
+	getSidecarRegionPath,
+	warnSidecarNotConfigured
+} from '$lib/sidecarConfig.js';
 
 export async function GET({ url }) {
-	if (!env.PRIVATE_OBACO_API_BASE_URL) {
-		console.warn('[surveys] PRIVATE_OBACO_API_BASE_URL not configured, skipping surveys');
+	const baseURL = getSidecarBaseURL();
+	const regionPath = getSidecarRegionPath();
+	const missing = [];
+	if (!baseURL) missing.push('PRIVATE_SIDECAR_API_BASE_URL');
+	if (!regionPath) missing.push('PRIVATE_SIDECAR_REGION_ID');
+	if (missing.length > 0) {
+		warnSidecarNotConfigured('surveys', missing);
 		return json({ surveys: [] });
 	}
 
 	const userId = url.searchParams.get('userId');
 
 	try {
-		const url = buildURL(env.PRIVATE_OBACO_API_BASE_URL, `${REGION_PATH}surveys.json`, {
+		const url = buildURL(baseURL, `${regionPath}surveys.json`, {
 			user_id: userId
 		});
 

--- a/src/routes/api/oba/surveys/submit-survey/+server.js
+++ b/src/routes/api/oba/surveys/submit-survey/+server.js
@@ -1,17 +1,19 @@
 import { json } from '@sveltejs/kit';
-import { env } from '$env/dynamic/private';
 import { buildURL } from '$lib/urls.js';
+import { getSidecarBaseURL, warnSidecarNotConfigured } from '$lib/sidecarConfig.js';
 
 export async function POST({ request }) {
-	if (!env.PRIVATE_OBACO_API_BASE_URL) {
-		console.warn('[submit-survey] PRIVATE_OBACO_API_BASE_URL not configured');
+	// No region path here: the survey_responses endpoints are not region-scoped.
+	const baseURL = getSidecarBaseURL();
+	if (!baseURL) {
+		warnSidecarNotConfigured('submit-survey', ['PRIVATE_SIDECAR_API_BASE_URL']);
 		return json({ error: 'Survey service not configured' }, { status: 503 });
 	}
 
 	try {
 		const body = await request.text();
 
-		const url = buildURL(env.PRIVATE_OBACO_API_BASE_URL, '/survey_responses.json');
+		const url = buildURL(baseURL, '/survey_responses.json');
 
 		const response = await fetch(url, {
 			method: 'POST',

--- a/src/routes/api/oba/surveys/update-survey/[id]/+server.js
+++ b/src/routes/api/oba/surveys/update-survey/[id]/+server.js
@@ -1,10 +1,12 @@
 import { json } from '@sveltejs/kit';
-import { env } from '$env/dynamic/private';
 import { buildURL } from '$lib/urls.js';
+import { getSidecarBaseURL, warnSidecarNotConfigured } from '$lib/sidecarConfig.js';
 
 export async function POST({ request, params }) {
-	if (!env.PRIVATE_OBACO_API_BASE_URL) {
-		console.warn('[update-survey] PRIVATE_OBACO_API_BASE_URL not configured');
+	// No region path here: the survey_responses endpoints are not region-scoped.
+	const baseURL = getSidecarBaseURL();
+	if (!baseURL) {
+		warnSidecarNotConfigured('update-survey', ['PRIVATE_SIDECAR_API_BASE_URL']);
 		return json({ error: 'Survey service not configured' }, { status: 503 });
 	}
 
@@ -12,7 +14,7 @@ export async function POST({ request, params }) {
 		const { id } = params;
 		const body = await request.text();
 
-		const url = buildURL(env.PRIVATE_OBACO_API_BASE_URL, `/survey_responses/${id}`);
+		const url = buildURL(baseURL, `/survey_responses/${id}`);
 
 		const response = await fetch(url, {
 			method: 'POST',

--- a/src/tests/api/alerts.test.js
+++ b/src/tests/api/alerts.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockEnv = vi.hoisted(() => ({
-	PRIVATE_OBACO_API_BASE_URL: '',
-	PRIVATE_REGION_ID: '1',
-	PRIVATE_OBACO_SHOW_TEST_ALERTS: 'false'
+	PRIVATE_SIDECAR_API_BASE_URL: '',
+	PRIVATE_SIDECAR_REGION_ID: '1',
+	PRIVATE_SIDECAR_SHOW_TEST_ALERTS: 'false'
 }));
 
 vi.mock('$env/dynamic/private', () => ({
@@ -38,18 +38,64 @@ vi.mock('gtfs-realtime-bindings', () => ({
 }));
 
 import { GET } from '../../routes/api/oba/alerts/+server.js';
+import { buildURL } from '$lib/urls.js';
 import { isStartDateWithin24Hours, isHighSeverity } from '$lib/alerts.js';
 
 describe('GET /api/oba/alerts', () => {
 	beforeEach(() => {
+		mockEnv.PRIVATE_SIDECAR_API_BASE_URL = '';
+		mockEnv.PRIVATE_SIDECAR_REGION_ID = '1';
+		mockEnv.PRIVATE_SIDECAR_SHOW_TEST_ALERTS = 'false';
 		mockEnv.PRIVATE_OBACO_API_BASE_URL = '';
-		mockEnv.PRIVATE_REGION_ID = '1';
-		mockEnv.PRIVATE_OBACO_SHOW_TEST_ALERTS = 'false';
+		mockEnv.PRIVATE_REGION_ID = '';
+		mockEnv.PRIVATE_OBACO_SHOW_TEST_ALERTS = '';
 		vi.restoreAllMocks();
 	});
 
-	it('returns 204 when PRIVATE_OBACO_API_BASE_URL is not set', async () => {
-		mockEnv.PRIVATE_OBACO_API_BASE_URL = '';
+	it('returns 204 without fetching when the base URL is set but no region ID is', async () => {
+		mockEnv.PRIVATE_SIDECAR_API_BASE_URL = 'https://sidecar.onebusaway.org/api/v1';
+		mockEnv.PRIVATE_SIDECAR_REGION_ID = '';
+		vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const fetchMock = vi.spyOn(globalThis, 'fetch');
+
+		const response = await GET();
+
+		expect(response.status).toBe(204);
+		// Never request regions/undefined/alerts.pb
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('requests the region-scoped alerts path', async () => {
+		mockEnv.PRIVATE_SIDECAR_API_BASE_URL = 'https://sidecar.onebusaway.org/api/v1';
+		mockEnv.PRIVATE_SIDECAR_REGION_ID = '7';
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(new ArrayBuffer(0)));
+
+		await GET();
+
+		expect(buildURL).toHaveBeenCalledWith(
+			'https://sidecar.onebusaway.org/api/v1',
+			'regions/7/alerts.pb',
+			{}
+		);
+	});
+
+	it('asks Sidecar for test alerts when the test flag is on', async () => {
+		mockEnv.PRIVATE_SIDECAR_API_BASE_URL = 'https://sidecar.onebusaway.org/api/v1';
+		mockEnv.PRIVATE_SIDECAR_REGION_ID = '7';
+		mockEnv.PRIVATE_SIDECAR_SHOW_TEST_ALERTS = 'true';
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(new ArrayBuffer(0)));
+
+		await GET();
+
+		expect(buildURL).toHaveBeenCalledWith(
+			'https://sidecar.onebusaway.org/api/v1',
+			'regions/7/alerts.pb',
+			{ test: 1 }
+		);
+	});
+
+	it('returns 204 when PRIVATE_SIDECAR_API_BASE_URL is not set', async () => {
+		mockEnv.PRIVATE_SIDECAR_API_BASE_URL = '';
 
 		const response = await GET();
 
@@ -57,8 +103,8 @@ describe('GET /api/oba/alerts', () => {
 		expect(response.headers.get('Content-Type')).toBe('application/json');
 	});
 
-	it('returns 204 when PRIVATE_OBACO_API_BASE_URL is undefined', async () => {
-		mockEnv.PRIVATE_OBACO_API_BASE_URL = undefined;
+	it('returns 204 when PRIVATE_SIDECAR_API_BASE_URL is undefined', async () => {
+		mockEnv.PRIVATE_SIDECAR_API_BASE_URL = undefined;
 
 		const response = await GET();
 

--- a/src/tests/api/submit-survey.test.js
+++ b/src/tests/api/submit-survey.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockEnv = vi.hoisted(() => ({
-	PRIVATE_OBACO_API_BASE_URL: ''
+	PRIVATE_SIDECAR_API_BASE_URL: ''
 }));
 
 vi.mock('$env/dynamic/private', () => ({
@@ -18,12 +18,12 @@ import { POST } from '../../routes/api/oba/surveys/submit-survey/+server.js';
 
 describe('POST /api/oba/surveys/submit-survey', () => {
 	beforeEach(() => {
-		mockEnv.PRIVATE_OBACO_API_BASE_URL = '';
+		mockEnv.PRIVATE_SIDECAR_API_BASE_URL = '';
 		vi.restoreAllMocks();
 	});
 
-	it('returns 503 when PRIVATE_OBACO_API_BASE_URL is not set', async () => {
-		mockEnv.PRIVATE_OBACO_API_BASE_URL = '';
+	it('returns 503 when PRIVATE_SIDECAR_API_BASE_URL is not set', async () => {
+		mockEnv.PRIVATE_SIDECAR_API_BASE_URL = '';
 
 		const request = new Request('http://localhost/api/oba/surveys/submit-survey', {
 			method: 'POST',
@@ -38,8 +38,8 @@ describe('POST /api/oba/surveys/submit-survey', () => {
 		expect(data).toEqual({ error: 'Survey service not configured' });
 	});
 
-	it('returns 503 when PRIVATE_OBACO_API_BASE_URL is undefined', async () => {
-		mockEnv.PRIVATE_OBACO_API_BASE_URL = undefined;
+	it('returns 503 when PRIVATE_SIDECAR_API_BASE_URL is undefined', async () => {
+		mockEnv.PRIVATE_SIDECAR_API_BASE_URL = undefined;
 
 		const request = new Request('http://localhost/api/oba/surveys/submit-survey', {
 			method: 'POST',

--- a/src/tests/api/surveys.test.js
+++ b/src/tests/api/surveys.test.js
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockEnv = vi.hoisted(() => ({
-	PRIVATE_OBACO_API_BASE_URL: '',
-	PRIVATE_REGION_ID: '1'
+	PRIVATE_SIDECAR_API_BASE_URL: '',
+	PRIVATE_SIDECAR_REGION_ID: '1'
 }));
 
 vi.mock('$env/dynamic/private', () => ({
@@ -16,16 +16,19 @@ vi.mock('$lib/urls.js', () => ({
 }));
 
 import { GET } from '../../routes/api/oba/surveys/+server.js';
+import { buildURL } from '$lib/urls.js';
 
 describe('GET /api/oba/surveys', () => {
 	beforeEach(() => {
+		mockEnv.PRIVATE_SIDECAR_API_BASE_URL = '';
+		mockEnv.PRIVATE_SIDECAR_REGION_ID = '1';
 		mockEnv.PRIVATE_OBACO_API_BASE_URL = '';
-		mockEnv.PRIVATE_REGION_ID = '1';
+		mockEnv.PRIVATE_REGION_ID = '';
 		vi.restoreAllMocks();
 	});
 
-	it('returns empty surveys when PRIVATE_OBACO_API_BASE_URL is not set', async () => {
-		mockEnv.PRIVATE_OBACO_API_BASE_URL = '';
+	it('returns empty surveys when PRIVATE_SIDECAR_API_BASE_URL is not set', async () => {
+		mockEnv.PRIVATE_SIDECAR_API_BASE_URL = '';
 
 		const url = new URL('http://localhost/api/oba/surveys?userId=123');
 		const response = await GET({ url });
@@ -35,8 +38,8 @@ describe('GET /api/oba/surveys', () => {
 		expect(data).toEqual({ surveys: [] });
 	});
 
-	it('returns empty surveys when PRIVATE_OBACO_API_BASE_URL is undefined', async () => {
-		mockEnv.PRIVATE_OBACO_API_BASE_URL = undefined;
+	it('returns empty surveys when PRIVATE_SIDECAR_API_BASE_URL is undefined', async () => {
+		mockEnv.PRIVATE_SIDECAR_API_BASE_URL = undefined;
 
 		const url = new URL('http://localhost/api/oba/surveys?userId=123');
 		const response = await GET({ url });
@@ -44,5 +47,41 @@ describe('GET /api/oba/surveys', () => {
 
 		expect(response.status).toBe(200);
 		expect(data).toEqual({ surveys: [] });
+	});
+
+	it('returns an empty list without fetching when no region ID is configured', async () => {
+		mockEnv.PRIVATE_SIDECAR_API_BASE_URL = 'https://sidecar.onebusaway.org/api/v1';
+		mockEnv.PRIVATE_SIDECAR_REGION_ID = '';
+		vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const fetchMock = vi.spyOn(globalThis, 'fetch');
+
+		const url = new URL('http://localhost/api/oba/surveys?userId=123');
+		const response = await GET({ url });
+
+		expect(await response.json()).toEqual({ surveys: [] });
+		// Never request regions/undefined/surveys.json
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('honors the deprecated PRIVATE_OBACO_* names', async () => {
+		mockEnv.PRIVATE_SIDECAR_API_BASE_URL = '';
+		mockEnv.PRIVATE_SIDECAR_REGION_ID = '';
+		mockEnv.PRIVATE_OBACO_API_BASE_URL = 'https://onebusaway.co/api/v1';
+		mockEnv.PRIVATE_REGION_ID = '7';
+		vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValue(new Response(JSON.stringify({ surveys: [] }), { status: 200 }));
+
+		const url = new URL('http://localhost/api/oba/surveys?userId=123');
+		const response = await GET({ url });
+
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalled();
+		expect(buildURL).toHaveBeenCalledWith(
+			'https://onebusaway.co/api/v1',
+			'regions/7/surveys.json',
+			{ user_id: '123' }
+		);
 	});
 });

--- a/src/tests/api/update-survey.test.js
+++ b/src/tests/api/update-survey.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockEnv = vi.hoisted(() => ({
-	PRIVATE_OBACO_API_BASE_URL: ''
+	PRIVATE_SIDECAR_API_BASE_URL: ''
 }));
 
 vi.mock('$env/dynamic/private', () => ({
@@ -18,12 +18,12 @@ import { POST } from '../../routes/api/oba/surveys/update-survey/[id]/+server.js
 
 describe('POST /api/oba/surveys/update-survey/[id]', () => {
 	beforeEach(() => {
-		mockEnv.PRIVATE_OBACO_API_BASE_URL = '';
+		mockEnv.PRIVATE_SIDECAR_API_BASE_URL = '';
 		vi.restoreAllMocks();
 	});
 
-	it('returns 503 when PRIVATE_OBACO_API_BASE_URL is not set', async () => {
-		mockEnv.PRIVATE_OBACO_API_BASE_URL = '';
+	it('returns 503 when PRIVATE_SIDECAR_API_BASE_URL is not set', async () => {
+		mockEnv.PRIVATE_SIDECAR_API_BASE_URL = '';
 
 		const request = new Request('http://localhost/api/oba/surveys/update-survey/42', {
 			method: 'POST',
@@ -38,8 +38,8 @@ describe('POST /api/oba/surveys/update-survey/[id]', () => {
 		expect(data).toEqual({ error: 'Survey service not configured' });
 	});
 
-	it('returns 503 when PRIVATE_OBACO_API_BASE_URL is undefined', async () => {
-		mockEnv.PRIVATE_OBACO_API_BASE_URL = undefined;
+	it('returns 503 when PRIVATE_SIDECAR_API_BASE_URL is undefined', async () => {
+		mockEnv.PRIVATE_SIDECAR_API_BASE_URL = undefined;
 
 		const request = new Request('http://localhost/api/oba/surveys/update-survey/42', {
 			method: 'POST',

--- a/src/tests/lib/sidecarConfig.test.js
+++ b/src/tests/lib/sidecarConfig.test.js
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockEnv = vi.hoisted(() => ({}));
+
+vi.mock('$env/dynamic/private', () => ({
+	get env() {
+		return mockEnv;
+	}
+}));
+
+/**
+ * The module warns at most once per deprecated variable, so each test needs a
+ * fresh copy to observe the warning rather than a suppressed repeat.
+ */
+async function loadSidecarConfig() {
+	vi.resetModules();
+	return import('$lib/sidecarConfig.js');
+}
+
+describe('sidecarConfig', () => {
+	let warn;
+
+	beforeEach(() => {
+		for (const key of Object.keys(mockEnv)) {
+			delete mockEnv[key];
+		}
+		warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('getSidecarBaseURL', () => {
+		it('reads PRIVATE_SIDECAR_API_BASE_URL without warning', async () => {
+			mockEnv.PRIVATE_SIDECAR_API_BASE_URL = 'https://sidecar.onebusaway.org/api/v1';
+
+			const { getSidecarBaseURL } = await loadSidecarConfig();
+
+			expect(getSidecarBaseURL()).toBe('https://sidecar.onebusaway.org/api/v1');
+			expect(warn).not.toHaveBeenCalled();
+		});
+
+		it('falls back to PRIVATE_OBACO_API_BASE_URL and warns once', async () => {
+			mockEnv.PRIVATE_OBACO_API_BASE_URL = 'https://onebusaway.co/api/v1';
+
+			const { getSidecarBaseURL } = await loadSidecarConfig();
+
+			expect(getSidecarBaseURL()).toBe('https://onebusaway.co/api/v1');
+			expect(getSidecarBaseURL()).toBe('https://onebusaway.co/api/v1');
+			expect(warn).toHaveBeenCalledTimes(1);
+			expect(warn.mock.calls[0][0]).toContain('PRIVATE_OBACO_API_BASE_URL');
+			expect(warn.mock.calls[0][0]).toContain('PRIVATE_SIDECAR_API_BASE_URL');
+		});
+
+		it('prefers the new name, and says the deprecated one is being ignored', async () => {
+			mockEnv.PRIVATE_SIDECAR_API_BASE_URL = 'https://sidecar.onebusaway.org/api/v1';
+			mockEnv.PRIVATE_OBACO_API_BASE_URL = 'https://onebusaway.co/api/v1';
+
+			const { getSidecarBaseURL } = await loadSidecarConfig();
+
+			expect(getSidecarBaseURL()).toBe('https://sidecar.onebusaway.org/api/v1');
+			expect(getSidecarBaseURL()).toBe('https://sidecar.onebusaway.org/api/v1');
+			expect(warn).toHaveBeenCalledTimes(1);
+			expect(warn.mock.calls[0][0]).toContain('is set but ignored');
+		});
+
+		it('does not warn when only the new name is set', async () => {
+			mockEnv.PRIVATE_SIDECAR_API_BASE_URL = 'https://sidecar.onebusaway.org/api/v1';
+
+			const { getSidecarBaseURL } = await loadSidecarConfig();
+
+			expect(getSidecarBaseURL()).toBe('https://sidecar.onebusaway.org/api/v1');
+			expect(warn).not.toHaveBeenCalled();
+		});
+
+		it('lets a deprecated name win when the new name is set but empty', async () => {
+			mockEnv.PRIVATE_SIDECAR_API_BASE_URL = '';
+			mockEnv.PRIVATE_OBACO_API_BASE_URL = 'https://onebusaway.co/api/v1';
+
+			const { getSidecarBaseURL } = await loadSidecarConfig();
+
+			expect(getSidecarBaseURL()).toBe('https://onebusaway.co/api/v1');
+		});
+
+		it('returns undefined when neither name is set', async () => {
+			const { getSidecarBaseURL } = await loadSidecarConfig();
+
+			expect(getSidecarBaseURL()).toBeUndefined();
+			expect(warn).not.toHaveBeenCalled();
+		});
+
+		it('treats an empty deprecated value as unset', async () => {
+			mockEnv.PRIVATE_OBACO_API_BASE_URL = '';
+
+			const { getSidecarBaseURL } = await loadSidecarConfig();
+
+			expect(getSidecarBaseURL()).toBeUndefined();
+			expect(warn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('getSidecarRegionPath', () => {
+		it('builds the region path from PRIVATE_SIDECAR_REGION_ID', async () => {
+			mockEnv.PRIVATE_SIDECAR_REGION_ID = '1';
+
+			const { getSidecarRegionPath } = await loadSidecarConfig();
+
+			expect(getSidecarRegionPath()).toBe('regions/1/');
+			expect(warn).not.toHaveBeenCalled();
+		});
+
+		it('falls back to PRIVATE_REGION_ID and warns', async () => {
+			mockEnv.PRIVATE_REGION_ID = '42';
+
+			const { getSidecarRegionPath } = await loadSidecarConfig();
+
+			expect(getSidecarRegionPath()).toBe('regions/42/');
+			expect(warn).toHaveBeenCalledTimes(1);
+			expect(warn.mock.calls[0][0]).toContain('PRIVATE_SIDECAR_REGION_ID');
+		});
+
+		it('is undefined when no region ID is configured', async () => {
+			mockEnv.PRIVATE_SIDECAR_API_BASE_URL = 'https://sidecar.onebusaway.org/api/v1';
+
+			const { getSidecarRegionPath } = await loadSidecarConfig();
+
+			expect(getSidecarRegionPath()).toBeUndefined();
+		});
+
+		it('reflects a region ID that changes after the module is loaded', async () => {
+			mockEnv.PRIVATE_SIDECAR_REGION_ID = '1';
+
+			const { getSidecarRegionPath } = await loadSidecarConfig();
+			expect(getSidecarRegionPath()).toBe('regions/1/');
+
+			mockEnv.PRIVATE_SIDECAR_REGION_ID = '2';
+			expect(getSidecarRegionPath()).toBe('regions/2/');
+		});
+	});
+
+	describe('sidecarShowsTestAlerts', () => {
+		it('is true only for the string "true"', async () => {
+			mockEnv.PRIVATE_SIDECAR_SHOW_TEST_ALERTS = 'true';
+
+			const { sidecarShowsTestAlerts } = await loadSidecarConfig();
+
+			expect(sidecarShowsTestAlerts()).toBe(true);
+		});
+
+		it('is false when unset', async () => {
+			const { sidecarShowsTestAlerts } = await loadSidecarConfig();
+
+			expect(sidecarShowsTestAlerts()).toBe(false);
+			expect(warn).not.toHaveBeenCalled();
+		});
+
+		it('falls back to PRIVATE_OBACO_SHOW_TEST_ALERTS and warns', async () => {
+			mockEnv.PRIVATE_OBACO_SHOW_TEST_ALERTS = 'true';
+
+			const { sidecarShowsTestAlerts } = await loadSidecarConfig();
+
+			expect(sidecarShowsTestAlerts()).toBe(true);
+			expect(warn).toHaveBeenCalledTimes(1);
+			expect(warn.mock.calls[0][0]).toContain('PRIVATE_SIDECAR_SHOW_TEST_ALERTS');
+		});
+	});
+});
+
+describe('warnSidecarNotConfigured', () => {
+	let warn;
+
+	beforeEach(() => {
+		warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('names only the variables that are missing', async () => {
+		const { warnSidecarNotConfigured } = await loadSidecarConfig();
+
+		warnSidecarNotConfigured('alerts', ['PRIVATE_SIDECAR_REGION_ID']);
+
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0][0]).toContain('PRIVATE_SIDECAR_REGION_ID');
+		expect(warn.mock.calls[0][0]).not.toContain('PRIVATE_SIDECAR_API_BASE_URL');
+	});
+
+	it('warns once per route and missing-variable set, not once per request', async () => {
+		const { warnSidecarNotConfigured } = await loadSidecarConfig();
+
+		warnSidecarNotConfigured('alerts', ['PRIVATE_SIDECAR_REGION_ID']);
+		warnSidecarNotConfigured('alerts', ['PRIVATE_SIDECAR_REGION_ID']);
+		warnSidecarNotConfigured('alerts', ['PRIVATE_SIDECAR_REGION_ID']);
+
+		expect(warn).toHaveBeenCalledTimes(1);
+	});
+
+	it('still reports a different route or a different missing set', async () => {
+		const { warnSidecarNotConfigured } = await loadSidecarConfig();
+
+		warnSidecarNotConfigured('alerts', ['PRIVATE_SIDECAR_REGION_ID']);
+		warnSidecarNotConfigured('surveys', ['PRIVATE_SIDECAR_REGION_ID']);
+		warnSidecarNotConfigured('alerts', ['PRIVATE_SIDECAR_API_BASE_URL']);
+
+		expect(warn).toHaveBeenCalledTimes(3);
+	});
+});
+
+describe('DEPRECATED_ALIASES agrees with env-schema.json', () => {
+	it('lists the same old-name/new-name pairs as the schema', async () => {
+		const [{ DEPRECATED_ALIASES }, schema] = await Promise.all([
+			import('$lib/sidecarConfig.js'),
+			import('../../../env-schema.json').then((m) => m.default)
+		]);
+
+		// Compare pairs rather than an object keyed by the new name: a schema entry
+		// listing two aliases must fail here, not silently keep only the last.
+		const fromSchema = Object.entries(schema)
+			.filter(([, rule]) => rule.deprecatedNames)
+			.flatMap(([name, rule]) => rule.deprecatedNames.map((alias) => `${name}=${alias}`));
+		const fromRuntime = Object.entries(DEPRECATED_ALIASES).map(
+			([name, alias]) => `${name}=${alias}`
+		);
+
+		expect(fromSchema.sort()).toEqual(fromRuntime.sort());
+	});
+});

--- a/src/tests/scripts/validate-env.test.js
+++ b/src/tests/scripts/validate-env.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+/**
+ * `scripts/validate-env.js` is top-level code that ends in `process.exit`, so it
+ * is exercised by running it. It already takes an env file path as argv[2].
+ * Vitest's `include` only covers `src/`, so this test lives here rather than
+ * beside the script.
+ */
+const root = resolve(__dirname, '../../..');
+const script = join(root, 'scripts/validate-env.js');
+
+let dir;
+
+beforeAll(() => {
+	dir = mkdtempSync(join(tmpdir(), 'validate-env-'));
+});
+
+afterAll(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+/** Runs the validator against `contents`, returning its output and exit code. */
+function validate(contents) {
+	const envPath = join(dir, `${Math.random().toString(36).slice(2)}.env`);
+	writeFileSync(envPath, contents);
+	try {
+		return { code: 0, output: execFileSync('node', [script, envPath], { encoding: 'utf-8' }) };
+	} catch (err) {
+		return { code: err.status, output: err.stdout ?? '' };
+	}
+}
+
+// Derived from .env.example, minus every Sidecar line, so each test can vary
+// the Sidecar config alone without hand-maintaining the list of required vars.
+const BASE =
+	readFileSync(join(root, '.env.example'), 'utf-8')
+		.split('\n')
+		.filter((line) => !/^\s*(PRIVATE_SIDECAR_|PRIVATE_OBACO_|PRIVATE_REGION_ID)/.test(line))
+		.join('\n') + '\n';
+
+describe('validate-env deprecated aliases', () => {
+	it('accepts a deprecated name and asks for the rename', () => {
+		const { code, output } = validate(
+			`${BASE}PRIVATE_OBACO_API_BASE_URL=https://onebusaway.co/api/v1\nPRIVATE_REGION_ID=7\n`
+		);
+
+		expect(code).toBe(0);
+		expect(output).toContain('PRIVATE_OBACO_API_BASE_URL: deprecated, rename to');
+	});
+
+	it('does not report a deprecated name as unknown', () => {
+		const { output } = validate(`${BASE}PRIVATE_OBACO_API_BASE_URL=https://onebusaway.co/api/v1\n`);
+
+		expect(output).not.toContain('not defined in env-schema.json');
+	});
+
+	it('says a deprecated name is ignored when its replacement is set', () => {
+		const { output } = validate(
+			`${BASE}PRIVATE_SIDECAR_API_BASE_URL=https://sidecar.onebusaway.org/api/v1\n` +
+				`PRIVATE_SIDECAR_REGION_ID=3\nPRIVATE_OBACO_API_BASE_URL=https://onebusaway.co/api/v1\n`
+		);
+
+		expect(output).toContain('deprecated and ignored');
+	});
+
+	it('does not fail the build on a superseded alias holding a bad value', () => {
+		const { code, output } = validate(
+			`${BASE}PRIVATE_SIDECAR_API_BASE_URL=https://sidecar.onebusaway.org/api/v1\n` +
+				`PRIVATE_SIDECAR_REGION_ID=3\nPRIVATE_OBACO_API_BASE_URL=notaurl\n`
+		);
+
+		expect(code).toBe(0);
+		expect(output).not.toContain('invalid URL');
+	});
+
+	it('still validates a deprecated name that is the one taking effect', () => {
+		const { code, output } = validate(
+			`${BASE}PRIVATE_OBACO_API_BASE_URL=notaurl\nPRIVATE_REGION_ID=7\n`
+		);
+
+		expect(code).toBe(1);
+		expect(output).toContain('invalid URL');
+	});
+
+	it('stays quiet about a deprecated name that is present but empty', () => {
+		const { output } = validate(`${BASE}PRIVATE_REGION_ID=\n`);
+
+		expect(output).not.toContain('PRIVATE_REGION_ID: deprecated');
+	});
+});
+
+describe('validate-env requiredWith', () => {
+	it('rejects a Sidecar base URL with no region ID', () => {
+		const { code, output } = validate(
+			`${BASE}PRIVATE_SIDECAR_API_BASE_URL=https://sidecar.onebusaway.org/api/v1\n`
+		);
+
+		expect(code).toBe(1);
+		expect(output).toContain(
+			'PRIVATE_SIDECAR_REGION_ID: required when PRIVATE_SIDECAR_API_BASE_URL is set'
+		);
+	});
+
+	it('accepts a region ID supplied only under its deprecated name', () => {
+		const { code } = validate(
+			`${BASE}PRIVATE_SIDECAR_API_BASE_URL=https://sidecar.onebusaway.org/api/v1\nPRIVATE_REGION_ID=7\n`
+		);
+
+		expect(code).toBe(0);
+	});
+
+	it('does not require a region ID when no base URL is set', () => {
+		const { code } = validate(BASE);
+
+		expect(code).toBe(0);
+	});
+});
+
+describe('validate-env shipped example', () => {
+	it('validates .env.example cleanly', () => {
+		const output = execFileSync('node', [script, join(root, '.env.example')], {
+			encoding: 'utf-8'
+		});
+
+		expect(output).toContain('variables validated');
+	});
+});


### PR DESCRIPTION
## Summary

- Renames the Obaco / OneBusAway.co service to **Sidecar** throughout. Every pre-rename environment variable keeps working as a deprecated alias, so existing deployments don't break — each warns once at first use naming its replacement.
- Adds `src/lib/sidecarConfig.js` as the single place that resolves Sidecar settings, and points the four alerts/surveys API routes at it instead of reading `$env/dynamic/private` directly.
- Teaches `env-schema.json` / `scripts/validate-env.js` two general fields: `deprecatedNames` and `requiredWith`.

| New | Deprecated alias |
|---|---|
| `PRIVATE_SIDECAR_API_BASE_URL` | `PRIVATE_OBACO_API_BASE_URL` |
| `PRIVATE_SIDECAR_REGION_ID` | `PRIVATE_REGION_ID` |
| `PRIVATE_SIDECAR_SHOW_TEST_ALERTS` | `PRIVATE_OBACO_SHOW_TEST_ALERTS` |

Precedence: a `PRIVATE_SIDECAR_*` variable wins **only when non-empty**. Set to an empty string it counts as unset and the pre-rename name still takes effect — which matters because a half-migrated `.env` hits exactly that case. A stale legacy value that loses to a new name is now reported rather than silently ignored.

## Behavior changes beyond the rename

These came out of review and go slightly past a pure rename — flagging them explicitly:

1. **No more `regions/undefined/` requests.** The region path was previously built at module load with no guard, so a missing region ID produced a real request to `.../regions/undefined/alerts.pb`. `getSidecarRegionPath()` now returns `undefined` and the two region-scoped GET routes degrade instead (alerts → 204, surveys → `{surveys: []}`). The POST survey-response routes are unaffected; they aren't region-scoped.
2. **`.env.example` ships the Sidecar block commented out.** It previously set a base URL with an empty region ID — the exact configuration that silently disabled both features.
3. **`requiredWith` makes "region ID required once a base URL is set" enforceable** rather than prose. This is what lets `validate-env` catch (1) at config time.
4. The region path is now read per request rather than captured at import.

## Test plan

- [x] `npx vitest run` — 1827 passed, 105 files
- [x] `npm run lint` — prettier + eslint clean
- [x] Drove all four endpoints against a stub Sidecar via `vite dev`, in four configurations: new names only, legacy names only, neither set, and both set. Verified the exact upstream URLs (`/api/v1/regions/9/surveys.json?user_id=…`, `/api/v1/regions/9/alerts.pb`), that alerts decodes a real GTFS-RT protobuf and returns the alert, and that with both names set the request goes to the **new** name's region.
- [x] Region-less config issues **zero** upstream requests and logs `Sidecar is disabled: PRIVATE_SIDECAR_REGION_ID is not set` — once per route across repeated requests, not once per map load.
- [x] `validate-env` across new-names / legacy-only / half-migrated / superseded-with-a-bad-value / base-URL-without-region.
- [x] Mutation-tested the new guards: removing the region guard, or restoring `regions/undefined/`, both turn the suite red.

## Review notes

Pre-existing issues in these files that I did **not** change, surfaced by the review — worth separate work:

- `src/routes/api/oba/alerts/+server.js` never checks `response.ok` before feeding the body to the protobuf decoder. A Sidecar outage decodes to an empty feed and returns **204 — indistinguishable from "no alerts right now"**, so riders can miss a real disruption silently. This is the most significant of the three.
- The three survey routes discard the upstream status/body (`throw new Error('Failed to…')`), so a 422, a 401, and a local `TypeError` all reach operators as one generic 500.
- `submit-survey` and `update-survey` return raw `error.message` to the client, which can leak internal detail.

Also: `npm run test` maps to bare `vitest`, which parks in watch mode rather than running once as CLAUDE.md describes — it probably wants `vitest run`. Left alone as out of scope.

https://claude.ai/code/session_01Upr2AgZoRfC3YLjT2bQQPs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Sidecar configuration using the new `PRIVATE_SIDECAR_*` environment variables.
  * Added an optional OBA agency filter setting.
  * Legacy configuration names continue to work as fallbacks with deprecation warnings.
  * Sidecar region settings are required only when a Sidecar API URL is configured.

* **Bug Fixes**
  * Improved alerts and survey behavior when Sidecar configuration is incomplete, including clearer warnings and safe empty responses.

* **Documentation**
  * Updated setup guidance and environment-variable validation documentation for renamed settings and configuration requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->