### PR TITLE
fix(insights): return 400 for malformed event envelopes

### DIFF
--- a/src/lib/Insights/adapters/PlausibleAdapter.js
+++ b/src/lib/Insights/adapters/PlausibleAdapter.js
@@ -1,4 +1,4 @@
-import { upstreamError } from '../upstreamError.js';
+import { insightsError, upstreamError } from '../upstreamError.js';
 
 const UPSTREAM_TIMEOUT_MS = 5000;
 
@@ -25,17 +25,20 @@ export class PlausibleAdapter {
 		return `${this.env.PUBLIC_ANALYTICS_API_HOST}/api/event`;
 	}
 
-	async forwardEvent(envelope = {}, requestContext) {
+	async forwardEvent(envelope, requestContext) {
 		// Disabled analytics intentionally ignores malformed events so local development
 		// and tests without a complete analytics configuration remain quiet.
 		if (!this.isEnabled()) {
 			return { status: 'analytics disabled' };
 		}
 
-		const { name, url, referrer = '', props = {} } = envelope;
+		// `??` rather than a default parameter: the endpoint gets this from
+		// `await request.json()`, which returns null for a literal null body and
+		// never undefined, so a default parameter never fires on the reachable case.
+		const { name, url, referrer = '', props = {} } = envelope ?? {};
 
 		if (!name || !url) {
-			throw new Error('forwardEvent requires name and url');
+			throw insightsError('forwardEvent requires name and url', 400);
 		}
 
 		const headers = { 'Content-Type': 'application/json' };

--- a/src/lib/Insights/adapters/UmamiAdapter.js
+++ b/src/lib/Insights/adapters/UmamiAdapter.js
@@ -96,10 +96,10 @@ export class UmamiAdapter {
 			language = '',
 			screen = '',
 			props = {}
-		} = envelope;
+		} = envelope ?? {};
 
 		if (!name || !url) {
-			throw new Error('forwardEvent requires name and url');
+			throw insightsError('forwardEvent requires name and url', 400);
 		}
 
 		const body = {

--- a/src/tests/lib/Insights/adapters/PlausibleAdapter.test.js
+++ b/src/tests/lib/Insights/adapters/PlausibleAdapter.test.js
@@ -102,6 +102,21 @@ describe('PlausibleAdapter.forwardEvent', () => {
 		).rejects.toThrow('forwardEvent requires name and url');
 	});
 
+	it('rejects a null envelope as a 400 rather than a destructuring TypeError', async () => {
+		// /api/events builds the envelope from await request.json(), which returns
+		// null for a literal null body, so the default parameter never fires here.
+		const err = await new PlausibleAdapter(fullEnv).forwardEvent(null, ctx).catch((e) => e);
+		expect(err.message).toBe('forwardEvent requires name and url');
+		expect(err.upstreamStatus).toBe(400);
+	});
+
+	it('marks a missing name as a client error', async () => {
+		const err = await new PlausibleAdapter(fullEnv)
+			.forwardEvent({ url: '/x' }, ctx)
+			.catch((e) => e);
+		expect(err.upstreamStatus).toBe(400);
+	});
+
 	it('throws a clear validation error when called without an envelope', async () => {
 		await expect(new PlausibleAdapter(fullEnv).forwardEvent()).rejects.toThrow(
 			'forwardEvent requires name and url'

--- a/src/tests/lib/Insights/adapters/UmamiAdapter.test.js
+++ b/src/tests/lib/Insights/adapters/UmamiAdapter.test.js
@@ -197,6 +197,20 @@ describe('UmamiAdapter.forwardEvent (edge cases)', () => {
 		expect(global.fetch).not.toHaveBeenCalled();
 	});
 
+	it('rejects a null envelope as a 400 rather than a destructuring TypeError', async () => {
+		// /api/events builds the envelope from await request.json(), which returns
+		// null for a literal null body, so this is the reachable malformed case.
+		const err = await new UmamiAdapter(fullEnv).forwardEvent(null, ctx).catch((e) => e);
+		expect(err.message).toBe('forwardEvent requires name and url');
+		expect(err.upstreamStatus).toBe(400);
+	});
+
+	it('rejects a missing envelope as a 400', async () => {
+		const err = await new UmamiAdapter(fullEnv).forwardEvent().catch((e) => e);
+		expect(err.message).toBe('forwardEvent requires name and url');
+		expect(err.upstreamStatus).toBe(400);
+	});
+
 	it('throws when envelope.name is missing', async () => {
 		await expect(new UmamiAdapter(fullEnv).forwardEvent({ url: '/x' }, ctx)).rejects.toThrow(
 			'forwardEvent requires name and url'


### PR DESCRIPTION
Fixes #603, all three items.

## 1 and 2. `envelope ?? {}` in both adapters

`PlausibleAdapter.forwardEvent(envelope = {}, ...)` used a default parameter, which only fires on `undefined`. `/api/events` builds the envelope from `await request.json()`, and that returns `null` for a literal `null` body and never `undefined`, so the guard covered direct API misuse but not the reachable case. `UmamiAdapter` had no default at all.

Both now destructure from `envelope ?? {}`.

## 3. `insightsError(msg, 400)` instead of a bare `Error`

`new Error('forwardEvent requires name and url')` carries no `upstreamStatus`, so `+server.js:37`'s `error.upstreamStatus || (isTimeout ? 504 : 500)` reported a malformed client body as a server fault. Both adapters now throw `insightsError(..., 400)`, which is the idiom already used for upstream failures in the same files. `insightsError` was already imported in `UmamiAdapter`; added to `PlausibleAdapter`'s existing import.

Applying it to both matters for the reason the issue gives: `createAdapter` switches on `PUBLIC_ANALYTICS_PROVIDER`, so leaving one behind means the same malformed request behaves differently depending on which provider a deployment runs.

## Verification

Four tests, two per adapter: a `null` envelope and a missing one, each asserting both the message and `upstreamStatus === 400`.

I checked they fail for the right reason rather than passing by accident. With both adapter changes stashed:

```
× PlausibleAdapter > rejects a null envelope as a 400 rather than a destructuring TypeError
× PlausibleAdapter > marks a missing name as a client error
× UmamiAdapter     > rejects a null envelope as a 400 rather than a destructuring TypeError
× UmamiAdapter     > rejects a missing envelope as a 400
  Tests  4 failed | 64 passed (68)
```

With the fix, the whole suite is green: **110 files, 1881 tests**. Prettier clean.

The existing `throws when name is missing` / `throws when url is missing` tests are untouched and still pass, since the message is unchanged and only the carried status is new.
