### PR TITLE
Correct what the activeElement branches actually cover

### DIFF
--- a/src/components/favorites/FavoritesFloatingControl.svelte
+++ b/src/components/favorites/FavoritesFloatingControl.svelte
@@ -71,8 +71,15 @@
 			// The browser focuses a clicked element on mousedown, before this click
 			// reaches the window listener, so restoring focus here would yank the
 			// caret back out of whatever the user just clicked onto. Restore only
-			// when the click did not take focus itself: a click on the map leaves
-			// activeElement at <body>, and focus still inside the closing panel
+			// when the click did not take focus itself.
+			//
+			// The <body> branch is for genuinely non-focusable chrome. It does not
+			// cover the map: Leaflet's keyboard handler sets tabIndex on the map
+			// container and focuses it on mousedown, and initMap does not pass
+			// keyboard: false, so an OSM map click lands focus on the container.
+			// That skips the restore, which is what we want there anyway.
+			//
+			// The rootEl branch is separate: focus still inside the closing panel
 			// would be stranded when it unmounts.
 			const active = document.activeElement;
 			close({ restoreFocus: !active || active === document.body || rootEl.contains(active) });


### PR DESCRIPTION
Folding in the correction from the review on #605, comment only, no behaviour change.

The claim that a map click leaves `activeElement` at `<body>` is wrong on the default provider. I checked each step rather than taking it on faith:

- `.env.example:31` sets `PUBLIC_OBA_MAP_PROVIDER="osm"`
- `OpenStreetMapProvider.svelte.js:98` builds the map as `this.L.map(element, { zoomControl: false })`, so `keyboard` stays at Leaflet's default of `true`
- `leaflet/src/map/handler/Map.Keyboard.js:42-46` does `if (container.tabIndex <= 0) { container.tabIndex = '0'; }` and binds `mousedown` to `_onMouseDown`, which focuses the container
- `MapView.svelte:406` is `<div id="map" bind:this={mapElement}></div>`, no tabindex of its own

So an OSM map click puts focus on the map container, a focusable element outside `rootEl`, and `restoreFocus` is `false` there. That is the behaviour you want, focus follows what the user clicked, and the container is arrow-key pannable so nothing is stranded. Only the reason given was wrong.

The comment now describes the `<body>` branch as what it actually covers, non-focusable chrome such as the mobile in-flow area, and keeps the `rootEl` branch separate since that one is about focus stranded inside the closing panel.

`FavoritesFloatingControl.test.js` still passes, 9 of 9, and prettier is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified inline comments describing focus restoration behavior when closing the favorites panel, including interactions with the map and non-focusable interface areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->