### PR TITLE
fix(favorites): stop outside-click dismissal stealing focus

### DIFF
--- a/src/components/favorites/FavoritesFloatingControl.svelte
+++ b/src/components/favorites/FavoritesFloatingControl.svelte
@@ -68,7 +68,14 @@
 		if (!target.isConnected) return;
 
 		if (!rootEl.contains(target)) {
-			close();
+			// The browser focuses a clicked element on mousedown, before this click
+			// reaches the window listener, so restoring focus here would yank the
+			// caret back out of whatever the user just clicked onto. Restore only
+			// when the click did not take focus itself: a click on the map leaves
+			// activeElement at <body>, and focus still inside the closing panel
+			// would be stranded when it unmounts.
+			const active = document.activeElement;
+			close({ restoreFocus: !active || active === document.body || rootEl.contains(active) });
 		}
 	}
 

--- a/src/components/favorites/__tests__/FavoritesFloatingControl.test.js
+++ b/src/components/favorites/__tests__/FavoritesFloatingControl.test.js
@@ -161,6 +161,40 @@ describe('FavoritesFloatingControl', () => {
 		outside.remove();
 	});
 
+	it('leaves focus on an outside element that took it', async () => {
+		render(FavoritesFloatingControl);
+
+		const toggle = screen.getByRole('button', { name: 'Open favorites' });
+		await user.click(toggle);
+		expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+		const input = document.createElement('input');
+		document.body.appendChild(input);
+
+		await user.click(input);
+
+		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+		expect(input).toHaveFocus();
+		input.remove();
+	});
+
+	it('restores focus to the toggle when the outside click took none', async () => {
+		render(FavoritesFloatingControl);
+
+		const toggle = screen.getByRole('button', { name: 'Open favorites' });
+		await user.click(toggle);
+		expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+		const outside = document.createElement('div');
+		document.body.appendChild(outside);
+
+		await user.click(outside);
+
+		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+		expect(toggle).toHaveFocus();
+		outside.remove();
+	});
+
 	it('closes on Escape and restores focus to the toggle', async () => {
 		render(FavoritesFloatingControl);
 


### PR DESCRIPTION
Fixes #604.

## The change

`handleWindowClick` called `close()` with no arguments, so `restoreFocus` defaulted to `true` and the queued `tick().then(() => toggleBtn?.focus())` ran after the browser had already focused the clicked element.

Taking the approach from the issue rather than flipping the flag to `false`, since most of the map is non-focusable and clicking there does need the restore:

```js
const active = document.activeElement;
close({ restoreFocus: !active || active === document.body || rootEl.contains(active) });
```

The `rootEl.contains(active)` clause is there for the case the issue does not name: if focus is still inside the panel when it closes, skipping the restore strands it once the panel unmounts. That branch keeps the restore.

Escape is untouched, and `handleStopClick` / `handleRouteClick` keep their explicit `restoreFocus: false`.

8 lines.

## Verification

Two tests, one per branch:

- clicking an outside `<input>` closes the panel and **leaves focus on the input**
- clicking an outside non-focusable `<div>` closes the panel and **restores focus to the toggle**

I checked they fail for the right reason rather than passing by accident. With the component change stashed, the first fails and the second still passes, which is exactly the asymmetry the bug describes:

```
× leaves focus on an outside element that took it
✓ restores focus to the toggle when the outside click took none
  Tests  1 failed | 8 passed (9)
```

With the fix, the whole suite is green: **110 files, 1879 tests**. Prettier clean.

## Not included

The two smaller items at the bottom of #604 are left out, since #604 asks for one thing and those are separable:

- `FavoritesList.itemTitle` using `item.shortName || item.id` where `MapExperience.handleFavoriteRouteClick` uses `?? removeAgencyPrefix(...)`. Those disagree only on an empty-string `shortName`.
- The 50-item cap not being enforced on the localStorage load path.

Can take either in a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved focus handling when closing the favorites panel by clicking outside.
  - Preserves focus on clicked inputs and other focusable elements.
  - Restores focus to the favorites toggle when the outside click does not move focus.

- **Tests**
  - Added coverage for focus preservation and restoration when the panel closes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->