### PR TITLE
fix(map): recover missing route shapes

### DIFF
--- a/src/components/MapExperience.svelte
+++ b/src/components/MapExperience.svelte
@@ -109,7 +109,11 @@
 	let arrivalsMatchSelection = $derived(
 		stopArrivals?.data?.entry?.stopId != null && stopArrivals.data.entry.stopId === selectedStopId
 	);
-	let activeRoutes = $derived(arrivalsMatchSelection ? activeRoutesFromArrivals(stopArrivals) : []);
+	// Use the same non-departed arrival set the sheet renders. Keeping the raw
+	// response as the bound value is still useful to StopPane; the map derives a
+	// boardable subset whenever that response refreshes.
+	let boardableRoutes = $derived(activeRoutesFromArrivals(stopArrivals, { now: Date.now() }));
+	let activeRoutes = $derived(arrivalsMatchSelection ? boardableRoutes : []);
 	// Deliberately NOT gated on arrivalsMatchSelection (derived from stopArrivals
 	// directly, not from the gated activeRoutes above). StopPane's rendered rows are
 	// a one-time $state seed that doesn't react to stopArrivals going stale, so
@@ -117,9 +121,7 @@
 	// are the correct colors for them. The map is separately held back from drawing
 	// anything stale by activeRoutes being empty until B's arrivals land. Two
 	// consumers of routeColors, two different staleness semantics, one source.
-	let routeColors = $derived(
-		assignRouteColors(activeRoutesFromArrivals(stopArrivals), { dark: isDarkMode })
-	);
+	let routeColors = $derived(assignRouteColors(boardableRoutes, { dark: isDarkMode }));
 
 	// While a stop's bottom sheet is open, the search pane collapses to a single
 	// floating field below the md breakpoint; on wider viewports the pane stays

--- a/src/components/map/StopRoutesLayer.svelte
+++ b/src/components/map/StopRoutesLayer.svelte
@@ -47,8 +47,21 @@
 	// transform and has no cross-provider primitive — see the design spec.
 	const BASE_WEIGHT = 7;
 	const MIN_WEIGHT = 4;
+	// Bound the degraded path: a busy route can have dozens of arrivals in the
+	// loaded window, but trying all of them serially would amplify an upstream
+	// outage. Three candidates cover the immediate service without an unbounded
+	// request chain.
+	const MAX_TRIP_SHAPE_CANDIDATES = 3;
+	// GTFS shapes are immutable for the lifetime of this layer. Cache successes
+	// indefinitely and failures briefly, so redraws do not repeat healthy requests
+	// or hammer an unhealthy upstream forever.
+	const SHAPE_FAILURE_CACHE_MS = 30_000;
 
 	let vehicleIntervalId = null;
+	// Kept separately from polylinesByRouteId because vehicle polling starts for
+	// every active route, including a route whose shape ultimately cannot draw.
+	// Teardown must still remove that route's vehicle markers.
+	let polledRouteIds = new Set();
 	// Forces an immediate vehicle refresh (see fetchAndUpdateVehiclesForRoutes)
 	// rather than waiting up to 30s for the next scheduled poll. Set once the
 	// poll started by the main redraw effect below resolves; read by the
@@ -61,8 +74,9 @@
 	// currently on the map, so a redraw can be skipped when a new
 	// activeRoutes/routeColors identity carries identical content.
 	let lastSignature = null;
-	// routeId -> the polyline drawn for it, so the promotion effect below can
-	// re-pane a route without re-fetching or re-creating anything. Named
+	// routeId -> the polylines drawn for it, so the promotion effect below can
+	// re-pane a route without re-fetching or re-creating anything. A route-level
+	// fallback can contain multiple shape segments, hence the array value. Named
 	// distinctly from drawRoutes' local `drawnPolylines` paint-order array
 	// below, which tracks something else (resolution order, for
 	// bringToFront). Populated as each route's shape resolves in drawRoutes;
@@ -76,6 +90,8 @@
 	// the polylines were actually drawn/weighted in. Populated alongside
 	// polylinesByRouteId in drawRoutes; cleared in teardown().
 	let routeDrawIndex = new Map();
+	const tripShapeCache = new Map();
+	const routeShapeCache = new Map();
 	// The route currently sitting in ROUTE_PANE.PROMOTED, so the promotion
 	// effect can demote it before promoting a new one. Reset in teardown()
 	// since a redraw discards every polyline, promoted or not.
@@ -85,32 +101,134 @@
 		return Math.max(MIN_WEIGHT, BASE_WEIGHT - index);
 	}
 
-	async function fetchRouteShape(route) {
-		// includeStatus=false: the endpoint defaults it to true, and we need only
-		// the shape id and the stop times.
-		const tripResponse = await fetch(`/api/oba/trip-details/${route.tripId}?includeStatus=false`);
-		if (!tripResponse.ok) {
-			throw new Error(`trip-details ${tripResponse.status} for trip ${route.tripId}`);
+	function cachedShapeRequest(cache, key, load) {
+		const cached = cache.get(key);
+		if (cached && cached.expiresAt > Date.now()) return cached.promise;
+
+		const entry = { expiresAt: Number.POSITIVE_INFINITY, promise: null };
+		entry.promise = load().catch((error) => {
+			entry.expiresAt = Date.now() + SHAPE_FAILURE_CACHE_MS;
+			throw error;
+		});
+		cache.set(key, entry);
+		return entry.promise;
+	}
+
+	function fetchTripShape(candidate) {
+		const cacheKey = `${candidate.id}@${candidate.serviceDate ?? ''}`;
+		return cachedShapeRequest(tripShapeCache, cacheKey, async () => {
+			// includeStatus=false: the endpoint defaults it to true, and we need only
+			// the shape id and the stop times. serviceDate disambiguates trips on OBA
+			// deployments that reuse a trip id across service days.
+			const query = new URLSearchParams({ includeStatus: 'false' });
+			if (candidate.serviceDate != null) query.set('serviceDate', String(candidate.serviceDate));
+			const tripResponse = await fetch(
+				`/api/oba/trip-details/${encodeURIComponent(candidate.id)}?${query}`
+			);
+			if (!tripResponse.ok) {
+				throw new Error(`trip-details ${tripResponse.status} for trip ${candidate.id}`);
+			}
+			const tripData = await tripResponse.json();
+
+			const entry = tripData?.data?.entry;
+			const tripRef = tripData?.data?.references?.trips?.find((trip) => trip.id === candidate.id);
+			// Most OBA servers put the trip in references; tolerate servers that put
+			// the expanded object directly on the entry instead.
+			const shapeId = tripRef?.shapeId ?? entry?.trip?.shapeId ?? entry?.shapeId;
+			if (!shapeId) {
+				throw new Error(`no shapeId for trip ${candidate.id}`);
+			}
+
+			const shapeResponse = await fetch(`/api/oba/shape/${encodeURIComponent(shapeId)}`);
+			if (!shapeResponse.ok) {
+				throw new Error(`shape ${shapeResponse.status} for shape ${shapeId}`);
+			}
+			const shapeData = await shapeResponse.json();
+			const points = shapeData?.data?.entry?.points;
+			if (!points) throw new Error(`shape ${shapeId} contains no points`);
+
+			const stopIds = (entry?.schedule?.stopTimes ?? [])
+				.map((stopTime) => stopTime.stopId)
+				.filter(Boolean);
+
+			return { points, stopIds, tripId: candidate.id, shapeId };
+		});
+	}
+
+	function fetchRouteFallback(route) {
+		return cachedShapeRequest(routeShapeCache, route.id, async () => {
+			const response = await fetch(`/api/oba/stops-for-route/${encodeURIComponent(route.id)}`);
+			if (!response.ok) {
+				throw new Error(`stops-for-route ${response.status} for route ${route.id}`);
+			}
+			const data = await response.json();
+			const stopIds = (data?.data?.references?.stops ?? []).map((stop) => stop.id).filter(Boolean);
+			const seenPoints = new Set();
+			const shapes = (data?.data?.entry?.polylines ?? [])
+				.map((polyline) => polyline?.points)
+				.filter((points) => {
+					if (!points || seenPoints.has(points)) return false;
+					seenPoints.add(points);
+					return true;
+				})
+				.map((points) => ({ points, stopIds }));
+
+			if (shapes.length === 0) {
+				throw new Error(`stops-for-route returned no points for route ${route.id}`);
+			}
+			return shapes;
+		});
+	}
+
+	async function fetchRouteShapes(route) {
+		const candidates = (
+			route.tripCandidates?.length
+				? route.tripCandidates
+				: route.tripId
+					? [{ id: route.tripId }]
+					: []
+		).slice(0, MAX_TRIP_SHAPE_CANDIDATES);
+		const failures = [];
+
+		// A single malformed or stale arrival must not remove the route. Try the
+		// remaining boardable trips for the same route in arrival order first, so
+		// the successful shape still represents a direction the rider can board.
+		for (const candidate of candidates) {
+			try {
+				const shape = await fetchTripShape(candidate);
+				if (failures.length > 0) {
+					console.warn('StopRoutesLayer: using alternate trip shape', {
+						routeId: route.id,
+						tripId: shape.tripId,
+						shapeId: shape.shapeId,
+						failedTripIds: candidates
+							.slice(0, failures.length)
+							.map((failedCandidate) => failedCandidate.id),
+						failures
+					});
+				}
+				return [shape];
+			} catch (error) {
+				failures.push(error);
+			}
 		}
-		const tripData = await tripResponse.json();
 
-		const tripRef = tripData?.data?.references?.trips?.find((trip) => trip.id === route.tripId);
-		const shapeId = tripRef?.shapeId;
-		if (!shapeId) {
-			throw new Error(`no shapeId for trip ${route.tripId}`);
+		// Last-resort degraded view: route-level geometry may include more than one
+		// direction, but is preferable to showing a live vehicle with no line at
+		// all. SearchPane already uses this endpoint for its route overview.
+		let shapes;
+		try {
+			shapes = await fetchRouteFallback(route);
+		} catch (error) {
+			throw new AggregateError([...failures, error], `no usable shape for route ${route.id}`);
 		}
 
-		const shapeResponse = await fetch(`/api/oba/shape/${shapeId}`);
-		if (!shapeResponse.ok) {
-			throw new Error(`shape ${shapeResponse.status} for shape ${shapeId}`);
-		}
-		const shapeData = await shapeResponse.json();
-
-		const stopIds = (tripData?.data?.entry?.schedule?.stopTimes ?? [])
-			.map((stopTime) => stopTime.stopId)
-			.filter(Boolean);
-
-		return { points: shapeData?.data?.entry?.points, stopIds };
+		console.warn('StopRoutesLayer: using route-level shape fallback', {
+			routeId: route.id,
+			tripIds: candidates.map((candidate) => candidate.id),
+			failures
+		});
+		return shapes;
 	}
 
 	let notificationId = null;
@@ -145,13 +263,12 @@
 		await Promise.all(
 			routes.map(async (route, index) => {
 				const color = colors.get(route.id)?.line;
-				let shape;
+				let shapes;
 				try {
-					shape = await fetchRouteShape(route);
+					shapes = await fetchRouteShapes(route);
 				} catch (error) {
-					// One missing shape degrades the map rather than breaking it: the
-					// other routes still draw, and this one is simply absent from the
-					// lines, the legend, and the ring dots.
+					// Exhausting every trip plus the route-level fallback degrades only
+					// this route; neighboring routes still draw.
 					console.error('StopRoutesLayer: could not load shape', route.id, error);
 					attemptedRoutes++;
 					return;
@@ -160,11 +277,6 @@
 
 				attemptedRoutes++;
 
-				if (!shape.points) {
-					console.error('StopRoutesLayer: route shape contains no points', route.id);
-					return;
-				}
-
 				// untrack: this read happens after an await, so Svelte would not treat
 				// it as an effect dependency anyway — but reading it explicitly through
 				// untrack makes that non-dependency intentional rather than incidental,
@@ -172,33 +284,41 @@
 				// turn trip-expansion into a full redraw.
 				const promoted = untrack(() => promotedRouteId);
 				const isPromoted = promoted != null && route.id === promoted;
-				let polyline = null;
+				const routePolylines = [];
 
-				try {
-					polyline = await mapProvider.createPolyline(shape.points, {
-						color,
-						casing: true,
-						weight: weightFor(index),
-						pane: isPromoted ? ROUTE_PANE.PROMOTED : ROUTE_PANE.LINE,
-						casingPane: ROUTE_PANE.CASING
-					});
-				} catch (error) {
-					console.error('StopRoutesLayer: could not create polyline', route.id, error);
-					return;
+				for (const shape of shapes) {
+					let polyline = null;
+					try {
+						polyline = await mapProvider.createPolyline(shape.points, {
+							color,
+							casing: true,
+							weight: weightFor(index),
+							pane: isPromoted ? ROUTE_PANE.PROMOTED : ROUTE_PANE.LINE,
+							casingPane: ROUTE_PANE.CASING
+						});
+					} catch (error) {
+						console.error('StopRoutesLayer: could not create polyline', route.id, error);
+						continue;
+					}
+
+					if (token !== loadToken) {
+						// Google creates polylines asynchronously. If a newer stop wins
+						// during a multi-segment fallback, remove every segment this stale
+						// route attached before returning.
+						if (polyline) mapProvider.removePolyline(polyline);
+						for (const created of routePolylines) mapProvider.removePolyline(created);
+						return;
+					}
+					if (!polyline) {
+						console.error('StopRoutesLayer: could not create polyline', route.id);
+						continue;
+					}
+
+					routePolylines.push(polyline);
+					drawnPolylines.push({ index, polyline });
 				}
 
-				if (token !== loadToken) {
-					// A supersede ran clearAllPolylines() before this create resolved
-					// (Google's createPolyline is async, awaiting importLibrary), so
-					// the polyline this call just attached to the map is an orphan of
-					// the selection that's already gone — take it back off.
-					mapProvider.removePolyline(polyline);
-					return;
-				}
-				if (!polyline) {
-					console.error('StopRoutesLayer: could not create polyline', route.id);
-					return;
-				}
+				if (routePolylines.length === 0) return;
 
 				drawnRoutes++;
 
@@ -207,13 +327,13 @@
 				// the untracked promotedRouteId read at the top of this callback),
 				// so the promotion effect's own idea of "currently promoted" starts
 				// in sync with what was actually drawn.
-				polylinesByRouteId.set(route.id, polyline);
+				polylinesByRouteId.set(route.id, routePolylines);
 				routeDrawIndex.set(route.id, index);
 				if (isPromoted) currentlyPromotedRouteId = route.id;
 
 				// Reveal only this route: its neighbors may already be drawn, and
 				// re-animating them on every resolution would look like a glitch.
-				mapProvider.revealPolylines({ only: [polyline], duration: 0.8 });
+				mapProvider.revealPolylines({ only: routePolylines, duration: 0.8 });
 
 				// Paint order is shape-fetch resolution order, not index order, so
 				// re-assert index order after every resolution: the widest route
@@ -226,7 +346,6 @@
 				// it's a no-op on Google's polyline object, whose paint order already
 				// comes from the pane's zIndex set at creation, so this line is
 				// harmless there.
-				drawnPolylines.push({ index, polyline });
 				drawnPolylines.sort((a, b) => a.index - b.index);
 				for (const drawn of drawnPolylines) {
 					drawn.polyline.bringToFront?.();
@@ -239,11 +358,13 @@
 				// resolved route's turn, so two routes resolving "at the same time"
 				// (already-resolved microtasks) still apply one at a time rather than
 				// clobbering each other's contribution.
-				for (const stopId of shape.stopIds) {
-					const claimedIndex = stopClaimIndex.get(stopId);
-					if (claimedIndex === undefined || index < claimedIndex) {
-						nextStopIds.set(stopId, color);
-						stopClaimIndex.set(stopId, index);
+				for (const shape of shapes) {
+					for (const stopId of shape.stopIds) {
+						const claimedIndex = stopClaimIndex.get(stopId);
+						if (claimedIndex === undefined || index < claimedIndex) {
+							nextStopIds.set(stopId, color);
+							stopClaimIndex.set(stopId, index);
+						}
 					}
 				}
 				routeStopIds = new Map(nextStopIds);
@@ -283,17 +404,20 @@
 		// new drawRoutes() starts, so it still reflects the *previous* draw,
 		// which is what needs clearing.
 		if (mapProvider) {
-			for (const polyline of polylinesByRouteId.values()) {
-				mapProvider.removePolyline(polyline);
+			for (const polylines of polylinesByRouteId.values()) {
+				for (const polyline of polylines) mapProvider.removePolyline(polyline);
 			}
-			// Array.from, not the live Map iterator: polylinesByRouteId.clear()
-			// below would otherwise empty the iterator's backing map out from
-			// under a caller (or a test spy) that reads it after this call returns.
-			removeVehicleMarkersForRoutes(Array.from(polylinesByRouteId.keys()), mapProvider);
+			// Snapshot the union: a failed route can have vehicle markers despite
+			// having no entry in polylinesByRouteId.
+			removeVehicleMarkersForRoutes(
+				Array.from(new Set([...polylinesByRouteId.keys(), ...polledRouteIds])),
+				mapProvider
+			);
 		}
 		// promotion effect's own bookkeeping must be reset here too, or it would
 		// try to re-pane a polyline that no longer exists.
 		polylinesByRouteId.clear();
+		polledRouteIds.clear();
 		routeDrawIndex.clear();
 		currentlyPromotedRouteId = null;
 	}
@@ -314,8 +438,8 @@
 		const nonPromoted = [];
 		for (const [routeId, index] of routeDrawIndex) {
 			if (routeId === currentlyPromotedRouteId) continue;
-			const polyline = polylinesByRouteId.get(routeId);
-			if (polyline) nonPromoted.push({ index, polyline });
+			const polylines = polylinesByRouteId.get(routeId) ?? [];
+			for (const polyline of polylines) nonPromoted.push({ index, polyline });
 		}
 		nonPromoted.sort((a, b) => a.index - b.index);
 		for (const { polyline } of nonPromoted) {
@@ -371,6 +495,10 @@
 		// current at the *first* draw of this route set, not the live
 		// soonest-first order; that's a far smaller price than refetching and
 		// re-animating every 30 seconds.
+		// Candidate trips deliberately do not participate in this signature.
+		// Arrival polling naturally adds/removes candidates every 30s; the drawn
+		// route remains valid, so rebuilding it would flash the line and restart
+		// vehicle polling for no user-visible benefit.
 		const signature = routes
 			.map((route) => `${route.id}:${colors.get(route.id)?.line ?? ''}`)
 			.sort()
@@ -399,6 +527,7 @@
 		// started. Wrapped in untrack() so that if a future refactor ever calls
 		// this getter synchronously from inside an effect, it still won't
 		// register highlightedTripId as that effect's dependency.
+		polledRouteIds = new Set(routes.map((route) => route.id));
 		fetchAndUpdateVehiclesForRoutes(routes, mapProvider, {
 			highlightedTripId: () => untrack(() => highlightedTripId),
 			colorsByRouteId: colors,
@@ -444,19 +573,19 @@
 				// Demote the previously promoted route first — if the polyline it
 				// named ever resolved. Tolerated as a no-op otherwise (its shape
 				// fetch may have failed, or nothing was promoted yet).
-				const previousPolyline = currentlyPromotedRouteId
+				const previousPolylines = currentlyPromotedRouteId
 					? polylinesByRouteId.get(currentlyPromotedRouteId)
-					: null;
-				if (previousPolyline) {
-					mapProvider.setPolylineLayer(previousPolyline, ROUTE_PANE.LINE);
+					: [];
+				for (const polyline of previousPolylines ?? []) {
+					mapProvider.setPolylineLayer(polyline, ROUTE_PANE.LINE);
 				}
 
 				// Promote the new one — same tolerance: promotedRouteId may name a
 				// route whose shape fetch failed, in which case there's no
 				// polyline to move and this is a no-op.
-				const nextPolyline = promoted ? polylinesByRouteId.get(promoted) : null;
-				if (nextPolyline) {
-					mapProvider.setPolylineLayer(nextPolyline, ROUTE_PANE.PROMOTED);
+				const nextPolylines = promoted ? polylinesByRouteId.get(promoted) : [];
+				for (const polyline of nextPolylines ?? []) {
+					mapProvider.setPolylineLayer(polyline, ROUTE_PANE.PROMOTED);
 				}
 
 				currentlyPromotedRouteId = promoted;
@@ -482,5 +611,7 @@
 		loadToken++;
 		isMounted = false;
 		teardown();
+		tripShapeCache.clear();
+		routeShapeCache.clear();
 	});
 </script>

--- a/src/components/map/__tests__/StopRoutesLayer.test.js
+++ b/src/components/map/__tests__/StopRoutesLayer.test.js
@@ -94,6 +94,117 @@ describe('StopRoutesLayer', () => {
 		expect(tripDetailsUrl).toContain('includeStatus=false');
 	});
 
+	test('tries the next boardable trip when the first trip has no usable shape', async () => {
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const resilientRoute = {
+			...routes[0],
+			tripCandidates: [
+				{ id: 't_stale', serviceDate: 20260904 },
+				{ id: 't_good', serviceDate: 20260904 }
+			]
+		};
+		global.fetch = vi.fn(async (url) => {
+			if (url.includes('/trip-details/t_stale')) return { ok: false, status: 500 };
+			if (url.includes('/trip-details/t_good')) {
+				return {
+					ok: true,
+					json: async () => ({
+						data: {
+							entry: { schedule: { stopTimes: [{ stopId: 'stop_good' }] } },
+							references: { trips: [{ id: 't_good', shapeId: 'shape_good' }] }
+						}
+					})
+				};
+			}
+			if (url.includes('/shape/shape_good')) {
+				return { ok: true, json: async () => ({ data: { entry: { points: 'encoded_good' } } }) };
+			}
+			throw new Error(`unexpected fetch: ${url}`);
+		});
+
+		const mapProvider = makeProvider();
+		render(StopRoutesLayer, {
+			props: { mapProvider, activeRoutes: [resilientRoute], routeColors: colors }
+		});
+
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(1));
+		expect(mapProvider.createPolyline).toHaveBeenCalledWith(
+			'encoded_good',
+			expect.objectContaining({ color: '#b02a37' })
+		);
+		expect(global.fetch.mock.calls[0][0]).toContain('serviceDate=20260904');
+		expect(global.fetch.mock.calls.some(([url]) => url.includes('/stops-for-route/'))).toBe(false);
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			'StopRoutesLayer: using alternate trip shape',
+			expect.objectContaining({
+				routeId: 'r_c',
+				tripId: 't_good',
+				shapeId: 'shape_good',
+				failedTripIds: ['t_stale']
+			})
+		);
+		expect(notifyPartialRouteShape).not.toHaveBeenCalled();
+		consoleWarnSpy.mockRestore();
+	});
+
+	test('uses every route-level polyline when all boardable trip shapes fail', async () => {
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const resilientRoute = {
+			...routes[0],
+			tripCandidates: [{ id: 't_bad_1' }, { id: 't_bad_2' }, { id: 't_bad_3' }, { id: 't_bad_4' }]
+		};
+		global.fetch = vi.fn(async (url) => {
+			if (url.includes('/trip-details/')) return { ok: false, status: 500 };
+			if (url.includes('/stops-for-route/r_c')) {
+				return {
+					ok: true,
+					json: async () => ({
+						data: {
+							entry: {
+								polylines: [
+									{ points: 'fallback_a' },
+									{ points: 'fallback_b' },
+									{ points: 'fallback_a' }
+								]
+							},
+							references: { stops: [{ id: 'fallback_stop' }] }
+						}
+					})
+				};
+			}
+			throw new Error(`unexpected fetch: ${url}`);
+		});
+
+		const mapProvider = makeProvider();
+		render(StopRoutesLayer, {
+			props: { mapProvider, activeRoutes: [resilientRoute], routeColors: colors }
+		});
+
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(2));
+		expect(mapProvider.createPolyline.mock.calls.map(([points]) => points)).toEqual([
+			'fallback_a',
+			'fallback_b'
+		]);
+		const attemptedTrips = global.fetch.mock.calls
+			.map(([url]) => url)
+			.filter((url) => url.includes('/trip-details/'));
+		expect(attemptedTrips).toHaveLength(3);
+		expect(attemptedTrips.some((url) => url.includes('t_bad_4'))).toBe(false);
+		expect(mapProvider.revealPolylines).toHaveBeenCalledWith({
+			only: expect.arrayContaining([expect.any(Object), expect.any(Object)]),
+			duration: 0.8
+		});
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			'StopRoutesLayer: using route-level shape fallback',
+			expect.objectContaining({
+				routeId: 'r_c',
+				tripIds: ['t_bad_1', 't_bad_2', 't_bad_3']
+			})
+		);
+		expect(notifyPartialRouteShape).not.toHaveBeenCalled();
+		consoleWarnSpy.mockRestore();
+	});
+
 	// $bindable writes land on the parent's reactive state, and $state is a runes
 	// macro that only compiles in a .svelte/.svelte.js module — so a plain
 	// .test.js can't create the proxy to read back. Use a support harness, the
@@ -214,7 +325,9 @@ describe('StopRoutesLayer', () => {
 		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 		mockShapeFetches({ failRouteId: 'r_22' });
 		const mapProvider = makeProvider();
-		render(StopRoutesLayer, { props: { mapProvider, activeRoutes: routes, routeColors: colors } });
+		const { unmount } = render(StopRoutesLayer, {
+			props: { mapProvider, activeRoutes: routes, routeColors: colors }
+		});
 
 		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(1));
 		expect(mapProvider.createPolyline.mock.calls[0][1].color).toBe('#b02a37');
@@ -231,6 +344,12 @@ describe('StopRoutesLayer', () => {
 			expect.any(Error)
 		);
 		expect(notifyPartialRouteShape).toHaveBeenCalledTimes(1);
+
+		unmount();
+		expect(removeVehicleMarkersForRoutes).toHaveBeenCalledWith(
+			expect.arrayContaining(['r_c', 'r_22']),
+			mapProvider
+		);
 
 		consoleErrorSpy.mockRestore();
 	});
@@ -340,6 +459,27 @@ describe('StopRoutesLayer', () => {
 		expect(mapProvider.removePolyline.mock.calls.length).toBe(removeCallsAfterFirstDraw);
 	});
 
+	test('does not redraw when polling only changes a route candidate list', async () => {
+		const mapProvider = makeProvider();
+		const initialRoutes = [{ ...routes[0], tripCandidates: [{ id: 't_c' }, { id: 't_c_next' }] }];
+		const { rerender } = render(StopRoutesLayer, {
+			props: { mapProvider, activeRoutes: initialRoutes, routeColors: colors }
+		});
+		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(1));
+		const fetchCallsAfterFirstDraw = global.fetch.mock.calls.length;
+
+		await rerender({
+			mapProvider,
+			activeRoutes: [{ ...routes[0], tripCandidates: [{ id: 't_c_next' }, { id: 't_c_later' }] }],
+			routeColors: colors
+		});
+		await flush();
+
+		expect(mapProvider.createPolyline).toHaveBeenCalledTimes(1);
+		expect(global.fetch).toHaveBeenCalledTimes(fetchCallsAfterFirstDraw);
+		expect(mapProvider.removePolyline).not.toHaveBeenCalled();
+	});
+
 	test('does redraw when the route set actually changes', async () => {
 		const mapProvider = makeProvider();
 		const { rerender } = render(StopRoutesLayer, {
@@ -349,9 +489,12 @@ describe('StopRoutesLayer', () => {
 
 		const changedColors = new Map(colors);
 		changedColors.set('r_c', { ...colors.get('r_c'), line: '#000000' });
+		const fetchCallsBeforeRedraw = global.fetch.mock.calls.length;
 		await rerender({ mapProvider, activeRoutes: routes, routeColors: changedColors });
 
 		await vi.waitFor(() => expect(mapProvider.createPolyline).toHaveBeenCalledTimes(4));
+		// Geometry is immutable; a color-only redraw should reuse cached shapes.
+		expect(global.fetch).toHaveBeenCalledTimes(fetchCallsBeforeRedraw);
 		// The redraw's own teardown removes exactly the two polylines the
 		// previous draw produced (the first mount's teardown had nothing to
 		// remove yet).

--- a/src/lib/__tests__/activeRoutes.test.js
+++ b/src/lib/__tests__/activeRoutes.test.js
@@ -42,6 +42,7 @@ describe('activeRoutesFromArrivals', () => {
 			shortName: 'C Line',
 			type: 3,
 			tripId: 't_a',
+			tripCandidates: [{ id: 't_a' }],
 			gtfsColor: 'b02a37'
 		});
 	});
@@ -70,6 +71,68 @@ describe('activeRoutesFromArrivals', () => {
 		);
 		expect(result).toHaveLength(1);
 		expect(result[0].tripId).toBe('t_soon');
+		expect(result[0].tripCandidates).toEqual([{ id: 't_soon' }, { id: 't_late' }]);
+	});
+
+	test('keeps ordered, unique trip candidates with their service dates', () => {
+		const result = activeRoutesFromArrivals(
+			makeResponse([
+				{
+					routeId: 'r_c',
+					tripId: 't_soon',
+					serviceDate: 20260904,
+					predicted: true,
+					predictedArrivalTime: 1000,
+					scheduledArrivalTime: 1000
+				},
+				{
+					routeId: 'r_c',
+					tripId: 't_soon',
+					serviceDate: 20260904,
+					predicted: true,
+					predictedArrivalTime: 2000,
+					scheduledArrivalTime: 2000
+				},
+				{
+					routeId: 'r_c',
+					tripId: 't_next',
+					serviceDate: 20260904,
+					predicted: false,
+					predictedArrivalTime: 0,
+					scheduledArrivalTime: 3000
+				}
+			])
+		);
+
+		expect(result[0].tripCandidates).toEqual([
+			{ id: 't_soon', serviceDate: 20260904 },
+			{ id: 't_next', serviceDate: 20260904 }
+		]);
+	});
+
+	test('excludes departed arrivals when the caller supplies the current time', () => {
+		const minute = 60_000;
+		const result = activeRoutesFromArrivals(
+			makeResponse([
+				{
+					routeId: 'r_departed',
+					tripId: 't_departed',
+					predicted: true,
+					predictedArrivalTime: 9 * minute,
+					scheduledArrivalTime: 9 * minute
+				},
+				{
+					routeId: 'r_boardable',
+					tripId: 't_boardable',
+					predicted: false,
+					predictedArrivalTime: 0,
+					scheduledArrivalTime: 11 * minute
+				}
+			]),
+			{ now: 10 * minute }
+		);
+
+		expect(result.map((route) => route.id)).toEqual(['r_boardable']);
 	});
 
 	// OBA sends predictedArrivalTime: 0 (not null) when there is no real-time

--- a/src/lib/activeRoutes.js
+++ b/src/lib/activeRoutes.js
@@ -1,3 +1,7 @@
+import { filterDeparted } from '$lib/arrivalFiltering.js';
+import { mapContrastColor, contrastRatio } from '$lib/colorUtils.js';
+import { ROUTE_FALLBACK_PALETTE } from '$lib/colors.js';
+
 /**
  * Derives the set of routes a rider can actually board from a stop, from that
  * stop's arrivals-and-departures response.
@@ -13,7 +17,8 @@
  * @property {string} id
  * @property {string} shortName
  * @property {number} type
- * @property {string} tripId
+ * @property {string|null} tripId
+ * @property {{id: string, serviceDate?: number}[]} tripCandidates
  * @property {string|null} gtfsColor
  */
 
@@ -35,46 +40,67 @@ function effectiveArrivalTime(arrival) {
 
 /**
  * @param {Object} response - an /arrivals-and-departures-for-stop response
+ * @param {{now?: number}} options - when supplied, ignore arrivals that have already departed
  * @returns {ActiveRoute[]} distinct routes, soonest arrival first
  */
-export function activeRoutesFromArrivals(response) {
-	const arrivals = response?.data?.entry?.arrivalsAndDepartures;
-	if (!Array.isArray(arrivals)) return [];
+export function activeRoutesFromArrivals(response, { now } = {}) {
+	const rawArrivals = response?.data?.entry?.arrivalsAndDepartures;
+	if (!Array.isArray(rawArrivals)) return [];
+
+	// StopPane filters departed rows before rendering them. Apply the same rule
+	// here when the caller supplies its clock so the map cannot choose a stale,
+	// just-departed trip as the only shape candidate for a route that still has
+	// boardable arrivals.
+	const arrivals = Number.isFinite(now) ? filterDeparted(rawArrivals, now) : rawArrivals;
 
 	const routeRefs = new Map(
 		(response?.data?.references?.routes ?? []).map((route) => [route.id, route])
 	);
 
-	/** @type {Map<string, {arrival: Object, time: number}>} */
-	const soonestByRoute = new Map();
+	/** @type {Map<string, {arrival: Object, time: number, index: number}[]>} */
+	const arrivalsByRoute = new Map();
 
-	for (const arrival of arrivals) {
+	for (const [index, arrival] of arrivals.entries()) {
 		const routeId = arrival?.routeId;
 		if (!routeId) continue;
 
 		const time = effectiveArrivalTime(arrival);
-		const existing = soonestByRoute.get(routeId);
-		if (!existing || time < existing.time) {
-			soonestByRoute.set(routeId, { arrival, time });
-		}
+		if (!arrivalsByRoute.has(routeId)) arrivalsByRoute.set(routeId, []);
+		arrivalsByRoute.get(routeId).push({ arrival, time, index });
 	}
 
-	return [...soonestByRoute.entries()]
-		.sort((a, b) => a[1].time - b[1].time)
-		.map(([routeId, { arrival }]) => {
+	const grouped = [...arrivalsByRoute.entries()].map(([routeId, candidates]) => {
+		candidates.sort((a, b) => a.time - b.time || a.index - b.index);
+		return [routeId, candidates];
+	});
+
+	return grouped
+		.sort((a, b) => a[1][0].time - b[1][0].time || a[1][0].index - b[1][0].index)
+		.map(([routeId, candidates]) => {
+			const arrival = candidates[0].arrival;
 			const ref = routeRefs.get(routeId);
+			const seenTrips = new Set();
+			const tripCandidates = candidates
+				.map(({ arrival: candidate }) => ({
+					id: candidate.tripId,
+					...(candidate.serviceDate != null ? { serviceDate: candidate.serviceDate } : {})
+				}))
+				.filter((candidate) => {
+					const key = `${candidate.id}@${candidate.serviceDate ?? ''}`;
+					if (!candidate.id || seenTrips.has(key)) return false;
+					seenTrips.add(key);
+					return true;
+				});
 			return {
 				id: routeId,
 				shortName: ref?.shortName ?? arrival.routeShortName ?? '',
 				type: ref?.type ?? 3,
-				tripId: arrival.tripId,
+				tripId: tripCandidates[0]?.id ?? null,
+				tripCandidates,
 				gtfsColor: ref?.color || null
 			};
 		});
 }
-
-import { mapContrastColor, contrastRatio } from '$lib/colorUtils.js';
-import { ROUTE_FALLBACK_PALETTE } from '$lib/colors.js';
 
 /**
  * @typedef {Object} RouteColors


### PR DESCRIPTION
## Summary

- align map routes with the non-departed arrivals shown to riders
- try up to three upcoming trip shapes before falling back to route-level geometry
- cache successful shapes and briefly cache failures to avoid request amplification
- keep arrival polling from redrawing healthy routes and clean up fallback segments and vehicles
- add regression coverage for retries, fallback deduplication, caching, and redraw behavior

## Testing

- npm test -- --run (1,799 tests passed)
- Prettier and ESLint checks on changed files
- npm run build

Closes #607

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Map route displays now prioritize currently boardable arrivals and exclude trips that have already departed.
  * Route lines are more resilient when trip-specific geometry is unavailable, using alternate trips or route-level geometry when possible.
  * Multiple route segments can now be displayed for more complete coverage.
  * Map updates reuse previously loaded route geometry, improving redraw behavior.
  * Vehicle markers are cleaned up reliably when routes are removed from the map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->