### PR TITLE
i18n: bring all 24 locales to full key parity with en

### DIFF
--- a/src/locales/am.json
+++ b/src/locales/am.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "የጉዞ አይነቶች",
 		"show_steps": "ደረጃዎችን አሳይ",
 		"hide_steps": "ደረጃዎችን ደብቅ",
+		"options": "አማራጮች",
+		"trip_options": "የጉዞ አማራጮች",
+		"cancel": "ሰርዝ",
+		"done": "ጨርስ",
+		"reset_to_defaults": "ወደ ነባሪ መልስ",
+		"departure_time": "የመነሻ ጊዜ",
+		"departure_date": "የመነሻ ቀን",
+		"leave_now": "አሁን መነሳት",
+		"depart_at": "በዚህ ሰዓት መነሳት",
+		"arrive_by": "እስከዚህ ሰዓት መድረስ",
+		"wheelchair_accessible": "ለተሽከርካሪ ወንበር ተደራሽ",
+		"wheelchair_desc": "ለመንቀሳቀሻ መርጃ መሣሪያዎችና ለተሽከርካሪ ወንበሮች የሚስማሙ መንገዶችን ይፈልጉ",
+		"wheelchair": "ተሽከርካሪ ወንበር",
+		"route_optimization": "የመንገድ ምርጫ",
+		"fastest_trip": "ፈጣኑ ጉዞ",
+		"fewest_transfers": "አነስተኛ ዝውውር",
+		"stay_on_board": "በተሽከርካሪው ውስጥ ይቆዩ። ይህ ጉዞ እንደ መንገድ {route} ይቀጥላል።",
+		"walking_distance": "የእግር ጉዞ ርቀት",
+		"max_walking_distance": "ከፍተኛ የእግር ጉዞ ርቀት",
 		"distance_unit": "የርቀት መለኪያ",
 		"unit_auto": "በራስ-ሰር ይለዩ",
 		"unit_metric": "ሜትሪክ (ኪሜ፣ ሜ)",
-		"unit_imperial": "ኢምፔሪያል (ማይል፣ ጫማ)"
+		"unit_imperial": "ኢምፔሪያል (ማይል፣ ጫማ)",
+		"swap_locations": "የመነሻና የመድረሻ ቦታዎችን ቀያይር",
+		"error_code": "የስህተት ኮድ",
+		"remove_recent_trip": "የቅርብ ጊዜ ጉዞን አስወግድ",
+		"recent_trip": "ከ{from} ወደ {to} የቅርብ ጊዜ ጉዞን ተጠቀም",
+		"recent_searches": "የቅርብ ጊዜ ፍለጋዎች",
+		"recents": "የቅርብ ጊዜ ጉዞዎች",
+		"clear_all": "ሁሉንም አጥፋ",
+		"request_failed": "የጉዞ እቅድ አገልግሎትን ማግኘት አልተቻለም። እባክዎ እንደገና ይሞክሩ።",
+		"invalid_shared_link": "ይህ የተጋራው የጉዞ አገናኝ የተበላሸ ይመስላል። ጉዞውን እንደገና ለማቀድ ይሞክሩ።"
 	},
 	"tabs": {
 		"stops-and-stations": "ማቆሚያዎችና ጣቢያዎች",
 		"plan_trip": "ጉዞን አቅድ"
+	},
+	"favorites": {
+		"title": "ተወዳጆች",
+		"add": "ወደ ተወዳጆች አክል",
+		"remove": "ከተወዳጆች አስወግድ",
+		"clear_all": "ሁሉንም አጥፋ",
+		"open_panel": "ተወዳጆችን ክፈት",
+		"close_panel": "ተወዳጆችን ዝጋ",
+		"empty": "እስካሁን ምንም ተወዳጅ የለም። እዚህ ለማስቀመጥ በማቆሚያ ወይም በመንገድ ላይ ያለውን ኮከብ መታ ያድርጉ።",
+		"stop_code": "ኮድ",
+		"open_item": "ክፈት: {name}",
+		"remove_item": "ከተወዳጆች አስወግድ: {name}"
 	},
 	"search": {
 		"placeholder": "ቆሻሻዎችን፣ መንገዶችን እና ቦታዎችን ይፈልጉ",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "ለመገኘት የሚገባቸው መንገዶች",
 		"search_for_routes": "መንገዶችን ይፈልጉ...",
 		"no_routes_found": "ምንም መንገዶች አልተገኙም",
-		"all_routes": "ሁሉም መንገዶች"
+		"all_routes": "ሁሉም መንገዶች",
+		"clear": "አጥፋ",
+		"collapse": "ፍለጋን ሰብስብ"
+	},
+	"sheet": {
+		"close": "ዝጋ",
+		"resize_handle": "የፓነሉን መጠን ቀይር",
+		"snap_full": "ሙሉ ከፍታ",
+		"snap_half": "ግማሽ ከፍታ",
+		"snap_peek": "የተሰበሰበ"
+	},
+	"survey": {
+		"required_question": "የግዴታ ጥያቄ",
+		"required_answer": "ይህ ጥያቄ የግዴታ ነው።",
+		"expand": "ጥያቄውን አሳይ",
+		"collapse": "ጥያቄውን ደብቅ",
+		"dismiss": "የዳሰሳ ጥናቱን ዝጋ",
+		"submit": "አስገባ",
+		"next": "ቀጣይ",
+		"submit_failed": "መልስዎን መላክ አልተቻለም። እባክዎ እንደገና ይሞክሩ።"
 	},
 	"header": {
 		"home": "ቤት",
@@ -88,13 +147,26 @@
 		"close": "ዝጋ"
 	},
 	"arrivals_and_departures": "መግቢያዎችና መውጫዎች",
+	"show_more": "ተጨማሪ አሳይ",
+	"show_less": "ያነሰ አሳይ",
 	"load_more_arrivals": "ተጨማሪ መድረሻዎችን ጫን",
+	"refresh": "አድስ",
 	"no_arrivals_found_in_next_minutes": "በሚቀጥሉት {minutes} ደቂቃዎች ውስጥ ምንም መድረሻ አልተገኘም",
 	"no_more_arrivals_in_next_minutes": "በሚቀጥሉት {minutes} ደቂቃዎች ውስጥ ምንም ተጨማሪ መድረሻ የለም",
 	"stop": "ቆሻሻ",
+	"direction_bound": "ወደ {direction} አቅጣጫ",
 	"routes": "መንገዶች",
 	"route": "መንገድ",
 	"route_modal_title": "መስመር {name}",
+	"notifications": {
+		"route_load_failed": "ይህን መንገድ መጫን አልተቻለም።",
+		"route_shape_failed": "ይህን መንገድ በካርታው ላይ መሳል አልተቻለም።",
+		"route_shape_partial": "የዚህ መንገድ ከፊሉ ሊሳል አልቻለም። ካርታው አንድ ክፍል ሊጎድለው ይችላል።",
+		"favorite_saved": "ወደ ተወዳጆች ተቀምጧል።",
+		"favorite_removed": "ከተወዳጆች ተወግዷል።",
+		"tap_to_retry": "እንደገና ለመሞከር መታ ያድርጉ።",
+		"dismiss": "ዝጋ"
+	},
 	"loading": "በመጫን ላይ",
 	"arrives": "ይደርሳል",
 	"NA": "አቅርኛ",
@@ -105,13 +177,16 @@
 		"secs": "secs",
 		"min": "min",
 		"mins": "mins",
-		"minutes": "minutes"
+		"minutes": "minutes",
+		"min_compact": "{n} ደቂቃ"
 	},
 	"vehicle": {
 		"number": "ተሽከርካሪ #",
 		"data_updated": "የተሻሻለ ውሂብ",
 		"no_real_time_data": "ለዚህ ተሽከርካሪ በእሁድኛ ጊዜ ውሂብ አናስተውላም።",
-		"next_stop": "ቀጣይ ማቆሚያ:"
+		"next_stop": "ቀጣይ ማቆሚያ:",
+		"label": "ተሽከርካሪ",
+		"to_headsign": "ወደ {headsign} የሚሄድ ተሽከርካሪ"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "መድረሻዎች እና ማቆሚያዎች"
@@ -150,18 +225,61 @@
 		"no_description": "ለዚህ ማስጠንቀቂያ ዝርዝር መግለጫ የለም",
 		"page": "ገፅ",
 		"show": "አሳይ",
-		"hide": "ደብቅ"
+		"hide": "ደብቅ",
+		"open_alert": "አገልግሎት ማስጠንቀቂያ ዝርዝሮችን ክፈት ({severity}): {summary}",
+		"affects_this_stop": "ይህን ማቆሚያ ይነካል",
+		"other_alerts": "ሌሎች ማስጠንቀቂያዎች",
+		"severity_severe": "ከባድ",
+		"severity_warning": "ማስጠንቀቂያ",
+		"severity_info": "መረጃ",
+		"cause": "ምክንያት",
+		"effect": "ተጽዕኖ",
+		"active": "ንቁ",
+		"active_until": "እስከ {date}",
+		"active_from": "ከ{date} ጀምሮ",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "ያልታወቀ",
+		"cause_other": "ሌላ",
+		"cause_technical": "ቴክኒካዊ ችግር",
+		"cause_strike": "የሥራ ማቆም አድማ",
+		"cause_demonstration": "ሰላማዊ ሰልፍ",
+		"cause_accident": "አደጋ",
+		"cause_holiday": "በዓል",
+		"cause_weather": "የአየር ሁኔታ",
+		"cause_maintenance": "ጥገና",
+		"cause_construction": "ግንባታ",
+		"cause_police": "የፖሊስ እንቅስቃሴ",
+		"cause_medical": "የሕክምና ድንገተኛ አደጋ",
+		"cause_equipment": "የመሣሪያ ችግር",
+		"cause_environment": "የአካባቢ ሁኔታ",
+		"cause_personnel": "የሰው ኃይል ችግር",
+		"cause_miscellaneous": "ልዩ ልዩ",
+		"cause_security": "የደህንነት ማስጠንቀቂያ",
+		"effect_no_service": "አገልግሎት የለም",
+		"effect_reduced_service": "የተቀነሰ አገልግሎት",
+		"effect_significant_delays": "ከፍተኛ መዘግየት",
+		"effect_detour": "የመንገድ ማዞሪያ",
+		"effect_additional_service": "ተጨማሪ አገልግሎት",
+		"effect_modified_service": "የተለወጠ አገልግሎት",
+		"effect_other": "ሌላ ተጽዕኖ",
+		"effect_unknown": "ያልታወቀ ተጽዕኖ",
+		"effect_stop_moved": "ማቆሚያ ተዛውሯል",
+		"effect_no_effect": "ተጽዕኖ የለም",
+		"effect_accessibility": "የተደራሽነት ችግር"
 	},
 	"view_stop_information": "የማቆሚያ መረጃ ይመልከቱ",
 	"stop_details": {
-		"view_details": "ዝርዝሮችን ይመልከቱ"
+		"view_details": "ዝርዝሮችን ይመልከቱ",
+		"stop_info": "የማቆሚያ መረጃ"
 	},
 	"language_switcher": {
 		"select_language": "ቋንቋ ይምረጡ: {language}",
 		"available_languages": "የሚገኙ ቋንቋዎች"
 	},
 	"map": {
-		"find_my_location": "ቦታዬን ፈልግ"
+		"find_my_location": "ቦታዬን ፈልግ",
+		"routes_shown": "የሚታዩ መንገዶች",
+		"live_vehicle_count": "{count} በቀጥታ"
 	},
 	"context-menu": {
 		"start_here": "ከዚህ ጀምር",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "ወደ መነሻ ይሂዱ",
 		"go_back": "ወደ ኋላ ይመለሱ"
+	},
+	"trip_details": {
+		"route": "መንገድ",
+		"no_stops": "ለዚህ ጉዞ ምንም የማቆሚያ ሰዓቶች የሉም።",
+		"loading": "የጉዞ ዝርዝሮች በመጫን ላይ...",
+		"live_vehicle": "በቀጥታ · ተሽከርካሪ {vehicleId}",
+		"collapsed_stops": "{count, plural, one {# ማቆሚያ} other {# ማቆሚያዎች}}"
 	},
 	"skip_to_main_content": "ወደ ዋና ይዘቱ ዝለል"
 }

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "مسارات الرحلة",
 		"show_steps": "عرض الخطوات",
 		"hide_steps": "إخفاء الخطوات",
+		"options": "خيارات",
+		"trip_options": "خيارات الرحلة",
+		"cancel": "إلغاء",
+		"done": "تم",
+		"reset_to_defaults": "استعادة الإعدادات الافتراضية",
+		"departure_time": "وقت المغادرة",
+		"departure_date": "تاريخ المغادرة",
+		"leave_now": "المغادرة الآن",
+		"depart_at": "المغادرة في",
+		"arrive_by": "الوصول بحلول",
+		"wheelchair_accessible": "مناسب للكراسي المتحركة",
+		"wheelchair_desc": "البحث عن مسارات مناسبة لأجهزة التنقّل والكراسي المتحركة",
+		"wheelchair": "كرسي متحرك",
+		"route_optimization": "تحسين المسار",
+		"fastest_trip": "أسرع رحلة",
+		"fewest_transfers": "أقل عدد تبديلات",
+		"stay_on_board": "ابقَ على متن المركبة. تستمر هذه الرحلة كالمسار {route}.",
+		"walking_distance": "مسافة المشي",
+		"max_walking_distance": "أقصى مسافة مشي",
 		"distance_unit": "وحدة المسافة",
 		"unit_auto": "اكتشاف تلقائي",
 		"unit_metric": "متري (كم، م)",
-		"unit_imperial": "إمبراطوري (mi, ft)"
+		"unit_imperial": "إمبراطوري (mi, ft)",
+		"swap_locations": "تبديل موقعي «من» و«إلى»",
+		"error_code": "رمز الخطأ",
+		"remove_recent_trip": "إزالة الرحلة الأخيرة",
+		"recent_trip": "استخدام الرحلة الأخيرة من {from} إلى {to}",
+		"recent_searches": "عمليات البحث الأخيرة",
+		"recents": "الأخيرة",
+		"clear_all": "مسح الكل",
+		"request_failed": "تعذّر الوصول إلى خدمة تخطيط الرحلات. يرجى المحاولة مرة أخرى.",
+		"invalid_shared_link": "يبدو أن رابط الرحلة المشترَك غير صالح. حاول تخطيط الرحلة مرة أخرى."
 	},
 	"tabs": {
 		"stops-and-stations": "المحطات والمواقف",
 		"plan_trip": "خطط لرحلة"
+	},
+	"favorites": {
+		"title": "المفضلة",
+		"add": "إضافة إلى المفضلة",
+		"remove": "إزالة من المفضلة",
+		"clear_all": "مسح الكل",
+		"open_panel": "فتح المفضلة",
+		"close_panel": "إغلاق المفضلة",
+		"empty": "لا توجد عناصر مفضلة بعد. اضغط على النجمة في أي محطة أو مسار لحفظه هنا.",
+		"stop_code": "الرمز",
+		"open_item": "فتح {name}",
+		"remove_item": "إزالة {name} من المفضلة"
 	},
 	"search": {
 		"placeholder": "ابحث عن المحطات، المسارات، والأماكن",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "لقائمة المسارات المتاحة",
 		"search_for_routes": "ابحث عن المسارات...",
 		"no_routes_found": "لم يتم العثور على مسارات",
-		"all_routes": "جميع المسارات"
+		"all_routes": "جميع المسارات",
+		"clear": "مسح",
+		"collapse": "طي البحث"
+	},
+	"sheet": {
+		"close": "إغلاق",
+		"resize_handle": "تغيير حجم اللوحة",
+		"snap_full": "ارتفاع كامل",
+		"snap_half": "نصف الارتفاع",
+		"snap_peek": "مطوي"
+	},
+	"survey": {
+		"required_question": "سؤال مطلوب",
+		"required_answer": "هذا السؤال مطلوب.",
+		"expand": "عرض السؤال",
+		"collapse": "إخفاء السؤال",
+		"dismiss": "تجاهل الاستطلاع",
+		"submit": "إرسال",
+		"next": "التالي",
+		"submit_failed": "تعذّر إرسال إجابتك. يرجى المحاولة مرة أخرى."
 	},
 	"header": {
 		"home": "الرئيسية",
@@ -88,13 +147,26 @@
 		"close": "إغلاق"
 	},
 	"arrivals_and_departures": "الوصول والمغادرة",
+	"show_more": "عرض المزيد",
+	"show_less": "عرض أقل",
 	"load_more_arrivals": "تحميل المزيد من الوصولات",
+	"refresh": "تحديث",
 	"no_arrivals_found_in_next_minutes": "لا توجد وصولات في الدقائق {minutes} القادمة",
 	"no_more_arrivals_in_next_minutes": "لا يوجد المزيد من الوصولات في الدقائق {minutes} القادمة",
 	"stop": "المحطة",
+	"direction_bound": "باتجاه {direction}",
 	"routes": "المسارات",
 	"route": "المسار",
 	"route_modal_title": "مسار {name}",
+	"notifications": {
+		"route_load_failed": "تعذّر تحميل هذا المسار.",
+		"route_shape_failed": "تعذّر رسم هذا المسار على الخريطة.",
+		"route_shape_partial": "تعذّر رسم جزء من هذا المسار. قد يكون هناك مقطع ناقص على الخريطة.",
+		"favorite_saved": "تم الحفظ في المفضلة.",
+		"favorite_removed": "تمت الإزالة من المفضلة.",
+		"tap_to_retry": "اضغط لإعادة المحاولة.",
+		"dismiss": "تجاهل"
+	},
 	"loading": "جاري التحميل",
 	"arrives": "يصل",
 	"NA": "غير متاح",
@@ -105,13 +177,16 @@
 		"secs": "secs",
 		"min": "min",
 		"mins": "mins",
-		"minutes": "minutes"
+		"minutes": "minutes",
+		"min_compact": "{n} د"
 	},
 	"vehicle": {
 		"number": "رقم المركبة",
 		"data_updated": "تم تحديث البيانات",
 		"no_real_time_data": "لا توجد بيانات في الوقت الحقيقي لهذه المركبة الآن.",
-		"next_stop": "المحطة التالية:"
+		"next_stop": "المحطة التالية:",
+		"label": "المركبة",
+		"to_headsign": "مركبة متجهة إلى {headsign}"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "الوصول والمغادرة"
@@ -150,18 +225,61 @@
 		"no_description": "لا يوجد وصف تفصيلي متاح لهذا التنبيه",
 		"page": "صفحة",
 		"show": "عرض",
-		"hide": "إخفاء"
+		"hide": "إخفاء",
+		"open_alert": "فتح تفاصيل تنبيه الخدمة ({severity}): {summary}",
+		"affects_this_stop": "يؤثر على هذه المحطة",
+		"other_alerts": "تنبيهات أخرى",
+		"severity_severe": "خطير",
+		"severity_warning": "تحذير",
+		"severity_info": "معلومات",
+		"cause": "السبب",
+		"effect": "التأثير",
+		"active": "نشط",
+		"active_until": "حتى {date}",
+		"active_from": "من {date}",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "غير معروف",
+		"cause_other": "سبب آخر",
+		"cause_technical": "مشكلة فنية",
+		"cause_strike": "إضراب",
+		"cause_demonstration": "مظاهرة",
+		"cause_accident": "حادث",
+		"cause_holiday": "عطلة",
+		"cause_weather": "الطقس",
+		"cause_maintenance": "صيانة",
+		"cause_construction": "أعمال إنشائية",
+		"cause_police": "نشاط الشرطة",
+		"cause_medical": "حالة طوارئ طبية",
+		"cause_equipment": "المعدات",
+		"cause_environment": "البيئة",
+		"cause_personnel": "الطاقم",
+		"cause_miscellaneous": "متنوع",
+		"cause_security": "تنبيه أمني",
+		"effect_no_service": "لا توجد خدمة",
+		"effect_reduced_service": "خدمة مخفّضة",
+		"effect_significant_delays": "تأخيرات كبيرة",
+		"effect_detour": "تحويلة",
+		"effect_additional_service": "خدمة إضافية",
+		"effect_modified_service": "خدمة معدّلة",
+		"effect_other": "تأثير آخر",
+		"effect_unknown": "تأثير غير معروف",
+		"effect_stop_moved": "تم نقل المحطة",
+		"effect_no_effect": "لا يوجد تأثير",
+		"effect_accessibility": "مشكلة في إمكانية الوصول"
 	},
 	"view_stop_information": "عرض معلومات المحطة",
 	"stop_details": {
-		"view_details": "عرض التفاصيل"
+		"view_details": "عرض التفاصيل",
+		"stop_info": "معلومات المحطة"
 	},
 	"language_switcher": {
 		"select_language": "اختر اللغة: {language}",
 		"available_languages": "اللغات المتاحة"
 	},
 	"map": {
-		"find_my_location": "تحديد موقعي"
+		"find_my_location": "تحديد موقعي",
+		"routes_shown": "المسارات المعروضة",
+		"live_vehicle_count": "مباشر: {count}"
 	},
 	"context-menu": {
 		"start_here": "ابدأ من هنا",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "الذهاب للرئيسية",
 		"go_back": "العودة"
+	},
+	"trip_details": {
+		"route": "المسار",
+		"no_stops": "لا توجد أوقات محطات متاحة لهذه الرحلة.",
+		"loading": "جاري تحميل تفاصيل الرحلة...",
+		"live_vehicle": "مباشر · المركبة {vehicleId}",
+		"collapsed_stops": "{count, plural, zero {# محطة} one {# محطة} two {# محطتان} few {# محطات} many {# محطة} other {# محطة}}"
 	},
 	"skip_to_main_content": "انتقل إلى المحتوى الرئيسي"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "Itinerarios de viaje",
 		"show_steps": "Mostrar pasos",
 		"hide_steps": "Ocultar pasos",
+		"options": "Opciones",
+		"trip_options": "Opciones de viaje",
+		"cancel": "Cancelar",
+		"done": "Listo",
+		"reset_to_defaults": "Restablecer valores predeterminados",
+		"departure_time": "Hora de salida",
+		"departure_date": "Fecha de salida",
+		"leave_now": "Salir ahora",
+		"depart_at": "Salir a las",
+		"arrive_by": "Llegar antes de las",
+		"wheelchair_accessible": "Accesible en silla de ruedas",
+		"wheelchair_desc": "Encuentra rutas adecuadas para dispositivos de movilidad y sillas de ruedas",
+		"wheelchair": "Silla de ruedas",
+		"route_optimization": "Optimización de ruta",
+		"fastest_trip": "Viaje más rápido",
+		"fewest_transfers": "Menos transbordos",
+		"stay_on_board": "Permanece a bordo. Este viaje continúa como la ruta {route}.",
+		"walking_distance": "Distancia a pie",
+		"max_walking_distance": "Distancia máxima a pie",
 		"distance_unit": "Unidad de distancia",
 		"unit_auto": "Detectar automáticamente",
 		"unit_metric": "Métrico (km, m)",
-		"unit_imperial": "Imperial (mi, ft)"
+		"unit_imperial": "Imperial (mi, ft)",
+		"swap_locations": "Intercambiar origen y destino",
+		"error_code": "Código de error",
+		"remove_recent_trip": "Eliminar viaje reciente",
+		"recent_trip": "Usar el viaje reciente de {from} a {to}",
+		"recent_searches": "Búsquedas recientes",
+		"recents": "Recientes",
+		"clear_all": "Borrar todo",
+		"request_failed": "No pudimos conectar con el servicio de planificación de viajes. Inténtalo de nuevo.",
+		"invalid_shared_link": "Este enlace de viaje compartido parece estar dañado. Intenta planificar el viaje de nuevo."
 	},
 	"tabs": {
 		"stops-and-stations": "Paradas y estaciones",
 		"plan_trip": "Planificar un viaje"
+	},
+	"favorites": {
+		"title": "Favoritos",
+		"add": "Agregar a favoritos",
+		"remove": "Quitar de favoritos",
+		"clear_all": "Borrar todo",
+		"open_panel": "Abrir favoritos",
+		"close_panel": "Cerrar favoritos",
+		"empty": "Aún no tienes favoritos. Toca la estrella de una parada o ruta para guardarla aquí.",
+		"stop_code": "Código",
+		"open_item": "Abrir {name}",
+		"remove_item": "Quitar {name} de favoritos"
 	},
 	"search": {
 		"placeholder": "Buscar paradas, rutas y lugares",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "para una lista de rutas disponibles",
 		"search_for_routes": "Buscar rutas...",
 		"no_routes_found": "No se encontraron rutas",
-		"all_routes": "Todas las rutas"
+		"all_routes": "Todas las rutas",
+		"clear": "Borrar",
+		"collapse": "Contraer búsqueda"
+	},
+	"sheet": {
+		"close": "Cerrar",
+		"resize_handle": "Cambiar el tamaño del panel",
+		"snap_full": "Altura completa",
+		"snap_half": "Media altura",
+		"snap_peek": "Contraído"
+	},
+	"survey": {
+		"required_question": "Pregunta obligatoria",
+		"required_answer": "Esta pregunta es obligatoria.",
+		"expand": "Mostrar pregunta",
+		"collapse": "Ocultar pregunta",
+		"dismiss": "Descartar encuesta",
+		"submit": "Enviar",
+		"next": "Siguiente",
+		"submit_failed": "No se pudo enviar tu respuesta. Inténtalo de nuevo."
 	},
 	"header": {
 		"home": "Inicio",
@@ -88,13 +147,26 @@
 		"close": "Cerrar"
 	},
 	"arrivals_and_departures": "Llegadas y salidas",
+	"show_more": "Mostrar más",
+	"show_less": "Mostrar menos",
 	"load_more_arrivals": "Cargar más llegadas",
+	"refresh": "Actualizar",
 	"no_arrivals_found_in_next_minutes": "No se encontraron llegadas en los próximos {minutes} minutos",
 	"no_more_arrivals_in_next_minutes": "No hay más llegadas en los próximos {minutes} minutos",
 	"stop": "Parada",
+	"direction_bound": "Dirección {direction}",
 	"routes": "Rutas",
 	"route": "Ruta",
 	"route_modal_title": "Ruta {name}",
+	"notifications": {
+		"route_load_failed": "No se pudo cargar esta ruta.",
+		"route_shape_failed": "No se pudo dibujar esta ruta en el mapa.",
+		"route_shape_partial": "No se pudo dibujar una parte de esta ruta. Es posible que falte un tramo en el mapa.",
+		"favorite_saved": "Se guardó en favoritos.",
+		"favorite_removed": "Se quitó de favoritos.",
+		"tap_to_retry": "Toca para reintentar.",
+		"dismiss": "Descartar"
+	},
 	"loading": "Cargando",
 	"arrives": "llega",
 	"NA": "N/D",
@@ -105,13 +177,16 @@
 		"secs": "segs",
 		"min": "min",
 		"mins": "mins",
-		"minutes": "minutos"
+		"minutes": "minutos",
+		"min_compact": "{n} min"
 	},
 	"vehicle": {
 		"number": "Vehículo #",
 		"data_updated": "Datos actualizados",
 		"no_real_time_data": "Actualmente no tenemos datos en tiempo real para este vehículo.",
-		"next_stop": "Próxima parada:"
+		"next_stop": "Próxima parada:",
+		"label": "Vehículo",
+		"to_headsign": "Vehículo hacia {headsign}"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "Llegadas y Salidas"
@@ -150,14 +225,61 @@
 		"no_description": "No hay descripción detallada disponible para esta alerta",
 		"page": "Página",
 		"show": "Mostrar",
-		"hide": "Ocultar"
+		"hide": "Ocultar",
+		"open_alert": "Abrir los detalles de la alerta de servicio ({severity}): {summary}",
+		"affects_this_stop": "Afecta a esta parada",
+		"other_alerts": "Otras alertas",
+		"severity_severe": "Grave",
+		"severity_warning": "Advertencia",
+		"severity_info": "Info",
+		"cause": "Causa",
+		"effect": "Efecto",
+		"active": "Vigencia",
+		"active_until": "Hasta {date}",
+		"active_from": "Desde {date}",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "Desconocida",
+		"cause_other": "Otra",
+		"cause_technical": "Problema técnico",
+		"cause_strike": "Huelga",
+		"cause_demonstration": "Manifestación",
+		"cause_accident": "Accidente",
+		"cause_holiday": "Día festivo",
+		"cause_weather": "Clima",
+		"cause_maintenance": "Mantenimiento",
+		"cause_construction": "Obras",
+		"cause_police": "Actividad policial",
+		"cause_medical": "Emergencia médica",
+		"cause_equipment": "Problema de equipamiento",
+		"cause_environment": "Condiciones ambientales",
+		"cause_personnel": "Personal",
+		"cause_miscellaneous": "Varios",
+		"cause_security": "Alerta de seguridad",
+		"effect_no_service": "Sin servicio",
+		"effect_reduced_service": "Servicio reducido",
+		"effect_significant_delays": "Retrasos importantes",
+		"effect_detour": "Desvío",
+		"effect_additional_service": "Servicio adicional",
+		"effect_modified_service": "Servicio modificado",
+		"effect_other": "Otro efecto",
+		"effect_unknown": "Efecto desconocido",
+		"effect_stop_moved": "Parada trasladada",
+		"effect_no_effect": "Sin efecto",
+		"effect_accessibility": "Problema de accesibilidad"
+	},
+	"view_stop_information": "Ver información de la parada",
+	"stop_details": {
+		"view_details": "Ver detalles",
+		"stop_info": "Info de la parada"
 	},
 	"language_switcher": {
 		"select_language": "Seleccionar idioma: {language}",
 		"available_languages": "Idiomas disponibles"
 	},
 	"map": {
-		"find_my_location": "Encontrar mi ubicación"
+		"find_my_location": "Encontrar mi ubicación",
+		"routes_shown": "Rutas mostradas",
+		"live_vehicle_count": "{count} en vivo"
 	},
 	"context-menu": {
 		"start_here": "Comenzar aquí",
@@ -182,6 +304,13 @@
 		},
 		"go_home": "Ir al inicio",
 		"go_back": "Volver"
+	},
+	"trip_details": {
+		"route": "Ruta",
+		"no_stops": "No hay horarios de parada disponibles para este viaje.",
+		"loading": "Cargando detalles del viaje...",
+		"live_vehicle": "En vivo · vehículo {vehicleId}",
+		"collapsed_stops": "{count, plural, one {# parada} other {# paradas}}"
 	},
 	"skip_to_main_content": "Saltar al contenido principal"
 }

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "مسیرهای سفر",
 		"show_steps": "نمایش مراحل",
 		"hide_steps": "پنهان کردن مراحل",
+		"options": "گزینه‌ها",
+		"trip_options": "گزینه‌های سفر",
+		"cancel": "انصراف",
+		"done": "تمام",
+		"reset_to_defaults": "بازنشانی به پیش‌فرض‌ها",
+		"departure_time": "زمان حرکت",
+		"departure_date": "تاریخ حرکت",
+		"leave_now": "حرکت هم‌اکنون",
+		"depart_at": "حرکت در ساعت",
+		"arrive_by": "رسیدن تا ساعت",
+		"wheelchair_accessible": "مناسب ویلچر",
+		"wheelchair_desc": "یافتن مسیرهای مناسب برای ویلچر و وسایل کمک‌حرکتی",
+		"wheelchair": "ویلچر",
+		"route_optimization": "بهینه‌سازی مسیر",
+		"fastest_trip": "سریع‌ترین سفر",
+		"fewest_transfers": "کمترین تعویض خط",
+		"stay_on_board": "در وسیله نقلیه بمانید. این سفر به‌عنوان خط {route} ادامه می‌یابد.",
+		"walking_distance": "مسافت پیاده‌روی",
+		"max_walking_distance": "حداکثر مسافت پیاده‌روی",
 		"distance_unit": "واحد مسافت",
 		"unit_auto": "تشخیص خودکار",
 		"unit_metric": "متریک (کم، م)",
-		"unit_imperial": "امپراطوری (mi, ft)"
+		"unit_imperial": "امپراطوری (mi, ft)",
+		"swap_locations": "جابه‌جا کردن مبدأ و مقصد",
+		"error_code": "کد خطا",
+		"remove_recent_trip": "حذف سفر اخیر",
+		"recent_trip": "استفاده از سفر اخیر از {from} به {to}",
+		"recent_searches": "جستجوهای اخیر",
+		"recents": "موارد اخیر",
+		"clear_all": "پاک کردن همه",
+		"request_failed": "دسترسی به سرویس برنامه‌ریزی سفر ممکن نشد. لطفاً دوباره تلاش کنید.",
+		"invalid_shared_link": "این پیوند اشتراکی سفر معتبر به نظر نمی‌رسد. لطفاً دوباره سفر را برنامه‌ریزی کنید."
 	},
 	"tabs": {
 		"stops-and-stations": "ایستگاه‌ها",
 		"plan_trip": "برنامه‌ریزی سفر"
+	},
+	"favorites": {
+		"title": "علاقه‌مندی‌ها",
+		"add": "افزودن به علاقه‌مندی‌ها",
+		"remove": "حذف از علاقه‌مندی‌ها",
+		"clear_all": "پاک کردن همه",
+		"open_panel": "باز کردن علاقه‌مندی‌ها",
+		"close_panel": "بستن علاقه‌مندی‌ها",
+		"empty": "هنوز موردی ذخیره نشده است. برای ذخیره یک ایستگاه یا خط، روی ستاره آن ضربه بزنید.",
+		"stop_code": "کد",
+		"open_item": "باز کردن {name}",
+		"remove_item": "حذف {name} از علاقه‌مندی‌ها"
 	},
 	"search": {
 		"placeholder": "جستجوی ایستگاه، خط و مکان",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "برای مشاهده لیست خطوط",
 		"search_for_routes": "جستجوی خطوط...",
 		"no_routes_found": "خطی یافت نشد",
-		"all_routes": "همه خطوط"
+		"all_routes": "همه خطوط",
+		"clear": "پاک کردن",
+		"collapse": "جمع کردن جستجو"
+	},
+	"sheet": {
+		"close": "بستن",
+		"resize_handle": "تغییر اندازه پنل",
+		"snap_full": "ارتفاع کامل",
+		"snap_half": "نصف ارتفاع",
+		"snap_peek": "جمع‌شده"
+	},
+	"survey": {
+		"required_question": "سؤال الزامی",
+		"required_answer": "پاسخ به این سؤال الزامی است.",
+		"expand": "نمایش سؤال",
+		"collapse": "پنهان کردن سؤال",
+		"dismiss": "بستن نظرسنجی",
+		"submit": "ارسال",
+		"next": "بعدی",
+		"submit_failed": "ارسال پاسخ شما ممکن نشد. لطفاً دوباره تلاش کنید."
 	},
 	"header": {
 		"home": "خانه",
@@ -88,13 +147,26 @@
 		"close": "بستن"
 	},
 	"arrivals_and_departures": "ورود و خروج",
+	"show_more": "نمایش بیشتر",
+	"show_less": "نمایش کمتر",
 	"load_more_arrivals": "بارگذاری ورودی‌های بیشتر",
+	"refresh": "به‌روزرسانی",
 	"no_arrivals_found_in_next_minutes": "هیچ ورودی در {minutes} دقیقه آینده یافت نشد",
 	"no_more_arrivals_in_next_minutes": "هیچ ورودی بیشتری در {minutes} دقیقه آینده وجود ندارد",
 	"stop": "ایستگاه",
+	"direction_bound": "به سمت {direction}",
 	"routes": "خطوط",
 	"route": "خط",
 	"route_modal_title": "خط {name}",
+	"notifications": {
+		"route_load_failed": "بارگذاری این خط ممکن نشد.",
+		"route_shape_failed": "ترسیم این خط روی نقشه ممکن نشد.",
+		"route_shape_partial": "بخشی از این خط ترسیم نشد. ممکن است قسمتی از مسیر روی نقشه نمایش داده نشود.",
+		"favorite_saved": "در علاقه‌مندی‌ها ذخیره شد.",
+		"favorite_removed": "از علاقه‌مندی‌ها حذف شد.",
+		"tap_to_retry": "برای تلاش دوباره ضربه بزنید.",
+		"dismiss": "بستن"
+	},
 	"loading": "در حال بارگذاری",
 	"arrives": "می‌رسد",
 	"NA": "نامشخص",
@@ -105,13 +177,16 @@
 		"secs": "ثانیه",
 		"min": "دقیقه",
 		"mins": "دقیقه",
-		"minutes": "دقیقه"
+		"minutes": "دقیقه",
+		"min_compact": "{n} دقیقه"
 	},
 	"vehicle": {
 		"number": "شماره وسیله نقلیه",
 		"data_updated": "آخرین به‌روزرسانی",
 		"no_real_time_data": "اطلاعات لحظه‌ای برای این وسیله نقلیه در دسترس نیست.",
-		"next_stop": "ایستگاه بعدی:"
+		"next_stop": "ایستگاه بعدی:",
+		"label": "وسیله نقلیه",
+		"to_headsign": "وسیله نقلیه به مقصد {headsign}"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "ورود و خروج"
@@ -150,18 +225,61 @@
 		"no_description": "توضیحات تکمیلی برای این اطلاعیه موجود نیست",
 		"page": "صفحه",
 		"show": "نمایش",
-		"hide": "پنهان"
+		"hide": "پنهان",
+		"open_alert": "باز کردن جزئیات اطلاعیه خدمات ({severity}): {summary}",
+		"affects_this_stop": "مربوط به این ایستگاه",
+		"other_alerts": "سایر اطلاعیه‌ها",
+		"severity_severe": "شدید",
+		"severity_warning": "هشدار",
+		"severity_info": "اطلاع‌رسانی",
+		"cause": "علت",
+		"effect": "تأثیر",
+		"active": "فعال",
+		"active_until": "تا {date}",
+		"active_from": "از {date}",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "نامشخص",
+		"cause_other": "سایر",
+		"cause_technical": "مشکل فنی",
+		"cause_strike": "اعتصاب",
+		"cause_demonstration": "تظاهرات",
+		"cause_accident": "تصادف",
+		"cause_holiday": "تعطیلات",
+		"cause_weather": "شرایط جوی",
+		"cause_maintenance": "تعمیر و نگهداری",
+		"cause_construction": "عملیات عمرانی",
+		"cause_police": "فعالیت پلیس",
+		"cause_medical": "اورژانس پزشکی",
+		"cause_equipment": "تجهیزات",
+		"cause_environment": "شرایط محیطی",
+		"cause_personnel": "مسائل پرسنلی",
+		"cause_miscellaneous": "متفرقه",
+		"cause_security": "هشدار امنیتی",
+		"effect_no_service": "بدون خدمات",
+		"effect_reduced_service": "کاهش خدمات",
+		"effect_significant_delays": "تأخیر قابل‌توجه",
+		"effect_detour": "مسیر انحرافی",
+		"effect_additional_service": "خدمات اضافی",
+		"effect_modified_service": "تغییر در خدمات",
+		"effect_other": "تأثیر دیگر",
+		"effect_unknown": "تأثیر نامشخص",
+		"effect_stop_moved": "جابه‌جایی ایستگاه",
+		"effect_no_effect": "بدون تأثیر",
+		"effect_accessibility": "مشکل دسترس‌پذیری"
 	},
 	"view_stop_information": "مشاهده اطلاعات ایستگاه",
 	"stop_details": {
-		"view_details": "مشاهده جزئیات"
+		"view_details": "مشاهده جزئیات",
+		"stop_info": "اطلاعات ایستگاه"
 	},
 	"language_switcher": {
 		"select_language": "انتخاب زبان: {language}",
 		"available_languages": "زبان‌های موجود"
 	},
 	"map": {
-		"find_my_location": "موقعیت من را پیدا کن"
+		"find_my_location": "موقعیت من را پیدا کن",
+		"routes_shown": "خطوط نمایش‌داده‌شده",
+		"live_vehicle_count": "{count} وسیله لحظه‌ای"
 	},
 	"context-menu": {
 		"start_here": "شروع از اینجا",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "رفتن به خانه",
 		"go_back": "بازگشت"
+	},
+	"trip_details": {
+		"route": "خط",
+		"no_stops": "زمان‌بندی ایستگاه‌ها برای این سفر موجود نیست.",
+		"loading": "در حال بارگذاری جزئیات سفر...",
+		"live_vehicle": "لحظه‌ای · وسیله نقلیه {vehicleId}",
+		"collapsed_stops": "{count, plural, one {# ایستگاه} other {# ایستگاه}}"
 	},
 	"skip_to_main_content": "رفتن به محتوای اصلی"
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "Itinéraires de trajet",
 		"show_steps": "Afficher les étapes",
 		"hide_steps": "Masquer les étapes",
+		"options": "Options",
+		"trip_options": "Options du trajet",
+		"cancel": "Annuler",
+		"done": "Terminé",
+		"reset_to_defaults": "Rétablir les valeurs par défaut",
+		"departure_time": "Heure de départ",
+		"departure_date": "Date de départ",
+		"leave_now": "Partir maintenant",
+		"depart_at": "Partir à",
+		"arrive_by": "Arriver avant",
+		"wheelchair_accessible": "Accessible en fauteuil roulant",
+		"wheelchair_desc": "Trouver des itinéraires adaptés aux aides à la mobilité et aux fauteuils roulants",
+		"wheelchair": "Fauteuil roulant",
+		"route_optimization": "Optimisation de l'itinéraire",
+		"fastest_trip": "Trajet le plus rapide",
+		"fewest_transfers": "Moins de correspondances",
+		"stay_on_board": "Restez à bord. Ce trajet se poursuit sur la ligne {route}.",
+		"walking_distance": "Distance de marche",
+		"max_walking_distance": "Distance de marche maximale",
 		"distance_unit": "Unité de distance",
 		"unit_auto": "Détection automatique",
 		"unit_metric": "Métrique (km, m)",
-		"unit_imperial": "Impérial (mi, ft)"
+		"unit_imperial": "Impérial (mi, ft)",
+		"swap_locations": "Intervertir les points de départ et d'arrivée",
+		"error_code": "Code d'erreur",
+		"remove_recent_trip": "Supprimer le trajet récent",
+		"recent_trip": "Utiliser le trajet récent de {from} à {to}",
+		"recent_searches": "Recherches récentes",
+		"recents": "Récents",
+		"clear_all": "Tout effacer",
+		"request_failed": "Impossible de contacter le service de planification de trajets. Veuillez réessayer.",
+		"invalid_shared_link": "Ce lien de trajet partagé semble invalide. Essayez de planifier à nouveau le trajet."
 	},
 	"tabs": {
 		"stops-and-stations": "Arrêts et stations",
 		"plan_trip": "Planifier un trajet"
+	},
+	"favorites": {
+		"title": "Favoris",
+		"add": "Ajouter aux favoris",
+		"remove": "Retirer des favoris",
+		"clear_all": "Tout effacer",
+		"open_panel": "Ouvrir les favoris",
+		"close_panel": "Fermer les favoris",
+		"empty": "Aucun favori pour le moment. Appuyez sur l'étoile d'un arrêt ou d'une ligne pour l'enregistrer ici.",
+		"stop_code": "Code",
+		"open_item": "Ouvrir {name}",
+		"remove_item": "Retirer {name} des favoris"
 	},
 	"search": {
 		"placeholder": "Rechercher des arrêts, lignes et lieux",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "pour la liste des lignes disponibles",
 		"search_for_routes": "Rechercher des lignes...",
 		"no_routes_found": "Aucune ligne trouvée",
-		"all_routes": "Toutes les lignes"
+		"all_routes": "Toutes les lignes",
+		"clear": "Effacer",
+		"collapse": "Réduire la recherche"
+	},
+	"sheet": {
+		"close": "Fermer",
+		"resize_handle": "Redimensionner le panneau",
+		"snap_full": "Pleine hauteur",
+		"snap_half": "Demi-hauteur",
+		"snap_peek": "Réduit"
+	},
+	"survey": {
+		"required_question": "Question obligatoire",
+		"required_answer": "Cette question est obligatoire.",
+		"expand": "Afficher la question",
+		"collapse": "Masquer la question",
+		"dismiss": "Ignorer le sondage",
+		"submit": "Envoyer",
+		"next": "Suivant",
+		"submit_failed": "Impossible d'envoyer votre réponse. Veuillez réessayer."
 	},
 	"header": {
 		"home": "Accueil",
@@ -88,13 +147,26 @@
 		"close": "Fermer"
 	},
 	"arrivals_and_departures": "Arrivées et départs",
+	"show_more": "Afficher plus",
+	"show_less": "Afficher moins",
 	"load_more_arrivals": "Charger plus d'arrivées",
+	"refresh": "Actualiser",
 	"no_arrivals_found_in_next_minutes": "Aucune arrivée trouvée dans les {minutes} prochaines minutes",
 	"no_more_arrivals_in_next_minutes": "Aucune autre arrivée dans les {minutes} prochaines minutes",
 	"stop": "Arrêt",
+	"direction_bound": "direction {direction}",
 	"routes": "Lignes",
 	"route": "ligne",
 	"route_modal_title": "Ligne {name}",
+	"notifications": {
+		"route_load_failed": "Impossible de charger cette ligne.",
+		"route_shape_failed": "Impossible de tracer cette ligne sur la carte.",
+		"route_shape_partial": "Une partie de cette ligne n'a pas pu être tracée. Il manque peut-être un segment sur la carte.",
+		"favorite_saved": "Ajouté aux favoris.",
+		"favorite_removed": "Retiré des favoris.",
+		"tap_to_retry": "Appuyez pour réessayer.",
+		"dismiss": "Ignorer"
+	},
 	"loading": "Chargement",
 	"arrives": "arrive",
 	"NA": "N/D",
@@ -105,13 +177,16 @@
 		"secs": "sec",
 		"min": "min",
 		"mins": "min",
-		"minutes": "minutes"
+		"minutes": "minutes",
+		"min_compact": "{n} min"
 	},
 	"vehicle": {
 		"number": "Véhicule n°",
 		"data_updated": "Données mises à jour",
 		"no_real_time_data": "Nous n'avons pas de données en temps réel pour ce véhicule actuellement.",
-		"next_stop": "Prochain arrêt :"
+		"next_stop": "Prochain arrêt :",
+		"label": "Véhicule",
+		"to_headsign": "Véhicule vers {headsign}"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "Arrivées et départs"
@@ -150,18 +225,61 @@
 		"no_description": "Aucune description détaillée disponible pour cette alerte",
 		"page": "Page",
 		"show": "Afficher",
-		"hide": "Masquer"
+		"hide": "Masquer",
+		"open_alert": "Ouvrir les détails de l'alerte de service ({severity}) : {summary}",
+		"affects_this_stop": "Concerne cet arrêt",
+		"other_alerts": "Autres alertes",
+		"severity_severe": "Grave",
+		"severity_warning": "Avertissement",
+		"severity_info": "Info",
+		"cause": "Cause",
+		"effect": "Effet",
+		"active": "Validité",
+		"active_until": "Jusqu'au {date}",
+		"active_from": "À partir du {date}",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "Inconnue",
+		"cause_other": "Autre",
+		"cause_technical": "Problème technique",
+		"cause_strike": "Grève",
+		"cause_demonstration": "Manifestation",
+		"cause_accident": "Accident",
+		"cause_holiday": "Jour férié",
+		"cause_weather": "Météo",
+		"cause_maintenance": "Maintenance",
+		"cause_construction": "Travaux",
+		"cause_police": "Intervention policière",
+		"cause_medical": "Urgence médicale",
+		"cause_equipment": "Équipement",
+		"cause_environment": "Environnement",
+		"cause_personnel": "Personnel",
+		"cause_miscellaneous": "Divers",
+		"cause_security": "Alerte de sécurité",
+		"effect_no_service": "Aucun service",
+		"effect_reduced_service": "Service réduit",
+		"effect_significant_delays": "Retards importants",
+		"effect_detour": "Déviation",
+		"effect_additional_service": "Service supplémentaire",
+		"effect_modified_service": "Service modifié",
+		"effect_other": "Autre effet",
+		"effect_unknown": "Effet inconnu",
+		"effect_stop_moved": "Arrêt déplacé",
+		"effect_no_effect": "Aucun effet",
+		"effect_accessibility": "Problème d'accessibilité"
 	},
 	"view_stop_information": "Voir les informations de l'arrêt",
 	"stop_details": {
-		"view_details": "Voir les détails"
+		"view_details": "Voir les détails",
+		"stop_info": "Infos sur l'arrêt"
 	},
 	"language_switcher": {
 		"select_language": "Sélectionner la langue : {language}",
 		"available_languages": "Langues disponibles"
 	},
 	"map": {
-		"find_my_location": "Trouver ma position"
+		"find_my_location": "Trouver ma position",
+		"routes_shown": "Lignes affichées",
+		"live_vehicle_count": "{count} en temps réel"
 	},
 	"context-menu": {
 		"start_here": "Partir d'ici",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "Retour à l'accueil",
 		"go_back": "Retour"
+	},
+	"trip_details": {
+		"route": "Ligne",
+		"no_stops": "Aucun horaire d'arrêt disponible pour ce trajet.",
+		"loading": "Chargement des détails du trajet...",
+		"live_vehicle": "Temps réel · véhicule {vehicleId}",
+		"collapsed_stops": "{count, plural, one {# arrêt} other {# arrêts}}"
 	},
 	"skip_to_main_content": "Aller au contenu principal"
 }

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "यात्रा विकल्प",
 		"show_steps": "चरण दिखाएँ",
 		"hide_steps": "चरण छिपाएँ",
+		"options": "विकल्प",
+		"trip_options": "यात्रा विकल्प",
+		"cancel": "रद्द करें",
+		"done": "हो गया",
+		"reset_to_defaults": "डिफ़ॉल्ट पर रीसेट करें",
+		"departure_time": "प्रस्थान समय",
+		"departure_date": "प्रस्थान तिथि",
+		"leave_now": "अभी निकलें",
+		"depart_at": "इस समय निकलें",
+		"arrive_by": "इस समय तक पहुंचें",
+		"wheelchair_accessible": "व्हीलचेयर सुलभ",
+		"wheelchair_desc": "मोबिलिटी उपकरणों और व्हीलचेयर के लिए उपयुक्त मार्ग खोजें",
+		"wheelchair": "व्हीलचेयर",
+		"route_optimization": "मार्ग अनुकूलन",
+		"fastest_trip": "सबसे तेज़ यात्रा",
+		"fewest_transfers": "सबसे कम बदलाव",
+		"stay_on_board": "इसी वाहन में रहें। यह यात्रा मार्ग {route} के रूप में जारी रहेगी।",
+		"walking_distance": "पैदल दूरी",
+		"max_walking_distance": "अधिकतम पैदल दूरी",
 		"distance_unit": "दूरी की इकाई",
 		"unit_auto": "स्वतः पता लगाएं",
 		"unit_metric": "मीट्रिक (km, m)",
-		"unit_imperial": "इम्पिरियल (mi, ft)"
+		"unit_imperial": "इम्पिरियल (mi, ft)",
+		"swap_locations": "प्रारंभ और गंतव्य स्थान आपस में बदलें",
+		"error_code": "त्रुटि कोड",
+		"remove_recent_trip": "हाल की यात्रा हटाएं",
+		"recent_trip": "{from} से {to} तक की हाल की यात्रा उपयोग करें",
+		"recent_searches": "हाल की खोजें",
+		"recents": "हाल की यात्राएं",
+		"clear_all": "सभी साफ़ करें",
+		"request_failed": "हम यात्रा योजना सेवा तक नहीं पहुंच सके। कृपया पुनः प्रयास करें।",
+		"invalid_shared_link": "यह साझा यात्रा लिंक टूटा हुआ लगता है। कृपया यात्रा की योजना फिर से बनाएं।"
 	},
 	"tabs": {
 		"stops-and-stations": "स्टॉप और स्टेशन",
 		"plan_trip": "यात्रा की योजना बनाएं"
+	},
+	"favorites": {
+		"title": "पसंदीदा",
+		"add": "पसंदीदा में जोड़ें",
+		"remove": "पसंदीदा से हटाएं",
+		"clear_all": "सभी साफ़ करें",
+		"open_panel": "पसंदीदा खोलें",
+		"close_panel": "पसंदीदा बंद करें",
+		"empty": "अभी कोई पसंदीदा नहीं। किसी स्टॉप या मार्ग पर तारे को टैप करके उसे यहां सहेजें।",
+		"stop_code": "कोड",
+		"open_item": "{name} खोलें",
+		"remove_item": "{name} को पसंदीदा से हटाएं"
 	},
 	"search": {
 		"placeholder": "स्टॉप, मार्ग और स्थान खोजें",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "उपलब्ध मार्गों की सूची के लिए",
 		"search_for_routes": "मार्ग खोजें...",
 		"no_routes_found": "कोई मार्ग नहीं मिला",
-		"all_routes": "सभी मार्ग"
+		"all_routes": "सभी मार्ग",
+		"clear": "साफ़ करें",
+		"collapse": "खोज छिपाएं"
+	},
+	"sheet": {
+		"close": "बंद करें",
+		"resize_handle": "पैनल का आकार बदलें",
+		"snap_full": "पूरी ऊंचाई",
+		"snap_half": "आधी ऊंचाई",
+		"snap_peek": "न्यूनतम ऊंचाई"
+	},
+	"survey": {
+		"required_question": "आवश्यक प्रश्न",
+		"required_answer": "इस प्रश्न का उत्तर देना आवश्यक है।",
+		"expand": "प्रश्न दिखाएं",
+		"collapse": "प्रश्न छिपाएं",
+		"dismiss": "सर्वेक्षण खारिज करें",
+		"submit": "सबमिट करें",
+		"next": "आगे",
+		"submit_failed": "आपका उत्तर नहीं भेजा जा सका। कृपया पुनः प्रयास करें।"
 	},
 	"header": {
 		"home": "होम",
@@ -88,13 +147,26 @@
 		"close": "बंद करें"
 	},
 	"arrivals_and_departures": "आगमन और प्रस्थान",
+	"show_more": "और दिखाएं",
+	"show_less": "कम दिखाएं",
 	"load_more_arrivals": "और आगमन लोड करें",
+	"refresh": "रीफ़्रेश करें",
 	"no_arrivals_found_in_next_minutes": "अगले {minutes} मिनट में कोई आगमन नहीं मिला",
 	"no_more_arrivals_in_next_minutes": "अगले {minutes} मिनट में कोई और आगमन नहीं",
 	"stop": "स्टॉप",
+	"direction_bound": "{direction} की ओर",
 	"routes": "मार्ग",
 	"route": "मार्ग",
 	"route_modal_title": "मार्ग {name}",
+	"notifications": {
+		"route_load_failed": "यह मार्ग लोड नहीं हो सका।",
+		"route_shape_failed": "इस मार्ग को मानचित्र पर नहीं दिखाया जा सका।",
+		"route_shape_partial": "इस मार्ग का कुछ हिस्सा नहीं दिखाया जा सका। मानचित्र में कोई खंड गायब हो सकता है।",
+		"favorite_saved": "पसंदीदा में सहेजा गया।",
+		"favorite_removed": "पसंदीदा से हटाया गया।",
+		"tap_to_retry": "पुनः प्रयास के लिए टैप करें।",
+		"dismiss": "खारिज करें"
+	},
 	"loading": "लोड हो रहा है",
 	"arrives": "पहुंचेगा",
 	"NA": "उपलब्ध नहीं",
@@ -105,13 +177,16 @@
 		"secs": "सेकंड",
 		"min": "मिनट",
 		"mins": "मिनट",
-		"minutes": "मिनट"
+		"minutes": "मिनट",
+		"min_compact": "{n} मिनट"
 	},
 	"vehicle": {
 		"number": "वाहन #",
 		"data_updated": "डेटा अपडेट किया गया",
 		"no_real_time_data": "इस वाहन के लिए वास्तविक समय डेटा उपलब्ध नहीं है।",
-		"next_stop": "अगला स्टॉप:"
+		"next_stop": "अगला स्टॉप:",
+		"label": "वाहन",
+		"to_headsign": "{headsign} की ओर जाने वाला वाहन"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "आगमन और प्रस्थान"
@@ -150,18 +225,61 @@
 		"no_description": "इस सूचना के लिए कोई विस्तृत विवरण उपलब्ध नहीं",
 		"page": "पृष्ठ",
 		"show": "दिखाएं",
-		"hide": "छुपाएं"
+		"hide": "छुपाएं",
+		"open_alert": "सेवा सूचना ({severity}) का विवरण खोलें: {summary}",
+		"affects_this_stop": "इस स्टॉप पर प्रभाव",
+		"other_alerts": "अन्य सूचनाएं",
+		"severity_severe": "गंभीर",
+		"severity_warning": "चेतावनी",
+		"severity_info": "जानकारी",
+		"cause": "कारण",
+		"effect": "प्रभाव",
+		"active": "सक्रिय",
+		"active_until": "{date} तक",
+		"active_from": "{date} से",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "अज्ञात",
+		"cause_other": "अन्य",
+		"cause_technical": "तकनीकी समस्या",
+		"cause_strike": "हड़ताल",
+		"cause_demonstration": "प्रदर्शन",
+		"cause_accident": "दुर्घटना",
+		"cause_holiday": "अवकाश",
+		"cause_weather": "मौसम",
+		"cause_maintenance": "रखरखाव",
+		"cause_construction": "निर्माण कार्य",
+		"cause_police": "पुलिस कार्रवाई",
+		"cause_medical": "चिकित्सा आपातकाल",
+		"cause_equipment": "उपकरण में खराबी",
+		"cause_environment": "पर्यावरणीय स्थितियां",
+		"cause_personnel": "कर्मचारी संबंधी समस्या",
+		"cause_miscellaneous": "विविध",
+		"cause_security": "सुरक्षा सूचना",
+		"effect_no_service": "कोई सेवा नहीं",
+		"effect_reduced_service": "कम सेवा",
+		"effect_significant_delays": "काफ़ी देरी",
+		"effect_detour": "मार्ग परिवर्तन",
+		"effect_additional_service": "अतिरिक्त सेवा",
+		"effect_modified_service": "संशोधित सेवा",
+		"effect_other": "अन्य प्रभाव",
+		"effect_unknown": "अज्ञात प्रभाव",
+		"effect_stop_moved": "स्टॉप स्थानांतरित",
+		"effect_no_effect": "कोई प्रभाव नहीं",
+		"effect_accessibility": "सुलभता संबंधी समस्या"
 	},
 	"view_stop_information": "स्टॉप जानकारी देखें",
 	"stop_details": {
-		"view_details": "विवरण देखें"
+		"view_details": "विवरण देखें",
+		"stop_info": "स्टॉप जानकारी"
 	},
 	"language_switcher": {
 		"select_language": "भाषा चुनें: {language}",
 		"available_languages": "उपलब्ध भाषाएं"
 	},
 	"map": {
-		"find_my_location": "मेरा स्थान खोजें"
+		"find_my_location": "मेरा स्थान खोजें",
+		"routes_shown": "दिखाए गए मार्ग",
+		"live_vehicle_count": "{count} लाइव"
 	},
 	"context-menu": {
 		"start_here": "यहाँ से शुरू करें",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "होम पर जाएँ",
 		"go_back": "वापस जाएँ"
+	},
+	"trip_details": {
+		"route": "मार्ग",
+		"no_stops": "इस यात्रा के लिए कोई स्टॉप समय उपलब्ध नहीं है।",
+		"loading": "यात्रा विवरण लोड हो रहा है...",
+		"live_vehicle": "लाइव · वाहन {vehicleId}",
+		"collapsed_stops": "{count, plural, one {# स्टॉप} other {# स्टॉप}}"
 	},
 	"skip_to_main_content": "मुख्य सामग्री पर जाएं"
 }

--- a/src/locales/ht.json
+++ b/src/locales/ht.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "Itinerè Vwayaj",
 		"show_steps": "Montre etap yo",
 		"hide_steps": "Kache etap yo",
+		"options": "Opsyon",
+		"trip_options": "Opsyon Vwayaj",
+		"cancel": "Anile",
+		"done": "Fini",
+		"reset_to_defaults": "Remete valè pa defo yo",
+		"departure_time": "Lè Depa",
+		"departure_date": "Dat depa",
+		"leave_now": "Pati Kounye a",
+		"depart_at": "Pati nan yon lè presi",
+		"arrive_by": "Rive Anvan",
+		"wheelchair_accessible": "Aksesib pou chèz woulant",
+		"wheelchair_desc": "Jwenn wout ki bon pou aparèy mobilite ak chèz woulant",
+		"wheelchair": "Chèz woulant",
+		"route_optimization": "Optimizasyon Wout",
+		"fastest_trip": "Vwayaj Pi Rapid",
+		"fewest_transfers": "Mwens Transfè",
+		"stay_on_board": "Rete nan machin nan. Vwayaj sa a kontinye kòm Wout {route}.",
+		"walking_distance": "Distans Mache",
+		"max_walking_distance": "Distans maksimòm pou mache",
 		"distance_unit": "Inite Distans",
 		"unit_auto": "Detekte otomatik",
 		"unit_metric": "Metrik (km, m)",
-		"unit_imperial": "Enperyyal (mi, ft)"
+		"unit_imperial": "Enperyyal (mi, ft)",
+		"swap_locations": "Chanje plas Soti ak Ale",
+		"error_code": "Kòd erè",
+		"remove_recent_trip": "Retire vwayaj resan an",
+		"recent_trip": "Sèvi ak vwayaj resan an soti nan {from} pou ale nan {to}",
+		"recent_searches": "Rechèch Resan",
+		"recents": "Resan yo",
+		"clear_all": "Efase Tout",
+		"request_failed": "Nou pa t rive kontakte sèvis planifikasyon vwayaj la. Tanpri eseye ankò.",
+		"invalid_shared_link": "Lyen vwayaj pataje sa a sanble kase. Eseye planifye vwayaj la ankò."
 	},
 	"tabs": {
 		"stops-and-stations": "Estasyon ak Arè",
 		"plan_trip": "Planifye yon Vwayaj"
+	},
+	"favorites": {
+		"title": "Favori yo",
+		"add": "Ajoute nan favori yo",
+		"remove": "Retire nan favori yo",
+		"clear_all": "Efase Tout",
+		"open_panel": "Louvri favori yo",
+		"close_panel": "Fèmen favori yo",
+		"empty": "Poko gen favori. Peze zetwal la sou yon arè oswa yon wout pou anrejistre l isit la.",
+		"stop_code": "Kòd",
+		"open_item": "Louvri {name}",
+		"remove_item": "Retire {name} nan favori yo"
 	},
 	"search": {
 		"placeholder": "Chèche arè, wout, ak kote",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "pou yon lis wout ki disponib",
 		"search_for_routes": "Chèche wout...",
 		"no_routes_found": "Pa jwenn okenn wout",
-		"all_routes": "Tout Wout"
+		"all_routes": "Tout Wout",
+		"clear": "Efase",
+		"collapse": "Fèmen rechèch la"
+	},
+	"sheet": {
+		"close": "Fèmen",
+		"resize_handle": "Chanje gwosè panèl la",
+		"snap_full": "Wotè konplè",
+		"snap_half": "Mwatye wotè",
+		"snap_peek": "Wotè minimòm"
+	},
+	"survey": {
+		"required_question": "Kesyon obligatwa",
+		"required_answer": "Kesyon sa a obligatwa.",
+		"expand": "Montre kesyon an",
+		"collapse": "Kache kesyon an",
+		"dismiss": "Fèmen sondaj la",
+		"submit": "Voye",
+		"next": "Pwochen",
+		"submit_failed": "Nou pa t ka voye repons ou an. Tanpri eseye ankò."
 	},
 	"header": {
 		"home": "Akèy",
@@ -88,13 +147,26 @@
 		"close": "Fèmen"
 	},
 	"arrivals_and_departures": "Arive ak depa",
+	"show_more": "Montre plis",
+	"show_less": "Montre mwens",
 	"load_more_arrivals": "Chaje plis arive",
+	"refresh": "Aktyalize",
 	"no_arrivals_found_in_next_minutes": "Pa gen arive nan {minutes} minit kap vini yo",
 	"no_more_arrivals_in_next_minutes": "Pa gen plis arive nan {minutes} minit kap vini yo",
 	"stop": "Arè",
+	"direction_bound": "Direksyon {direction}",
 	"routes": "Wout",
 	"route": "wout",
 	"route_modal_title": "Wout {name}",
+	"notifications": {
+		"route_load_failed": "Nou pa t ka chaje wout sa a.",
+		"route_shape_failed": "Nou pa t ka trase wout sa a sou kat la.",
+		"route_shape_partial": "Nou pa t ka trase yon pati nan wout sa a. Petèt gen yon segman ki manke sou kat la.",
+		"favorite_saved": "Anrejistre nan favori yo.",
+		"favorite_removed": "Retire nan favori yo.",
+		"tap_to_retry": "Peze pou eseye ankò.",
+		"dismiss": "Fèmen"
+	},
 	"loading": "Ap chaje",
 	"arrives": "rive",
 	"NA": "Pa disponib",
@@ -105,13 +177,16 @@
 		"secs": "sek",
 		"min": "min",
 		"mins": "min",
-		"minutes": "minit"
+		"minutes": "minit",
+		"min_compact": "{n} min"
 	},
 	"vehicle": {
 		"number": "Machin #",
 		"data_updated": "Done mete ajou",
 		"no_real_time_data": "Nou pa gen done an tan reyèl pou machin sa a kounye a.",
-		"next_stop": "Pwochen arè:"
+		"next_stop": "Pwochen arè:",
+		"label": "Machin",
+		"to_headsign": "Machin pou {headsign}"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "Arive ak Depa"
@@ -150,18 +225,61 @@
 		"no_description": "Pa gen deskripsyon detaye disponib pou avètisman sa a",
 		"page": "Paj",
 		"show": "Montre",
-		"hide": "Kache"
+		"hide": "Kache",
+		"open_alert": "Louvri detay avètisman sèvis la ({severity}): {summary}",
+		"affects_this_stop": "Afekte arè sa a",
+		"other_alerts": "Lòt avètisman",
+		"severity_severe": "Grav",
+		"severity_warning": "Atansyon",
+		"severity_info": "Enfo",
+		"cause": "Kòz",
+		"effect": "Efè",
+		"active": "Aktif",
+		"active_until": "Jiska {date}",
+		"active_from": "Apati {date}",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "Enkoni",
+		"cause_other": "Lòt",
+		"cause_technical": "Pwoblèm teknik",
+		"cause_strike": "Grèv",
+		"cause_demonstration": "Manifestasyon",
+		"cause_accident": "Aksidan",
+		"cause_holiday": "Jou ferye",
+		"cause_weather": "Kondisyon tan",
+		"cause_maintenance": "Antretyen",
+		"cause_construction": "Konstriksyon",
+		"cause_police": "Aktivite polis",
+		"cause_medical": "Ijans medikal",
+		"cause_equipment": "Ekipman",
+		"cause_environment": "Anviwònman",
+		"cause_personnel": "Pèsonèl",
+		"cause_miscellaneous": "Divès",
+		"cause_security": "Avètisman sekirite",
+		"effect_no_service": "Pa gen sèvis",
+		"effect_reduced_service": "Sèvis redwi",
+		"effect_significant_delays": "Gwo reta",
+		"effect_detour": "Detou",
+		"effect_additional_service": "Sèvis anplis",
+		"effect_modified_service": "Sèvis modifye",
+		"effect_other": "Lòt efè",
+		"effect_unknown": "Efè enkoni",
+		"effect_stop_moved": "Arè deplase",
+		"effect_no_effect": "Pa gen efè",
+		"effect_accessibility": "Pwoblèm aksesibilite"
 	},
 	"view_stop_information": "Gade Enfòmasyon Arè",
 	"stop_details": {
-		"view_details": "Gade Detay"
+		"view_details": "Gade Detay",
+		"stop_info": "Enfo Arè"
 	},
 	"language_switcher": {
 		"select_language": "Chwazi lang: {language}",
 		"available_languages": "Lang ki disponib"
 	},
 	"map": {
-		"find_my_location": "Jwenn kote mwen ye"
+		"find_my_location": "Jwenn kote mwen ye",
+		"routes_shown": "Wout ki afiche",
+		"live_vehicle_count": "{count} an tan reyèl"
 	},
 	"context-menu": {
 		"start_here": "Kòmanse isit",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "Ale lakay",
 		"go_back": "Tounen"
+	},
+	"trip_details": {
+		"route": "Wout",
+		"no_stops": "Pa gen lè arè disponib pou vwayaj sa a.",
+		"loading": "Ap chaje detay vwayaj la...",
+		"live_vehicle": "An tan reyèl · machin {vehicleId}",
+		"collapsed_stops": "{count, plural, one {# arè} other {# arè}}"
 	},
 	"skip_to_main_content": "Sote nan kontni prensipal la"
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "旅程一覧",
 		"show_steps": "手順を表示",
 		"hide_steps": "手順を非表示",
+		"options": "オプション",
+		"trip_options": "旅程オプション",
+		"cancel": "キャンセル",
+		"done": "完了",
+		"reset_to_defaults": "初期設定に戻す",
+		"departure_time": "出発時刻",
+		"departure_date": "出発日",
+		"leave_now": "今すぐ出発",
+		"depart_at": "出発時刻を指定",
+		"arrive_by": "到着時刻を指定",
+		"wheelchair_accessible": "車椅子対応",
+		"wheelchair_desc": "車椅子や移動補助用具に対応した経路を検索します",
+		"wheelchair": "車椅子",
+		"route_optimization": "経路の最適化",
+		"fastest_trip": "時間優先",
+		"fewest_transfers": "乗換回数優先",
+		"stay_on_board": "そのままご乗車ください。この便は{route}系統として運行を続けます。",
+		"walking_distance": "徒歩距離",
+		"max_walking_distance": "最大徒歩距離",
 		"distance_unit": "距離の単位",
 		"unit_auto": "自動検出",
 		"unit_metric": "メートル法 (km, m)",
-		"unit_imperial": "ヤード・ポンド法 (mi, ft)"
+		"unit_imperial": "ヤード・ポンド法 (mi, ft)",
+		"swap_locations": "出発地と目的地を入れ替える",
+		"error_code": "エラーコード",
+		"remove_recent_trip": "最近の旅程を削除",
+		"recent_trip": "{from}から{to}までの最近の旅程を使用",
+		"recent_searches": "最近の検索",
+		"recents": "履歴",
+		"clear_all": "すべてクリア",
+		"request_failed": "経路検索サービスに接続できませんでした。もう一度お試しください。",
+		"invalid_shared_link": "共有された旅程のリンクが無効なようです。もう一度旅程を計画してください。"
 	},
 	"tabs": {
 		"stops-and-stations": "停留所と駅",
 		"plan_trip": "旅程を計画"
+	},
+	"favorites": {
+		"title": "お気に入り",
+		"add": "お気に入りに追加",
+		"remove": "お気に入りから削除",
+		"clear_all": "すべてクリア",
+		"open_panel": "お気に入りを開く",
+		"close_panel": "お気に入りを閉じる",
+		"empty": "お気に入りはまだありません。停留所や路線の星アイコンをタップすると、ここに保存されます。",
+		"stop_code": "コード",
+		"open_item": "{name}を開く",
+		"remove_item": "{name}をお気に入りから削除"
 	},
 	"search": {
 		"placeholder": "停留所、路線、場所を検索",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "利用可能な路線一覧を表示",
 		"search_for_routes": "路線を検索...",
 		"no_routes_found": "路線が見つかりませんでした",
-		"all_routes": "全路線"
+		"all_routes": "全路線",
+		"clear": "クリア",
+		"collapse": "検索を折りたたむ"
+	},
+	"sheet": {
+		"close": "閉じる",
+		"resize_handle": "パネルのサイズを変更",
+		"snap_full": "全画面表示",
+		"snap_half": "半分表示",
+		"snap_peek": "折りたたみ"
+	},
+	"survey": {
+		"required_question": "必須の質問",
+		"required_answer": "この質問は必須です。",
+		"expand": "質問を表示",
+		"collapse": "質問を非表示",
+		"dismiss": "アンケートを閉じる",
+		"submit": "送信",
+		"next": "次へ",
+		"submit_failed": "回答を送信できませんでした。もう一度お試しください。"
 	},
 	"header": {
 		"home": "ホーム",
@@ -88,13 +147,26 @@
 		"close": "閉じる"
 	},
 	"arrivals_and_departures": "到着・出発",
+	"show_more": "もっと見る",
+	"show_less": "折りたたむ",
 	"load_more_arrivals": "さらに到着を読み込む",
+	"refresh": "更新",
 	"no_arrivals_found_in_next_minutes": "今後{minutes}分以内に到着はありません",
 	"no_more_arrivals_in_next_minutes": "今後{minutes}分以内にこれ以上の到着はありません",
 	"stop": "停留所",
+	"direction_bound": "{direction}方面",
 	"routes": "路線",
 	"route": "路線",
 	"route_modal_title": "{name}系統",
+	"notifications": {
+		"route_load_failed": "この路線を読み込めませんでした。",
+		"route_shape_failed": "この路線を地図上に表示できませんでした。",
+		"route_shape_partial": "この路線の一部を地図上に表示できませんでした。表示されていない区間がある可能性があります。",
+		"favorite_saved": "お気に入りに保存しました。",
+		"favorite_removed": "お気に入りから削除しました。",
+		"tap_to_retry": "タップして再試行してください。",
+		"dismiss": "閉じる"
+	},
 	"loading": "読み込み中",
 	"arrives": "到着",
 	"NA": "該当なし",
@@ -105,13 +177,16 @@
 		"secs": "秒",
 		"min": "分",
 		"mins": "分",
-		"minutes": "分"
+		"minutes": "分",
+		"min_compact": "{n}分"
 	},
 	"vehicle": {
 		"number": "車両番号",
 		"data_updated": "データ更新日時",
 		"no_real_time_data": "この車両のリアルタイムデータは現在ありません。",
-		"next_stop": "次の停留所:"
+		"next_stop": "次の停留所:",
+		"label": "車両",
+		"to_headsign": "{headsign}行きの車両"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "到着・出発"
@@ -150,18 +225,61 @@
 		"no_description": "この通知の詳細説明はありません",
 		"page": "ページ",
 		"show": "表示",
-		"hide": "非表示"
+		"hide": "非表示",
+		"open_alert": "運行情報（{severity}）の詳細を開く: {summary}",
+		"affects_this_stop": "この停留所に影響あり",
+		"other_alerts": "その他の運行情報",
+		"severity_severe": "重大",
+		"severity_warning": "警告",
+		"severity_info": "情報",
+		"cause": "原因",
+		"effect": "影響",
+		"active": "有効期間",
+		"active_until": "{date}まで",
+		"active_from": "{date}から",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "不明",
+		"cause_other": "その他",
+		"cause_technical": "技術的な問題",
+		"cause_strike": "ストライキ",
+		"cause_demonstration": "デモ活動",
+		"cause_accident": "事故",
+		"cause_holiday": "祝日",
+		"cause_weather": "天候",
+		"cause_maintenance": "保守作業",
+		"cause_construction": "工事",
+		"cause_police": "警察活動",
+		"cause_medical": "救急対応",
+		"cause_equipment": "設備の問題",
+		"cause_environment": "環境要因",
+		"cause_personnel": "人員の問題",
+		"cause_miscellaneous": "その他の要因",
+		"cause_security": "保安上の警報",
+		"effect_no_service": "運休",
+		"effect_reduced_service": "減便",
+		"effect_significant_delays": "大幅な遅延",
+		"effect_detour": "迂回運行",
+		"effect_additional_service": "増便",
+		"effect_modified_service": "運行変更",
+		"effect_other": "その他の影響",
+		"effect_unknown": "影響不明",
+		"effect_stop_moved": "停留所の移設",
+		"effect_no_effect": "影響なし",
+		"effect_accessibility": "バリアフリーに関する問題"
 	},
 	"view_stop_information": "停留所情報を見る",
 	"stop_details": {
-		"view_details": "詳細を見る"
+		"view_details": "詳細を見る",
+		"stop_info": "停留所情報"
 	},
 	"language_switcher": {
 		"select_language": "言語を選択: {language}",
 		"available_languages": "利用可能な言語"
 	},
 	"map": {
-		"find_my_location": "現在地を表示"
+		"find_my_location": "現在地を表示",
+		"routes_shown": "表示中の路線",
+		"live_vehicle_count": "リアルタイム{count}台"
 	},
 	"context-menu": {
 		"start_here": "ここから出発",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "ホームへ",
 		"go_back": "戻る"
+	},
+	"trip_details": {
+		"route": "路線",
+		"no_stops": "この便の停車時刻はありません。",
+		"loading": "便の詳細を読み込み中...",
+		"live_vehicle": "リアルタイム · 車両{vehicleId}",
+		"collapsed_stops": "{count, plural, other {停留所#か所}}"
 	},
 	"skip_to_main_content": "メインコンテンツへスキップ"
 }

--- a/src/locales/km.json
+++ b/src/locales/km.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "កាលវិភាគធ្វើដំណើរ",
 		"show_steps": "បង្ហាញជំហាន",
 		"hide_steps": "លាក់ជំហាន",
+		"options": "ជម្រើស",
+		"trip_options": "ជម្រើសការធ្វើដំណើរ",
+		"cancel": "បោះបង់",
+		"done": "រួចរាល់",
+		"reset_to_defaults": "កំណត់ឡើងវិញតាមលំនាំដើម",
+		"departure_time": "ម៉ោងចេញដំណើរ",
+		"departure_date": "កាលបរិច្ឆេទចេញដំណើរ",
+		"leave_now": "ចេញឥឡូវនេះ",
+		"depart_at": "ចេញនៅម៉ោង",
+		"arrive_by": "មកដល់ត្រឹមម៉ោង",
+		"wheelchair_accessible": "ងាយស្រួលសម្រាប់រទេះរុញ",
+		"wheelchair_desc": "ស្វែងរកផ្លូវដែលសមស្របសម្រាប់ឧបករណ៍ជំនួយការធ្វើចលនា និងរទេះរុញ",
+		"wheelchair": "រទេះរុញ",
+		"route_optimization": "របៀបជ្រើសរើសផ្លូវ",
+		"fastest_trip": "ការធ្វើដំណើរលឿនបំផុត",
+		"fewest_transfers": "ប្តូររថយន្តតិចបំផុត",
+		"stay_on_board": "សូមនៅលើរថយន្តដដែល។ ការធ្វើដំណើរនេះបន្តជាផ្លូវ {route}។",
+		"walking_distance": "ចម្ងាយដើរ",
+		"max_walking_distance": "ចម្ងាយដើរអតិបរមា",
 		"distance_unit": "ឯកតារង្វាស់ចម្ងាយ",
 		"unit_auto": "រកឃើញដោយស្វ័យប្រវត្តិ",
 		"unit_metric": "ម៉ែត្រ (km, m)",
-		"unit_imperial": "អ៊ីមភេរៀល (mi, ft)"
+		"unit_imperial": "អ៊ីមភេរៀល (mi, ft)",
+		"swap_locations": "ប្តូរទីតាំង ពី និង ទៅ",
+		"error_code": "លេខកូដកំហុស",
+		"remove_recent_trip": "លុបការធ្វើដំណើរថ្មីៗនេះ",
+		"recent_trip": "ប្រើការធ្វើដំណើរថ្មីៗ ពី {from} ទៅ {to}",
+		"recent_searches": "ការស្វែងរកថ្មីៗ",
+		"recents": "ថ្មីៗ",
+		"clear_all": "សម្អាតទាំងអស់",
+		"request_failed": "យើងមិនអាចភ្ជាប់ទៅសេវាកម្មរៀបចំការធ្វើដំណើរបានទេ។ សូមព្យាយាមម្តងទៀត។",
+		"invalid_shared_link": "តំណការធ្វើដំណើរដែលបានចែករំលែកនេះហាក់ដូចជាខូច។ សូមរៀបចំការធ្វើដំណើរម្តងទៀត។"
 	},
 	"tabs": {
 		"stops-and-stations": "ចំណតនិងស្ថានីយ៍",
 		"plan_trip": "រៀបចំការធ្វើដំណើរ"
+	},
+	"favorites": {
+		"title": "សំណព្វ",
+		"add": "បន្ថែមទៅសំណព្វ",
+		"remove": "ដកចេញពីសំណព្វ",
+		"clear_all": "សម្អាតទាំងអស់",
+		"open_panel": "បើកសំណព្វ",
+		"close_panel": "បិទសំណព្វ",
+		"empty": "មិនទាន់មានសំណព្វទេ។ ចុចផ្កាយនៅលើចំណត ឬផ្លូវ ដើម្បីរក្សាទុកនៅទីនេះ។",
+		"stop_code": "លេខកូដ",
+		"open_item": "បើក {name}",
+		"remove_item": "ដក {name} ចេញពីសំណព្វ"
 	},
 	"search": {
 		"placeholder": "ស្វែងរកចំណត ផ្លូវ និងទីកន្លែង",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "សម្រាប់បញ្ជីផ្លូវដែលមាន",
 		"search_for_routes": "ស្វែងរកផ្លូវ...",
 		"no_routes_found": "រកមិនឃើញផ្លូវទេ",
-		"all_routes": "ផ្លូវទាំងអស់"
+		"all_routes": "ផ្លូវទាំងអស់",
+		"clear": "សម្អាត",
+		"collapse": "បង្រួមការស្វែងរក"
+	},
+	"sheet": {
+		"close": "បិទ",
+		"resize_handle": "ប្តូរទំហំផ្ទាំង",
+		"snap_full": "កម្ពស់ពេញ",
+		"snap_half": "កម្ពស់ពាក់កណ្តាល",
+		"snap_peek": "បង្រួម"
+	},
+	"survey": {
+		"required_question": "សំណួរចាំបាច់",
+		"required_answer": "សំណួរនេះចាំបាច់ត្រូវឆ្លើយ។",
+		"expand": "បង្ហាញសំណួរ",
+		"collapse": "លាក់សំណួរ",
+		"dismiss": "បិទការស្ទង់មតិ",
+		"submit": "ដាក់ស្នើ",
+		"next": "បន្ទាប់",
+		"submit_failed": "មិនអាចផ្ញើចម្លើយរបស់អ្នកបានទេ។ សូមព្យាយាមម្តងទៀត។"
 	},
 	"header": {
 		"home": "ទំព័រដើម",
@@ -88,13 +147,26 @@
 		"close": "បិទ"
 	},
 	"arrivals_and_departures": "ការមកដល់និងចេញដំណើរ",
+	"show_more": "បង្ហាញបន្ថែម",
+	"show_less": "បង្ហាញតិច",
 	"load_more_arrivals": "ផ្ទុកការមកដល់បន្ថែម",
+	"refresh": "ផ្ទុកឡើងវិញ",
 	"no_arrivals_found_in_next_minutes": "រកមិនឃើញការមកដល់ក្នុង {minutes} នាទីខាងមុខទេ",
 	"no_more_arrivals_in_next_minutes": "មិនមានការមកដល់បន្ថែមទៀតទេក្នុង {minutes} នាទីខាងមុខ",
 	"stop": "ចំណត",
+	"direction_bound": "ឆ្ពោះទៅទិស {direction}",
 	"routes": "ផ្លូវ",
 	"route": "ផ្លូវ",
 	"route_modal_title": "ផ្លូវ {name}",
+	"notifications": {
+		"route_load_failed": "មិនអាចផ្ទុកផ្លូវនេះបានទេ។",
+		"route_shape_failed": "មិនអាចគូសផ្លូវនេះនៅលើផែនទីបានទេ។",
+		"route_shape_partial": "ផ្នែកខ្លះនៃផ្លូវនេះមិនអាចគូសបានទេ។ ផែនទីអាចនឹងខ្វះចន្លោះខ្លះនៃខ្សែផ្លូវ។",
+		"favorite_saved": "បានរក្សាទុកទៅសំណព្វ។",
+		"favorite_removed": "បានដកចេញពីសំណព្វ។",
+		"tap_to_retry": "ចុចដើម្បីព្យាយាមម្តងទៀត។",
+		"dismiss": "បិទ"
+	},
 	"loading": "កំពុងផ្ទុក",
 	"arrives": "មកដល់",
 	"NA": "មិនមាន",
@@ -105,13 +177,16 @@
 		"secs": "វិនាទី",
 		"min": "នាទី",
 		"mins": "នាទី",
-		"minutes": "នាទី"
+		"minutes": "នាទី",
+		"min_compact": "{n} នាទី"
 	},
 	"vehicle": {
 		"number": "រថយន្តលេខ",
 		"data_updated": "ទិន្នន័យបានធ្វើបច្ចុប្បន្នភាព",
 		"no_real_time_data": "យើងមិនមានទិន្នន័យពេលវេលាជាក់ស្តែងសម្រាប់រថយន្តនេះឥឡូវទេ។",
-		"next_stop": "ចំណតបន្ទាប់៖"
+		"next_stop": "ចំណតបន្ទាប់៖",
+		"label": "រថយន្ត",
+		"to_headsign": "រថយន្តទៅ {headsign}"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "ការមកដល់និងចេញដំណើរ"
@@ -150,18 +225,61 @@
 		"no_description": "គ្មានការពិពណ៌នាលម្អិតសម្រាប់ការជូនដំណឹងនេះទេ",
 		"page": "ទំព័រ",
 		"show": "បង្ហាញ",
-		"hide": "លាក់"
+		"hide": "លាក់",
+		"open_alert": "បើកព័ត៌មានលម្អិតនៃការជូនដំណឹងសេវាកម្មកម្រិត{severity}៖ {summary}",
+		"affects_this_stop": "ប៉ះពាល់ដល់ចំណតនេះ",
+		"other_alerts": "ការជូនដំណឹងផ្សេងទៀត",
+		"severity_severe": "ធ្ងន់ធ្ងរ",
+		"severity_warning": "ព្រមាន",
+		"severity_info": "ព័ត៌មាន",
+		"cause": "មូលហេតុ",
+		"effect": "ផលប៉ះពាល់",
+		"active": "សុពលភាព",
+		"active_until": "រហូតដល់ {date}",
+		"active_from": "ចាប់ពី {date}",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "មិនស្គាល់",
+		"cause_other": "ផ្សេងទៀត",
+		"cause_technical": "បញ្ហាបច្ចេកទេស",
+		"cause_strike": "កូដកម្ម",
+		"cause_demonstration": "បាតុកម្ម",
+		"cause_accident": "គ្រោះថ្នាក់",
+		"cause_holiday": "ថ្ងៃឈប់សម្រាក",
+		"cause_weather": "អាកាសធាតុ",
+		"cause_maintenance": "ការថែទាំ",
+		"cause_construction": "ការសាងសង់",
+		"cause_police": "សកម្មភាពប៉ូលិស",
+		"cause_medical": "ករណីអាសន្នផ្នែកវេជ្ជសាស្ត្រ",
+		"cause_equipment": "ឧបករណ៍",
+		"cause_environment": "បរិស្ថាន",
+		"cause_personnel": "បុគ្គលិក",
+		"cause_miscellaneous": "ផ្សេងៗ",
+		"cause_security": "ការជូនដំណឹងសន្តិសុខ",
+		"effect_no_service": "គ្មានសេវាកម្ម",
+		"effect_reduced_service": "សេវាកម្មត្រូវបានកាត់បន្ថយ",
+		"effect_significant_delays": "ការយឺតយ៉ាវខ្លាំង",
+		"effect_detour": "ផ្លូវវាង",
+		"effect_additional_service": "សេវាកម្មបន្ថែម",
+		"effect_modified_service": "សេវាកម្មត្រូវបានកែប្រែ",
+		"effect_other": "ផលប៉ះពាល់ផ្សេងទៀត",
+		"effect_unknown": "ផលប៉ះពាល់មិនស្គាល់",
+		"effect_stop_moved": "ចំណតបានផ្លាស់ទី",
+		"effect_no_effect": "គ្មានផលប៉ះពាល់",
+		"effect_accessibility": "បញ្ហាភាពងាយស្រួលក្នុងការចូលប្រើ"
 	},
 	"view_stop_information": "មើលព័ត៌មានចំណត",
 	"stop_details": {
-		"view_details": "មើលព័ត៌មានលម្អិត"
+		"view_details": "មើលព័ត៌មានលម្អិត",
+		"stop_info": "ព័ត៌មានចំណត"
 	},
 	"language_switcher": {
 		"select_language": "ជ្រើសរើសភាសា: {language}",
 		"available_languages": "ភាសាដែលមាន"
 	},
 	"map": {
-		"find_my_location": "រកទីតាំងរបស់ខ្ញុំ"
+		"find_my_location": "រកទីតាំងរបស់ខ្ញុំ",
+		"routes_shown": "ផ្លូវដែលបង្ហាញ",
+		"live_vehicle_count": "{count} តាមពេលវេលាជាក់ស្តែង"
 	},
 	"context-menu": {
 		"start_here": "ចាប់ផ្ដើមនៅទីនេះ",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "ទៅទំព័រដើម",
 		"go_back": "ត្រឡប់ក្រោយ"
+	},
+	"trip_details": {
+		"route": "ផ្លូវ",
+		"no_stops": "គ្មានម៉ោងចំណតសម្រាប់ការធ្វើដំណើរនេះទេ។",
+		"loading": "កំពុងផ្ទុកព័ត៌មានលម្អិតនៃការធ្វើដំណើរ...",
+		"live_vehicle": "ពេលវេលាជាក់ស្តែង · រថយន្តលេខ {vehicleId}",
+		"collapsed_stops": "{count, plural, other {# ចំណត}}"
 	},
 	"skip_to_main_content": "រំលងទៅមាតិកាចម្បង"
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "여행 여정",
 		"show_steps": "단계 보기",
 		"hide_steps": "단계 숨기기",
+		"options": "옵션",
+		"trip_options": "여행 옵션",
+		"cancel": "취소",
+		"done": "완료",
+		"reset_to_defaults": "기본값으로 재설정",
+		"departure_time": "출발 시간",
+		"departure_date": "출발 날짜",
+		"leave_now": "지금 출발",
+		"depart_at": "출발 시간 지정",
+		"arrive_by": "도착 시간 지정",
+		"wheelchair_accessible": "휠체어 이용 가능",
+		"wheelchair_desc": "휠체어와 이동 보조 기기로 이용할 수 있는 경로를 찾습니다",
+		"wheelchair": "휠체어",
+		"route_optimization": "경로 최적화",
+		"fastest_trip": "최단 시간",
+		"fewest_transfers": "최소 환승",
+		"stay_on_board": "내리지 마세요. 이 차량은 {route} 노선으로 이어서 운행합니다.",
+		"walking_distance": "도보 거리",
+		"max_walking_distance": "최대 도보 거리",
 		"distance_unit": "거리 단위",
 		"unit_auto": "자동 감지",
 		"unit_metric": "미터법 (km, m)",
-		"unit_imperial": "야드파운드법 (mi, ft)"
+		"unit_imperial": "야드파운드법 (mi, ft)",
+		"swap_locations": "출발지와 도착지 바꾸기",
+		"error_code": "오류 코드",
+		"remove_recent_trip": "최근 여행 삭제",
+		"recent_trip": "{from}에서 {to}까지 최근 여행 사용",
+		"recent_searches": "최근 검색",
+		"recents": "최근 기록",
+		"clear_all": "전체 삭제",
+		"request_failed": "여행 계획 서비스에 연결할 수 없습니다. 다시 시도해 주세요.",
+		"invalid_shared_link": "공유된 여행 링크가 올바르지 않습니다. 여행을 다시 계획해 주세요."
 	},
 	"tabs": {
 		"stops-and-stations": "정류장 및 역",
 		"plan_trip": "여행 계획"
+	},
+	"favorites": {
+		"title": "즐겨찾기",
+		"add": "즐겨찾기에 추가",
+		"remove": "즐겨찾기에서 삭제",
+		"clear_all": "전체 삭제",
+		"open_panel": "즐겨찾기 열기",
+		"close_panel": "즐겨찾기 닫기",
+		"empty": "아직 즐겨찾기가 없습니다. 정류장이나 노선의 별표를 눌러 여기에 저장하세요.",
+		"stop_code": "번호",
+		"open_item": "{name} 열기",
+		"remove_item": "즐겨찾기에서 {name} 삭제"
 	},
 	"search": {
 		"placeholder": "정류장, 노선, 장소 검색",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "이용 가능한 노선 목록 보기",
 		"search_for_routes": "노선 검색...",
 		"no_routes_found": "노선을 찾을 수 없습니다",
-		"all_routes": "전체 노선"
+		"all_routes": "전체 노선",
+		"clear": "지우기",
+		"collapse": "검색 접기"
+	},
+	"sheet": {
+		"close": "닫기",
+		"resize_handle": "패널 크기 조절",
+		"snap_full": "전체 높이",
+		"snap_half": "절반 높이",
+		"snap_peek": "접힘"
+	},
+	"survey": {
+		"required_question": "필수 질문",
+		"required_answer": "이 질문은 필수입니다.",
+		"expand": "질문 보기",
+		"collapse": "질문 숨기기",
+		"dismiss": "설문 닫기",
+		"submit": "제출",
+		"next": "다음",
+		"submit_failed": "답변을 보내지 못했습니다. 다시 시도해 주세요."
 	},
 	"header": {
 		"home": "홈",
@@ -88,13 +147,26 @@
 		"close": "닫기"
 	},
 	"arrivals_and_departures": "도착 및 출발",
+	"show_more": "더 보기",
+	"show_less": "접기",
 	"load_more_arrivals": "도착 정보 더 보기",
+	"refresh": "새로고침",
 	"no_arrivals_found_in_next_minutes": "{minutes}분 이내 도착 예정이 없습니다",
 	"no_more_arrivals_in_next_minutes": "앞으로 {minutes}분 이내에 더 이상 도착 예정이 없습니다",
 	"stop": "정류장",
+	"direction_bound": "{direction} 방면",
 	"routes": "노선",
 	"route": "노선",
 	"route_modal_title": "{name}번 노선",
+	"notifications": {
+		"route_load_failed": "이 노선을 불러오지 못했습니다.",
+		"route_shape_failed": "이 노선을 지도에 표시하지 못했습니다.",
+		"route_shape_partial": "이 노선의 일부를 지도에 표시하지 못했습니다. 일부 구간이 빠져 있을 수 있습니다.",
+		"favorite_saved": "즐겨찾기에 추가되었습니다.",
+		"favorite_removed": "즐겨찾기에서 삭제되었습니다.",
+		"tap_to_retry": "다시 시도하려면 누르세요.",
+		"dismiss": "닫기"
+	},
 	"loading": "로딩 중",
 	"arrives": "도착",
 	"NA": "정보 없음",
@@ -105,13 +177,16 @@
 		"secs": "초",
 		"min": "분",
 		"mins": "분",
-		"minutes": "분"
+		"minutes": "분",
+		"min_compact": "{n}분"
 	},
 	"vehicle": {
 		"number": "차량 번호",
 		"data_updated": "데이터 업데이트",
 		"no_real_time_data": "현재 이 차량의 실시간 정보가 없습니다.",
-		"next_stop": "다음 정류장:"
+		"next_stop": "다음 정류장:",
+		"label": "차량",
+		"to_headsign": "{headsign} 방면 차량"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "도착 및 출발"
@@ -150,18 +225,61 @@
 		"no_description": "이 알림에 대한 상세 설명이 없습니다",
 		"page": "페이지",
 		"show": "보기",
-		"hide": "숨기기"
+		"hide": "숨기기",
+		"open_alert": "{severity} 등급 운행 알림 상세 보기: {summary}",
+		"affects_this_stop": "이 정류장 관련 알림",
+		"other_alerts": "기타 알림",
+		"severity_severe": "심각",
+		"severity_warning": "경고",
+		"severity_info": "정보",
+		"cause": "원인",
+		"effect": "영향",
+		"active": "적용 기간",
+		"active_until": "{date}까지",
+		"active_from": "{date}부터",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "알 수 없음",
+		"cause_other": "기타",
+		"cause_technical": "기술적 문제",
+		"cause_strike": "파업",
+		"cause_demonstration": "시위",
+		"cause_accident": "사고",
+		"cause_holiday": "공휴일",
+		"cause_weather": "기상 상황",
+		"cause_maintenance": "정비",
+		"cause_construction": "공사",
+		"cause_police": "경찰 활동",
+		"cause_medical": "응급 의료 상황",
+		"cause_equipment": "장비 문제",
+		"cause_environment": "환경 요인",
+		"cause_personnel": "인력 문제",
+		"cause_miscellaneous": "기타 사유",
+		"cause_security": "보안 경보",
+		"effect_no_service": "운행 중단",
+		"effect_reduced_service": "운행 축소",
+		"effect_significant_delays": "심각한 지연",
+		"effect_detour": "우회 운행",
+		"effect_additional_service": "증편 운행",
+		"effect_modified_service": "운행 변경",
+		"effect_other": "기타 영향",
+		"effect_unknown": "알 수 없는 영향",
+		"effect_stop_moved": "정류장 이전",
+		"effect_no_effect": "영향 없음",
+		"effect_accessibility": "접근성 문제"
 	},
 	"view_stop_information": "정류장 정보 보기",
 	"stop_details": {
-		"view_details": "상세 정보 보기"
+		"view_details": "상세 정보 보기",
+		"stop_info": "정류장 정보"
 	},
 	"language_switcher": {
 		"select_language": "언어 선택: {language}",
 		"available_languages": "사용 가능한 언어"
 	},
 	"map": {
-		"find_my_location": "내 위치 찾기"
+		"find_my_location": "내 위치 찾기",
+		"routes_shown": "표시된 노선",
+		"live_vehicle_count": "실시간 {count}대"
 	},
 	"context-menu": {
 		"start_here": "여기에서 출발",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "홈으로",
 		"go_back": "뒤로 가기"
+	},
+	"trip_details": {
+		"route": "노선",
+		"no_stops": "이 운행의 정류장 시간 정보가 없습니다.",
+		"loading": "운행 정보를 불러오는 중...",
+		"live_vehicle": "실시간 · 차량 {vehicleId}",
+		"collapsed_stops": "{count, plural, other {정류장 #개}}"
 	},
 	"skip_to_main_content": "주요 콘텐츠로 건너뛰기"
 }

--- a/src/locales/lo.json
+++ b/src/locales/lo.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "ລາຍການເດີນທາງ",
 		"show_steps": "ສະແດງຂັ້ນຕອນ",
 		"hide_steps": "ເຊື່ອງຂັ້ນຕອນ",
+		"options": "ຕົວເລືອກ",
+		"trip_options": "ຕົວເລືອກການເດີນທາງ",
+		"cancel": "ຍົກເລີກ",
+		"done": "ຕົກລົງ",
+		"reset_to_defaults": "ຕັ້ງຄືນເປັນຄ່າເລີ່ມຕົ້ນ",
+		"departure_time": "ເວລາອອກເດີນທາງ",
+		"departure_date": "ວັນທີອອກເດີນທາງ",
+		"leave_now": "ອອກເດີນທາງດຽວນີ້",
+		"depart_at": "ອອກເດີນທາງເວລາ",
+		"arrive_by": "ມາຮອດກ່ອນເວລາ",
+		"wheelchair_accessible": "ເຂົ້າເຖິງໄດ້ດ້ວຍລົດເຂັນ",
+		"wheelchair_desc": "ຄົ້ນຫາເສັ້ນທາງທີ່ເໝາະສົມສຳລັບອຸປະກອນຊ່ວຍການເຄື່ອນທີ່ ແລະ ລົດເຂັນ",
+		"wheelchair": "ລົດເຂັນ",
+		"route_optimization": "ການປັບເສັ້ນທາງໃຫ້ເໝາະສົມ",
+		"fastest_trip": "ການເດີນທາງໄວທີ່ສຸດ",
+		"fewest_transfers": "ປ່ຽນລົດໜ້ອຍທີ່ສຸດ",
+		"stay_on_board": "ນັ່ງຢູ່ໃນລົດຄັນເດີມ. ການເດີນທາງນີ້ສືບຕໍ່ເປັນເສັ້ນທາງ {route}.",
+		"walking_distance": "ໄລຍະທາງຍ່າງ",
+		"max_walking_distance": "ໄລຍະທາງຍ່າງສູງສຸດ",
 		"distance_unit": "ຫົວໜ່ວຍໄລຍະທາງ",
 		"unit_auto": "ກວດຫາອັດຕະໂນມັດ",
 		"unit_metric": "ລະບົບເມຕຣິກ (ກມ, ມ)",
-		"unit_imperial": "ລະບົບອິມພີຣຽລ (ໄມລ໌, ຟຸດ)"
+		"unit_imperial": "ລະບົບອິມພີຣຽລ (ໄມລ໌, ຟຸດ)",
+		"swap_locations": "ສະຫຼັບສະຖານທີ່ຕົ້ນທາງ ແລະ ປາຍທາງ",
+		"error_code": "ລະຫັດຂໍ້ຜິດພາດ",
+		"remove_recent_trip": "ລຶບການເດີນທາງລ່າສຸດ",
+		"recent_trip": "ໃຊ້ການເດີນທາງລ່າສຸດຈາກ {from} ໄປ {to}",
+		"recent_searches": "ການຄົ້ນຫາລ່າສຸດ",
+		"recents": "ລ່າສຸດ",
+		"clear_all": "ລຶບທັງໝົດ",
+		"request_failed": "ພວກເຮົາບໍ່ສາມາດເຊື່ອມຕໍ່ຫາບໍລິການວາງແຜນການເດີນທາງໄດ້. ກະລຸນາລອງໃໝ່.",
+		"invalid_shared_link": "ລິ້ງການເດີນທາງທີ່ແບ່ງປັນນີ້ເບິ່ງຄືວ່າໃຊ້ບໍ່ໄດ້. ກະລຸນາວາງແຜນການເດີນທາງໃໝ່ອີກຄັ້ງ."
 	},
 	"tabs": {
 		"stops-and-stations": "ປ້າຍ ແລະ ສະຖານີ",
 		"plan_trip": "ວາງແຜນການເດີນທາງ"
+	},
+	"favorites": {
+		"title": "ລາຍການໂປດ",
+		"add": "ເພີ່ມໃສ່ລາຍການໂປດ",
+		"remove": "ລຶບອອກຈາກລາຍການໂປດ",
+		"clear_all": "ລຶບທັງໝົດ",
+		"open_panel": "ເປີດລາຍການໂປດ",
+		"close_panel": "ປິດລາຍການໂປດ",
+		"empty": "ຍັງບໍ່ມີລາຍການໂປດ. ກົດຮູບດາວຢູ່ປ້າຍ ຫຼື ເສັ້ນທາງ ເພື່ອບັນທຶກໄວ້ບ່ອນນີ້.",
+		"stop_code": "ລະຫັດ",
+		"open_item": "ເປີດ {name}",
+		"remove_item": "ລຶບ {name} ອອກຈາກລາຍການໂປດ"
 	},
 	"search": {
 		"placeholder": "ຄົ້ນຫາປ້າຍ, ເສັ້ນທາງ, ແລະ ສະຖານທີ່",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "ເພື່ອເບິ່ງລາຍການເສັ້ນທາງທີ່ມີ",
 		"search_for_routes": "ຄົ້ນຫາເສັ້ນທາງ...",
 		"no_routes_found": "ບໍ່ພົບເສັ້ນທາງ",
-		"all_routes": "ທຸກເສັ້ນທາງ"
+		"all_routes": "ທຸກເສັ້ນທາງ",
+		"clear": "ລຶບ",
+		"collapse": "ຫຍໍ້ການຄົ້ນຫາ"
+	},
+	"sheet": {
+		"close": "ປິດ",
+		"resize_handle": "ປັບຂະໜາດແຜງ",
+		"snap_full": "ຄວາມສູງເຕັມ",
+		"snap_half": "ຄວາມສູງເຄິ່ງໜຶ່ງ",
+		"snap_peek": "ຫຍໍ້ລົງ"
+	},
+	"survey": {
+		"required_question": "ຄຳຖາມທີ່ຕ້ອງຕອບ",
+		"required_answer": "ຄຳຖາມນີ້ຈຳເປັນຕ້ອງຕອບ.",
+		"expand": "ສະແດງຄຳຖາມ",
+		"collapse": "ເຊື່ອງຄຳຖາມ",
+		"dismiss": "ປິດແບບສຳຫຼວດ",
+		"submit": "ສົ່ງ",
+		"next": "ຕໍ່ໄປ",
+		"submit_failed": "ບໍ່ສາມາດສົ່ງຄຳຕອບຂອງທ່ານໄດ້. ກະລຸນາລອງໃໝ່."
 	},
 	"header": {
 		"home": "ໜ້າຫຼັກ",
@@ -88,13 +147,26 @@
 		"close": "ປິດ"
 	},
 	"arrivals_and_departures": "ການມາຮອດ ແລະ ການອອກເດີນທາງ",
+	"show_more": "ສະແດງເພີ່ມເຕີມ",
+	"show_less": "ສະແດງໜ້ອຍລົງ",
 	"load_more_arrivals": "ໂຫຼດການມາຮອດເພີ່ມເຕີມ",
+	"refresh": "ໂຫຼດຄືນ",
 	"no_arrivals_found_in_next_minutes": "ບໍ່ພົບການມາຮອດໃນ {minutes} ນາທີຕໍ່ໄປ",
 	"no_more_arrivals_in_next_minutes": "ບໍ່ມີການມາຮອດເພີ່ມເຕີມໃນ {minutes} ນາທີຕໍ່ໄປ",
 	"stop": "ປ້າຍ",
+	"direction_bound": "ມຸ່ງໜ້າໄປທາງ {direction}",
 	"routes": "ເສັ້ນທາງ",
 	"route": "ເສັ້ນທາງ",
 	"route_modal_title": "ເສັ້ນທາງ {name}",
+	"notifications": {
+		"route_load_failed": "ບໍ່ສາມາດໂຫຼດເສັ້ນທາງນີ້ໄດ້.",
+		"route_shape_failed": "ບໍ່ສາມາດແຕ້ມເສັ້ນທາງນີ້ໃສ່ແຜນທີ່ໄດ້.",
+		"route_shape_partial": "ບາງສ່ວນຂອງເສັ້ນທາງນີ້ແຕ້ມບໍ່ໄດ້. ແຜນທີ່ອາດຈະຂາດບາງຊ່ວງ.",
+		"favorite_saved": "ບັນທຶກໃສ່ລາຍການໂປດແລ້ວ.",
+		"favorite_removed": "ລຶບອອກຈາກລາຍການໂປດແລ້ວ.",
+		"tap_to_retry": "ກົດເພື່ອລອງໃໝ່.",
+		"dismiss": "ປິດ"
+	},
 	"loading": "ກຳລັງໂຫລດ",
 	"arrives": "ມາຮອດ",
 	"NA": "ບໍ່ມີຂໍ້ມູນ",
@@ -105,13 +177,16 @@
 		"secs": "ວິນາທີ",
 		"min": "ນາທີ",
 		"mins": "ນາທີ",
-		"minutes": "ນາທີ"
+		"minutes": "ນາທີ",
+		"min_compact": "{n} ນາທີ"
 	},
 	"vehicle": {
 		"number": "ລົດເລກ #",
 		"data_updated": "ຂໍ້ມູນອັບເດດແລ້ວ",
 		"no_real_time_data": "ພວກເຮົາບໍ່ມີຂໍ້ມູນເວລາຈິງສຳລັບລົດຄັນນີ້ໃນຕອນນີ້.",
-		"next_stop": "ປ້າຍຕໍ່ໄປ:"
+		"next_stop": "ປ້າຍຕໍ່ໄປ:",
+		"label": "ລົດ",
+		"to_headsign": "ລົດໄປ {headsign}"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "ການມາຮອດ ແລະ ການອອກເດີນທາງ"
@@ -150,18 +225,61 @@
 		"no_description": "ບໍ່ມີລາຍລະອຽດສຳລັບການແຈ້ງເຕືອນນີ້",
 		"page": "ໜ້າ",
 		"show": "ສະແດງ",
-		"hide": "ເຊື່ອງ"
+		"hide": "ເຊື່ອງ",
+		"open_alert": "ເປີດລາຍລະອຽດການແຈ້ງເຕືອນການບໍລິການ ({severity}): {summary}",
+		"affects_this_stop": "ມີຜົນຕໍ່ປ້າຍນີ້",
+		"other_alerts": "ການແຈ້ງເຕືອນອື່ນໆ",
+		"severity_severe": "ຮ້າຍແຮງ",
+		"severity_warning": "ຄຳເຕືອນ",
+		"severity_info": "ຂໍ້ມູນ",
+		"cause": "ສາເຫດ",
+		"effect": "ຜົນກະທົບ",
+		"active": "ໄລຍະເວລາທີ່ມີຜົນ",
+		"active_until": "ຈົນຮອດ {date}",
+		"active_from": "ຕັ້ງແຕ່ {date}",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "ບໍ່ຮູ້ສາເຫດ",
+		"cause_other": "ອື່ນໆ",
+		"cause_technical": "ບັນຫາທາງເຕັກນິກ",
+		"cause_strike": "ການນັດຢຸດງານ",
+		"cause_demonstration": "ການປະທ້ວງ",
+		"cause_accident": "ອຸປະຕິເຫດ",
+		"cause_holiday": "ວັນພັກ",
+		"cause_weather": "ສະພາບອາກາດ",
+		"cause_maintenance": "ການບຳລຸງຮັກສາ",
+		"cause_construction": "ການກໍ່ສ້າງ",
+		"cause_police": "ການປະຕິບັດງານຂອງຕຳຫຼວດ",
+		"cause_medical": "ເຫດສຸກເສີນທາງການແພດ",
+		"cause_equipment": "ບັນຫາອຸປະກອນ",
+		"cause_environment": "ບັນຫາສິ່ງແວດລ້ອມ",
+		"cause_personnel": "ບັນຫາພະນັກງານ",
+		"cause_miscellaneous": "ບັນຫາເບັດເຕັດ",
+		"cause_security": "ບັນຫາຄວາມປອດໄພ",
+		"effect_no_service": "ບໍ່ມີການບໍລິການ",
+		"effect_reduced_service": "ຫຼຸດການບໍລິການ",
+		"effect_significant_delays": "ຊັກຊ້າຫຼາຍ",
+		"effect_detour": "ອ້ອມທາງ",
+		"effect_additional_service": "ເພີ່ມການບໍລິການ",
+		"effect_modified_service": "ປັບປ່ຽນການບໍລິການ",
+		"effect_other": "ຜົນກະທົບອື່ນໆ",
+		"effect_unknown": "ບໍ່ຮູ້ຜົນກະທົບ",
+		"effect_stop_moved": "ຍ້າຍປ້າຍ",
+		"effect_no_effect": "ບໍ່ມີຜົນກະທົບ",
+		"effect_accessibility": "ບັນຫາການເຂົ້າເຖິງ"
 	},
 	"view_stop_information": "ເບິ່ງຂໍ້ມູນປ້າຍ",
 	"stop_details": {
-		"view_details": "ເບິ່ງລາຍລະອຽດ"
+		"view_details": "ເບິ່ງລາຍລະອຽດ",
+		"stop_info": "ຂໍ້ມູນປ້າຍ"
 	},
 	"language_switcher": {
 		"select_language": "ເລືອກພາສາ: {language}",
 		"available_languages": "ພາສາທີ່ມີ"
 	},
 	"map": {
-		"find_my_location": "ຊອກຫາທີ່ຕັ້ງຂອງຂ້ອຍ"
+		"find_my_location": "ຊອກຫາທີ່ຕັ້ງຂອງຂ້ອຍ",
+		"routes_shown": "ເສັ້ນທາງທີ່ສະແດງ",
+		"live_vehicle_count": "ລົດເວລາຈິງ {count} ຄັນ"
 	},
 	"context-menu": {
 		"start_here": "ເລີ່ມຈາກບ່ອນນີ້",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "ໄປໜ້າຫຼັກ",
 		"go_back": "ກັບຄືນ"
+	},
+	"trip_details": {
+		"route": "ເສັ້ນທາງ",
+		"no_stops": "ບໍ່ມີເວລາຮອດປ້າຍສຳລັບການເດີນທາງນີ້.",
+		"loading": "ກຳລັງໂຫຼດລາຍລະອຽດການເດີນທາງ...",
+		"live_vehicle": "ເວລາຈິງ · ລົດເລກ {vehicleId}",
+		"collapsed_stops": "{count, plural, other {# ປ້າຍ}}"
 	},
 	"skip_to_main_content": "ຂ້າມໄປຍັງເນື້ອຫາຫຼັກ"
 }

--- a/src/locales/om.json
+++ b/src/locales/om.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "Karoorsawwan Imala",
 		"show_steps": "Tarkaanfii Agarsiisi",
 		"hide_steps": "Tarkaanfii Dhoksi",
+		"options": "Filannoowwan",
+		"trip_options": "Filannoowwan Imalaa",
+		"cancel": "Dhiisi",
+		"done": "Xumuri",
+		"reset_to_defaults": "Qindaa'ina jalqabaatti deebisi",
+		"departure_time": "Yeroo Ka'umsaa",
+		"departure_date": "Guyyaa ka'umsaa",
+		"leave_now": "Amma Ka'i",
+		"depart_at": "Yeroo Kanatti Ka'i",
+		"arrive_by": "Yeroo Kanaan Ga'i",
+		"wheelchair_accessible": "Wiilcheeriif mijataa",
+		"wheelchair_desc": "Sararawwan meeshaalee gargaarsa sochii fi wiilcheeriif mijatan barbaadi",
+		"wheelchair": "Wiilcheerii",
+		"route_optimization": "Fooyya'iinsa Sararaa",
+		"fastest_trip": "Imala Saffisaa",
+		"fewest_transfers": "Jijjiirraa Xiqqaa",
+		"stay_on_board": "Konkolaataa keessa turi. Imalli kun Sarara {route} ta'ee itti fufa.",
+		"walking_distance": "Fageenya Miilaa",
+		"max_walking_distance": "Fageenya miilaa ol'aanaa",
 		"distance_unit": "Safartuu Fageenya",
 		"unit_auto": "Ofumaan adda baasi",
 		"unit_metric": "Meetirikii (km, m)",
-		"unit_imperial": "Impeeriyaalii (mi, ft)"
+		"unit_imperial": "Impeeriyaalii (mi, ft)",
+		"swap_locations": "Bakkeewwan Irraa fi Gara wal jijjiiri",
+		"error_code": "Koodii dogoggoraa",
+		"remove_recent_trip": "Imala dhiyeenyaa haqi",
+		"recent_trip": "Imala dhiyeenyaa {from} irraa gara {to} fayyadami",
+		"recent_searches": "Barbaacha Dhiyeenyaa",
+		"recents": "Kan Dhiyeenyaa",
+		"clear_all": "Hunda Haqi",
+		"request_failed": "Tajaajila karoorsa imalaa argachuun hin danda'amne. Maaloo irra deebi'ii yaali.",
+		"invalid_shared_link": "Liinkiin imala qoodame kun sirrii hin fakkaatu. Imalicha irra deebi'ii karoorfadhu."
 	},
 	"tabs": {
 		"stops-and-stations": "Dhaabbii fi Buufataalee",
 		"plan_trip": "Imala Karoorfadhu"
+	},
+	"favorites": {
+		"title": "Jaalatamoo",
+		"add": "Jaalatamootti dabali",
+		"remove": "Jaalatamoo keessaa baasi",
+		"clear_all": "Hunda Haqi",
+		"open_panel": "Jaalatamoo bani",
+		"close_panel": "Jaalatamoo cufi",
+		"empty": "Hanga ammaa jaalatamoon hin jiru. Dhaabbii yookaan sarara tokko as kaa'uuf urjii isaa tuqi.",
+		"stop_code": "Koodii",
+		"open_item": "{name} bani",
+		"remove_item": "{name} jaalatamoo keessaa baasi"
 	},
 	"search": {
 		"placeholder": "Dhaabbii, sarara fi bakkeewwan barbaadi",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "tarree sararawwan jiraniif",
 		"search_for_routes": "Sarara barbaadi...",
 		"no_routes_found": "Sarari hin argamne",
-		"all_routes": "Sarara Hunda"
+		"all_routes": "Sarara Hunda",
+		"clear": "Haqi",
+		"collapse": "Barbaacha dhoksi"
+	},
+	"sheet": {
+		"close": "Cufi",
+		"resize_handle": "Guddina paanelii jijjiiri",
+		"snap_full": "Dheerina guutuu",
+		"snap_half": "Dheerina walakkaa",
+		"snap_peek": "Xiqqeeffame"
+	},
+	"survey": {
+		"required_question": "Gaaffii dirqamaa",
+		"required_answer": "Gaaffiin kun dirqamaadha.",
+		"expand": "Gaaffii agarsiisi",
+		"collapse": "Gaaffii dhoksi",
+		"dismiss": "Qorannoo cufi",
+		"submit": "Ergi",
+		"next": "Itti Aanu",
+		"submit_failed": "Deebii kee erguun hin danda'amne. Maaloo irra deebi'ii yaali."
 	},
 	"header": {
 		"home": "Mana",
@@ -88,13 +147,26 @@
 		"close": "Cufi"
 	},
 	"arrivals_and_departures": "Dhufaatii fi ka'umsa",
+	"show_more": "Dabalataa agarsiisi",
+	"show_less": "Dabalataa dhoksi",
 	"load_more_arrivals": "Dhufaatii dabalataa fe'i",
+	"refresh": "Haaromsi",
 	"no_arrivals_found_in_next_minutes": "Daqiiqaa {minutes} itti aanu keessatti dhufaatiin hin argamne",
 	"no_more_arrivals_in_next_minutes": "Daqiiqaa {minutes} itti aanu keessatti dhufaataa dabalataa hin jiru",
 	"stop": "Dhaabbii",
+	"direction_bound": "gara {direction}",
 	"routes": "Sararawwan",
 	"route": "sarara",
 	"route_modal_title": "Sarara {name}",
+	"notifications": {
+		"route_load_failed": "Sarara kana fe'uun hin danda'amne.",
+		"route_shape_failed": "Sarara kana kaartaa irratti agarsiisuun hin danda'amne.",
+		"route_shape_partial": "Kutaa sarara kanaa tokko agarsiisuun hin danda'amne. Kaartaa irraa kutaan tokko hir'achuu danda'a.",
+		"favorite_saved": "Jaalatamootti kaa'ame.",
+		"favorite_removed": "Jaalatamoo keessaa baafame.",
+		"tap_to_retry": "Irra deebi'ii yaaluuf tuqi.",
+		"dismiss": "Cufi"
+	},
 	"loading": "Fe'aa jira",
 	"arrives": "ni ga'a",
 	"NA": "Hin jiru",
@@ -105,13 +177,16 @@
 		"secs": "sek",
 		"min": "daqiiqaa",
 		"mins": "daqiiqaa",
-		"minutes": "daqiiqaawwan"
+		"minutes": "daqiiqaawwan",
+		"min_compact": "{n} daq"
 	},
 	"vehicle": {
 		"number": "Konkolaataa #",
 		"data_updated": "Odeeffannoon haaromfame",
 		"no_real_time_data": "Amma odeeffannoo yeroo qabatamaa konkolaataa kanaaf hin qabnu.",
-		"next_stop": "Dhaabbii itti aanu:"
+		"next_stop": "Dhaabbii itti aanu:",
+		"label": "Konkolaataa",
+		"to_headsign": "Konkolaataa gara {headsign} deemu"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "Dhufaatii fi Ka'umsa"
@@ -150,18 +225,61 @@
 		"no_description": "Beeksisa kanaaf ibsi bal'aan hin jiru",
 		"page": "Fuula",
 		"show": "Agarsiisi",
-		"hide": "Dhoksi"
+		"hide": "Dhoksi",
+		"open_alert": "Bal'ina beeksisa tajaajilaa ({severity}) bani: {summary}",
+		"affects_this_stop": "Dhaabbii kana ilaallata",
+		"other_alerts": "Beeksisa biroo",
+		"severity_severe": "Cimaa",
+		"severity_warning": "Akeekkachiisa",
+		"severity_info": "Odeeffannoo",
+		"cause": "Sababa",
+		"effect": "Dhiibbaa",
+		"active": "Hojii irra jira",
+		"active_until": "Hanga {date}",
+		"active_from": "{date} irraa",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "Hin beekamu",
+		"cause_other": "Kan biroo",
+		"cause_technical": "Rakkoo teeknikaa",
+		"cause_strike": "Hojii dhaabuu",
+		"cause_demonstration": "Hiriira",
+		"cause_accident": "Balaa",
+		"cause_holiday": "Ayyaana",
+		"cause_weather": "Haala qilleensaa",
+		"cause_maintenance": "Suphaa",
+		"cause_construction": "Ijaarsa",
+		"cause_police": "Sochii poolisii",
+		"cause_medical": "Hatattama fayyaa",
+		"cause_equipment": "Meeshaa",
+		"cause_environment": "Naannoo",
+		"cause_personnel": "Hojjettoota",
+		"cause_miscellaneous": "Adda addaa",
+		"cause_security": "Beeksisa nageenyaa",
+		"effect_no_service": "Tajaajilli hin jiru",
+		"effect_reduced_service": "Tajaajila hir'ate",
+		"effect_significant_delays": "Turtii guddaa",
+		"effect_detour": "Karaa jijjiirame",
+		"effect_additional_service": "Tajaajila dabalataa",
+		"effect_modified_service": "Tajaajila jijjiirame",
+		"effect_other": "Dhiibbaa biroo",
+		"effect_unknown": "Dhiibbaa hin beekamne",
+		"effect_stop_moved": "Dhaabbiin iddoo jijjiirate",
+		"effect_no_effect": "Dhiibbaa hin qabu",
+		"effect_accessibility": "Rakkoo mijatiinsaa"
 	},
 	"view_stop_information": "Odeeffannoo Dhaabbii Ilaali",
 	"stop_details": {
-		"view_details": "Bal'inaan Ilaali"
+		"view_details": "Bal'inaan Ilaali",
+		"stop_info": "Odeeffannoo Dhaabbii"
 	},
 	"language_switcher": {
 		"select_language": "Afaan filadhu: {language}",
 		"available_languages": "Afaanota jiran"
 	},
 	"map": {
-		"find_my_location": "Bakka Koo Barbaadi"
+		"find_my_location": "Bakka Koo Barbaadi",
+		"routes_shown": "Sararawwan agarsiifaman",
+		"live_vehicle_count": "{count} yeroo qabatamaa"
 	},
 	"context-menu": {
 		"start_here": "As'itti eegali",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "Gara manaatti deebi'i",
 		"go_back": "Duubatti deebi'i"
+	},
+	"trip_details": {
+		"route": "Sarara",
+		"no_stops": "Imala kanaaf yeroon dhaabbii hin jiru.",
+		"loading": "Odeeffannoo imalaa fe'aa jira...",
+		"live_vehicle": "Yeroo qabatamaa · konkolaataa {vehicleId}",
+		"collapsed_stops": "{count, plural, one {Dhaabbii #} other {Dhaabbii #}}"
 	},
 	"skip_to_main_content": "Gara qabiyyee jalqabaa darbi"
 }

--- a/src/locales/pa.json
+++ b/src/locales/pa.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "ਯਾਤਰਾ ਸੂਚੀਆਂ",
 		"show_steps": "ਕਦਮ ਦਿਖਾਓ",
 		"hide_steps": "ਕਦਮ ਲੁਕਾਓ",
+		"options": "ਵਿਕਲਪ",
+		"trip_options": "ਯਾਤਰਾ ਵਿਕਲਪ",
+		"cancel": "ਰੱਦ ਕਰੋ",
+		"done": "ਹੋ ਗਿਆ",
+		"reset_to_defaults": "ਡਿਫੌਲਟ 'ਤੇ ਰੀਸੈੱਟ ਕਰੋ",
+		"departure_time": "ਰਵਾਨਗੀ ਦਾ ਸਮਾਂ",
+		"departure_date": "ਰਵਾਨਗੀ ਦੀ ਤਾਰੀਖ",
+		"leave_now": "ਹੁਣੇ ਰਵਾਨਾ ਹੋਵੋ",
+		"depart_at": "ਇਸ ਸਮੇਂ ਰਵਾਨਾ ਹੋਵੋ",
+		"arrive_by": "ਇਸ ਸਮੇਂ ਤੱਕ ਪਹੁੰਚੋ",
+		"wheelchair_accessible": "ਵ੍ਹੀਲਚੇਅਰ ਪਹੁੰਚਯੋਗ",
+		"wheelchair_desc": "ਗਤੀਸ਼ੀਲਤਾ ਉਪਕਰਨਾਂ ਅਤੇ ਵ੍ਹੀਲਚੇਅਰਾਂ ਲਈ ਢੁੱਕਵੇਂ ਰੂਟ ਲੱਭੋ",
+		"wheelchair": "ਵ੍ਹੀਲਚੇਅਰ",
+		"route_optimization": "ਰੂਟ ਦੀ ਤਰਜੀਹ",
+		"fastest_trip": "ਸਭ ਤੋਂ ਤੇਜ਼ ਯਾਤਰਾ",
+		"fewest_transfers": "ਸਭ ਤੋਂ ਘੱਟ ਟ੍ਰਾਂਸਫਰ",
+		"stay_on_board": "ਗੱਡੀ ਵਿੱਚ ਹੀ ਰਹੋ। ਇਹ ਯਾਤਰਾ ਰੂਟ {route} ਵਜੋਂ ਜਾਰੀ ਰਹਿੰਦੀ ਹੈ।",
+		"walking_distance": "ਪੈਦਲ ਦੂਰੀ",
+		"max_walking_distance": "ਵੱਧ ਤੋਂ ਵੱਧ ਪੈਦਲ ਦੂਰੀ",
 		"distance_unit": "ਦੂਰੀ ਦੀ ਇਕਾਈ",
 		"unit_auto": "ਆਟੋ-ਖੋਜ",
 		"unit_metric": "ਮੀਟ੍ਰਿਕ (km, m)",
-		"unit_imperial": "ਇੰਪੀਰੀਅਲ (mi, ft)"
+		"unit_imperial": "ਇੰਪੀਰੀਅਲ (mi, ft)",
+		"swap_locations": "'ਤੋਂ' ਅਤੇ 'ਤੱਕ' ਥਾਵਾਂ ਅਦਲਾ-ਬਦਲੀ ਕਰੋ",
+		"error_code": "ਗਲਤੀ ਕੋਡ",
+		"remove_recent_trip": "ਹਾਲੀਆ ਯਾਤਰਾ ਹਟਾਓ",
+		"recent_trip": "{from} ਤੋਂ {to} ਤੱਕ ਦੀ ਹਾਲੀਆ ਯਾਤਰਾ ਵਰਤੋ",
+		"recent_searches": "ਹਾਲੀਆ ਖੋਜਾਂ",
+		"recents": "ਹਾਲੀਆ",
+		"clear_all": "ਸਭ ਸਾਫ਼ ਕਰੋ",
+		"request_failed": "ਅਸੀਂ ਯਾਤਰਾ ਯੋਜਨਾ ਸੇਵਾ ਤੱਕ ਨਹੀਂ ਪਹੁੰਚ ਸਕੇ। ਕਿਰਪਾ ਕਰਕੇ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ।",
+		"invalid_shared_link": "ਇਹ ਸਾਂਝਾ ਕੀਤਾ ਯਾਤਰਾ ਲਿੰਕ ਟੁੱਟਿਆ ਹੋਇਆ ਲੱਗਦਾ ਹੈ। ਯਾਤਰਾ ਦੀ ਯੋਜਨਾ ਦੁਬਾਰਾ ਬਣਾਉਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
 	},
 	"tabs": {
 		"stops-and-stations": "ਸਟਾਪ ਅਤੇ ਸਟੇਸ਼ਨ",
 		"plan_trip": "ਯਾਤਰਾ ਦੀ ਯੋਜਨਾ ਬਣਾਓ"
+	},
+	"favorites": {
+		"title": "ਮਨਪਸੰਦ",
+		"add": "ਮਨਪਸੰਦ ਵਿੱਚ ਸ਼ਾਮਲ ਕਰੋ",
+		"remove": "ਮਨਪਸੰਦ ਵਿੱਚੋਂ ਹਟਾਓ",
+		"clear_all": "ਸਭ ਸਾਫ਼ ਕਰੋ",
+		"open_panel": "ਮਨਪਸੰਦ ਖੋਲ੍ਹੋ",
+		"close_panel": "ਮਨਪਸੰਦ ਬੰਦ ਕਰੋ",
+		"empty": "ਅਜੇ ਕੋਈ ਮਨਪਸੰਦ ਨਹੀਂ। ਇਸਨੂੰ ਇੱਥੇ ਸੰਭਾਲਣ ਲਈ ਕਿਸੇ ਸਟਾਪ ਜਾਂ ਰੂਟ 'ਤੇ ਤਾਰੇ ਨੂੰ ਟੈਪ ਕਰੋ।",
+		"stop_code": "ਕੋਡ",
+		"open_item": "{name} ਖੋਲ੍ਹੋ",
+		"remove_item": "{name} ਨੂੰ ਮਨਪਸੰਦ ਵਿੱਚੋਂ ਹਟਾਓ"
 	},
 	"search": {
 		"placeholder": "ਸਟਾਪ, ਰੂਟ ਅਤੇ ਥਾਵਾਂ ਖੋਜੋ",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "ਉਪਲਬਧ ਰੂਟਾਂ ਦੀ ਸੂਚੀ ਲਈ",
 		"search_for_routes": "ਰੂਟ ਖੋਜੋ...",
 		"no_routes_found": "ਕੋਈ ਰੂਟ ਨਹੀਂ ਮਿਲੇ",
-		"all_routes": "ਸਾਰੇ ਰੂਟ"
+		"all_routes": "ਸਾਰੇ ਰੂਟ",
+		"clear": "ਸਾਫ਼ ਕਰੋ",
+		"collapse": "ਖੋਜ ਸਮੇਟੋ"
+	},
+	"sheet": {
+		"close": "ਬੰਦ ਕਰੋ",
+		"resize_handle": "ਪੈਨਲ ਦਾ ਆਕਾਰ ਬਦਲੋ",
+		"snap_full": "ਪੂਰੀ ਉਚਾਈ",
+		"snap_half": "ਅੱਧੀ ਉਚਾਈ",
+		"snap_peek": "ਸਮੇਟਿਆ ਹੋਇਆ"
+	},
+	"survey": {
+		"required_question": "ਲਾਜ਼ਮੀ ਸਵਾਲ",
+		"required_answer": "ਇਹ ਸਵਾਲ ਲਾਜ਼ਮੀ ਹੈ।",
+		"expand": "ਸਵਾਲ ਦਿਖਾਓ",
+		"collapse": "ਸਵਾਲ ਲੁਕਾਓ",
+		"dismiss": "ਸਰਵੇਖਣ ਖਾਰਜ ਕਰੋ",
+		"submit": "ਜਮ੍ਹਾਂ ਕਰੋ",
+		"next": "ਅੱਗੇ",
+		"submit_failed": "ਤੁਹਾਡਾ ਜਵਾਬ ਨਹੀਂ ਭੇਜਿਆ ਜਾ ਸਕਿਆ। ਕਿਰਪਾ ਕਰਕੇ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
 	},
 	"header": {
 		"home": "ਮੁੱਖ ਪੰਨਾ",
@@ -88,13 +147,26 @@
 		"close": "ਬੰਦ ਕਰੋ"
 	},
 	"arrivals_and_departures": "ਆਗਮਨ ਅਤੇ ਰਵਾਨਗੀਆਂ",
+	"show_more": "ਹੋਰ ਦਿਖਾਓ",
+	"show_less": "ਘੱਟ ਦਿਖਾਓ",
 	"load_more_arrivals": "ਹੋਰ ਆਗਮਨ ਲੋਡ ਕਰੋ",
+	"refresh": "ਤਾਜ਼ਾ ਕਰੋ",
 	"no_arrivals_found_in_next_minutes": "ਅਗਲੇ {minutes} ਮਿੰਟਾਂ ਵਿੱਚ ਕੋਈ ਆਗਮਨ ਨਹੀਂ ਮਿਲਿਆ",
 	"no_more_arrivals_in_next_minutes": "ਅਗਲੇ {minutes} ਮਿੰਟਾਂ ਵਿੱਚ ਹੋਰ ਕੋਈ ਆਗਮਨ ਨਹੀਂ",
 	"stop": "ਸਟਾਪ",
+	"direction_bound": "{direction} ਵੱਲ",
 	"routes": "ਰੂਟ",
 	"route": "ਰੂਟ",
 	"route_modal_title": "ਰੂਟ {name}",
+	"notifications": {
+		"route_load_failed": "ਇਹ ਰੂਟ ਲੋਡ ਨਹੀਂ ਹੋ ਸਕਿਆ।",
+		"route_shape_failed": "ਇਹ ਰੂਟ ਨਕਸ਼ੇ 'ਤੇ ਨਹੀਂ ਖਿੱਚਿਆ ਜਾ ਸਕਿਆ।",
+		"route_shape_partial": "ਇਸ ਰੂਟ ਦਾ ਕੁਝ ਹਿੱਸਾ ਨਹੀਂ ਖਿੱਚਿਆ ਜਾ ਸਕਿਆ। ਨਕਸ਼ੇ ਵਿੱਚੋਂ ਕੋਈ ਖੰਡ ਗਾਇਬ ਹੋ ਸਕਦਾ ਹੈ।",
+		"favorite_saved": "ਮਨਪਸੰਦ ਵਿੱਚ ਸੰਭਾਲਿਆ ਗਿਆ।",
+		"favorite_removed": "ਮਨਪਸੰਦ ਵਿੱਚੋਂ ਹਟਾਇਆ ਗਿਆ।",
+		"tap_to_retry": "ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰਨ ਲਈ ਟੈਪ ਕਰੋ।",
+		"dismiss": "ਖਾਰਜ ਕਰੋ"
+	},
 	"loading": "ਲੋਡ ਹੋ ਰਿਹਾ ਹੈ",
 	"arrives": "ਪਹੁੰਚਦਾ ਹੈ",
 	"NA": "ਉਪਲਬਧ ਨਹੀਂ",
@@ -105,13 +177,16 @@
 		"secs": "ਸਕਿੰਟ",
 		"min": "ਮਿੰਟ",
 		"mins": "ਮਿੰਟ",
-		"minutes": "ਮਿੰਟ"
+		"minutes": "ਮਿੰਟ",
+		"min_compact": "{n} ਮਿੰਟ"
 	},
 	"vehicle": {
 		"number": "ਵਾਹਨ #",
 		"data_updated": "ਡਾਟਾ ਅੱਪਡੇਟ ਕੀਤਾ ਗਿਆ",
 		"no_real_time_data": "ਸਾਡੇ ਕੋਲ ਇਸ ਸਮੇਂ ਇਸ ਵਾਹਨ ਲਈ ਅਸਲ-ਸਮੇਂ ਦਾ ਡਾਟਾ ਨਹੀਂ ਹੈ।",
-		"next_stop": "ਅਗਲਾ ਸਟਾਪ:"
+		"next_stop": "ਅਗਲਾ ਸਟਾਪ:",
+		"label": "ਵਾਹਨ",
+		"to_headsign": "{headsign} ਵੱਲ ਜਾਣ ਵਾਲਾ ਵਾਹਨ"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "ਆਗਮਨ ਅਤੇ ਰਵਾਨਗੀਆਂ"
@@ -150,18 +225,61 @@
 		"no_description": "ਇਸ ਚੇਤਾਵਨੀ ਲਈ ਕੋਈ ਵਿਸਤ੍ਰਿਤ ਵੇਰਵਾ ਉਪਲਬਧ ਨਹੀਂ",
 		"page": "ਪੰਨਾ",
 		"show": "ਦਿਖਾਓ",
-		"hide": "ਲੁਕਾਓ"
+		"hide": "ਲੁਕਾਓ",
+		"open_alert": "ਸੇਵਾ ਚੇਤਾਵਨੀ ਦੇ ਵੇਰਵੇ ਖੋਲ੍ਹੋ, ਪੱਧਰ {severity}: {summary}",
+		"affects_this_stop": "ਇਸ ਸਟਾਪ 'ਤੇ ਪ੍ਰਭਾਵ",
+		"other_alerts": "ਹੋਰ ਚੇਤਾਵਨੀਆਂ",
+		"severity_severe": "ਗੰਭੀਰ",
+		"severity_warning": "ਚੇਤਾਵਨੀ",
+		"severity_info": "ਜਾਣਕਾਰੀ",
+		"cause": "ਕਾਰਨ",
+		"effect": "ਪ੍ਰਭਾਵ",
+		"active": "ਸਰਗਰਮ",
+		"active_until": "{date} ਤੱਕ",
+		"active_from": "{date} ਤੋਂ",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "ਅਣਜਾਣ",
+		"cause_other": "ਹੋਰ",
+		"cause_technical": "ਤਕਨੀਕੀ ਸਮੱਸਿਆ",
+		"cause_strike": "ਹੜਤਾਲ",
+		"cause_demonstration": "ਪ੍ਰਦਰਸ਼ਨ",
+		"cause_accident": "ਹਾਦਸਾ",
+		"cause_holiday": "ਛੁੱਟੀ",
+		"cause_weather": "ਮੌਸਮ",
+		"cause_maintenance": "ਰੱਖ-ਰਖਾਅ",
+		"cause_construction": "ਉਸਾਰੀ",
+		"cause_police": "ਪੁਲਿਸ ਕਾਰਵਾਈ",
+		"cause_medical": "ਮੈਡੀਕਲ ਐਮਰਜੈਂਸੀ",
+		"cause_equipment": "ਸਾਜ਼ੋ-ਸਾਮਾਨ ਦੀ ਸਮੱਸਿਆ",
+		"cause_environment": "ਵਾਤਾਵਰਨ ਸੰਬੰਧੀ ਸਮੱਸਿਆ",
+		"cause_personnel": "ਸਟਾਫ਼ ਦੀ ਸਮੱਸਿਆ",
+		"cause_miscellaneous": "ਫੁਟਕਲ",
+		"cause_security": "ਸੁਰੱਖਿਆ ਚੇਤਾਵਨੀ",
+		"effect_no_service": "ਕੋਈ ਸੇਵਾ ਨਹੀਂ",
+		"effect_reduced_service": "ਘਟਾਈ ਗਈ ਸੇਵਾ",
+		"effect_significant_delays": "ਕਾਫ਼ੀ ਦੇਰੀ",
+		"effect_detour": "ਬਦਲਵਾਂ ਰਸਤਾ",
+		"effect_additional_service": "ਵਾਧੂ ਸੇਵਾ",
+		"effect_modified_service": "ਸੋਧੀ ਗਈ ਸੇਵਾ",
+		"effect_other": "ਹੋਰ ਪ੍ਰਭਾਵ",
+		"effect_unknown": "ਅਣਜਾਣ ਪ੍ਰਭਾਵ",
+		"effect_stop_moved": "ਸਟਾਪ ਦੀ ਥਾਂ ਬਦਲੀ ਗਈ",
+		"effect_no_effect": "ਕੋਈ ਪ੍ਰਭਾਵ ਨਹੀਂ",
+		"effect_accessibility": "ਪਹੁੰਚਯੋਗਤਾ ਸੰਬੰਧੀ ਸਮੱਸਿਆ"
 	},
 	"view_stop_information": "ਸਟਾਪ ਜਾਣਕਾਰੀ ਦੇਖੋ",
 	"stop_details": {
-		"view_details": "ਵੇਰਵੇ ਦੇਖੋ"
+		"view_details": "ਵੇਰਵੇ ਦੇਖੋ",
+		"stop_info": "ਸਟਾਪ ਜਾਣਕਾਰੀ"
 	},
 	"language_switcher": {
 		"select_language": "ਭਾਸ਼ਾ ਚੁਣੋ: {language}",
 		"available_languages": "ਉਪਲਬਧ ਭਾਸ਼ਾਵਾਂ"
 	},
 	"map": {
-		"find_my_location": "ਮੇਰੀ ਸਥਿਤੀ ਲੱਭੋ"
+		"find_my_location": "ਮੇਰੀ ਸਥਿਤੀ ਲੱਭੋ",
+		"routes_shown": "ਦਿਖਾਏ ਗਏ ਰੂਟ",
+		"live_vehicle_count": "{count} ਲਾਈਵ"
 	},
 	"context-menu": {
 		"start_here": "ਇੱਥੋਂ ਸ਼ੁਰੂ ਕਰੋ",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "ਘਰ ਜਾਓ",
 		"go_back": "ਵਾਪਸ ਜਾਓ"
+	},
+	"trip_details": {
+		"route": "ਰੂਟ",
+		"no_stops": "ਇਸ ਯਾਤਰਾ ਲਈ ਕੋਈ ਸਟਾਪ ਸਮੇਂ ਉਪਲਬਧ ਨਹੀਂ ਹਨ।",
+		"loading": "ਯਾਤਰਾ ਦੇ ਵੇਰਵੇ ਲੋਡ ਹੋ ਰਹੇ ਹਨ...",
+		"live_vehicle": "ਲਾਈਵ · ਵਾਹਨ {vehicleId}",
+		"collapsed_stops": "{count, plural, one {# ਸਟਾਪ} other {# ਸਟਾਪ}}"
 	},
 	"skip_to_main_content": "ਮੁੱਖ ਸਮੱਗਰੀ ਤੇ ਜਾਓ"
 }

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "Plany podróży",
 		"show_steps": "Pokaż kroki",
 		"hide_steps": "Ukryj kroki",
+		"options": "Opcje",
+		"trip_options": "Opcje podróży",
+		"cancel": "Anuluj",
+		"done": "Gotowe",
+		"reset_to_defaults": "Przywróć domyślne",
+		"departure_time": "Godzina odjazdu",
+		"departure_date": "Data odjazdu",
+		"leave_now": "Odjazd teraz",
+		"depart_at": "Odjazd o",
+		"arrive_by": "Przyjazd na",
+		"wheelchair_accessible": "Dostępne dla wózków inwalidzkich",
+		"wheelchair_desc": "Znajdź trasy odpowiednie dla wózków inwalidzkich i urządzeń wspomagających poruszanie się",
+		"wheelchair": "Wózek inwalidzki",
+		"route_optimization": "Optymalizacja trasy",
+		"fastest_trip": "Najszybsza podróż",
+		"fewest_transfers": "Najmniej przesiadek",
+		"stay_on_board": "Pozostań w pojeździe. Ten kurs jest kontynuowany jako trasa {route}.",
+		"walking_distance": "Odległość pieszo",
+		"max_walking_distance": "Maksymalna odległość pieszo",
 		"distance_unit": "Jednostka odległości",
 		"unit_auto": "Wykryj automatycznie",
 		"unit_metric": "Metryczny (km, m)",
-		"unit_imperial": "Imperialny (mi, ft)"
+		"unit_imperial": "Imperialny (mi, ft)",
+		"swap_locations": "Zamień miejscami pola Od i Do",
+		"error_code": "Kod błędu",
+		"remove_recent_trip": "Usuń podróż z historii",
+		"recent_trip": "Użyj podróży z historii: {from} – {to}",
+		"recent_searches": "Ostatnie wyszukiwania",
+		"recents": "Ostatnie",
+		"clear_all": "Wyczyść wszystko",
+		"request_failed": "Nie udało się połączyć z usługą planowania podróży. Spróbuj ponownie.",
+		"invalid_shared_link": "Ten udostępniony link do podróży wygląda na nieprawidłowy. Zaplanuj podróż ponownie."
 	},
 	"tabs": {
 		"stops-and-stations": "Przystanki i stacje",
 		"plan_trip": "Zaplanuj podróż"
+	},
+	"favorites": {
+		"title": "Ulubione",
+		"add": "Dodaj do ulubionych",
+		"remove": "Usuń z ulubionych",
+		"clear_all": "Wyczyść wszystko",
+		"open_panel": "Otwórz ulubione",
+		"close_panel": "Zamknij ulubione",
+		"empty": "Nie masz jeszcze ulubionych. Dotknij gwiazdki przy przystanku lub trasie, aby dodać do tej listy.",
+		"stop_code": "Kod",
+		"open_item": "Otwórz: {name}",
+		"remove_item": "Usuń z ulubionych: {name}"
 	},
 	"search": {
 		"placeholder": "Szukaj przystanków, tras i miejsc",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "dla listy dostępnych tras",
 		"search_for_routes": "Szukaj tras...",
 		"no_routes_found": "Nie znaleziono tras",
-		"all_routes": "Wszystkie trasy"
+		"all_routes": "Wszystkie trasy",
+		"clear": "Wyczyść",
+		"collapse": "Zwiń wyszukiwanie"
+	},
+	"sheet": {
+		"close": "Zamknij",
+		"resize_handle": "Zmień rozmiar panelu",
+		"snap_full": "Pełna wysokość",
+		"snap_half": "Połowa wysokości",
+		"snap_peek": "Zwinięty"
+	},
+	"survey": {
+		"required_question": "Pytanie wymagane",
+		"required_answer": "To pytanie jest wymagane.",
+		"expand": "Pokaż pytanie",
+		"collapse": "Ukryj pytanie",
+		"dismiss": "Zamknij ankietę",
+		"submit": "Wyślij",
+		"next": "Dalej",
+		"submit_failed": "Nie udało się wysłać odpowiedzi. Spróbuj ponownie."
 	},
 	"header": {
 		"home": "Strona główna",
@@ -88,13 +147,26 @@
 		"close": "Zamknij"
 	},
 	"arrivals_and_departures": "Przyjazdy i odjazdy",
+	"show_more": "Pokaż więcej",
+	"show_less": "Pokaż mniej",
 	"load_more_arrivals": "Załaduj więcej przyjazdów",
+	"refresh": "Odśwież",
 	"no_arrivals_found_in_next_minutes": "Brak przyjazdów w ciągu najbliższych {minutes} minut",
 	"no_more_arrivals_in_next_minutes": "Brak dalszych przyjazdów w ciągu najbliższych {minutes} minut",
 	"stop": "Przystanek",
+	"direction_bound": "Kierunek {direction}",
 	"routes": "Trasy",
 	"route": "trasa",
 	"route_modal_title": "Trasa {name}",
+	"notifications": {
+		"route_load_failed": "Nie udało się wczytać tej trasy.",
+		"route_shape_failed": "Nie udało się narysować tej trasy na mapie.",
+		"route_shape_partial": "Nie udało się narysować części tej trasy. Na mapie może brakować odcinka.",
+		"favorite_saved": "Zapisano w ulubionych.",
+		"favorite_removed": "Usunięto z ulubionych.",
+		"tap_to_retry": "Dotknij, aby spróbować ponownie.",
+		"dismiss": "Zamknij"
+	},
 	"loading": "Ładowanie",
 	"arrives": "przyjeżdża",
 	"NA": "N/D",
@@ -105,13 +177,16 @@
 		"secs": "secs",
 		"min": "min",
 		"mins": "mins",
-		"minutes": "minutes"
+		"minutes": "minutes",
+		"min_compact": "{n} min"
 	},
 	"vehicle": {
 		"number": "Pojazd #",
 		"data_updated": "Dane zaktualizowane",
 		"no_real_time_data": "Obecnie nie mamy danych w czasie rzeczywistym dla tego pojazdu.",
-		"next_stop": "Następny przystanek:"
+		"next_stop": "Następny przystanek:",
+		"label": "Pojazd",
+		"to_headsign": "Pojazd, kierunek: {headsign}"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "Przyjazdy i Odjazdy"
@@ -150,14 +225,61 @@
 		"no_description": "Brak szczegółowego opisu dla tego alertu",
 		"page": "Strona",
 		"show": "Pokaż",
-		"hide": "Ukryj"
+		"hide": "Ukryj",
+		"open_alert": "Otwórz szczegóły alertu serwisowego, poziom: {severity}. {summary}",
+		"affects_this_stop": "Dotyczy tego przystanku",
+		"other_alerts": "Pozostałe alerty",
+		"severity_severe": "Poważny",
+		"severity_warning": "Ostrzeżenie",
+		"severity_info": "Informacja",
+		"cause": "Przyczyna",
+		"effect": "Skutek",
+		"active": "Aktywny",
+		"active_until": "Do {date}",
+		"active_from": "Od {date}",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "Nieznana",
+		"cause_other": "Inna",
+		"cause_technical": "Problem techniczny",
+		"cause_strike": "Strajk",
+		"cause_demonstration": "Demonstracja",
+		"cause_accident": "Wypadek",
+		"cause_holiday": "Święto",
+		"cause_weather": "Pogoda",
+		"cause_maintenance": "Prace konserwacyjne",
+		"cause_construction": "Roboty budowlane",
+		"cause_police": "Działania policji",
+		"cause_medical": "Nagły przypadek medyczny",
+		"cause_equipment": "Awaria sprzętu",
+		"cause_environment": "Warunki środowiskowe",
+		"cause_personnel": "Problemy kadrowe",
+		"cause_miscellaneous": "Różne",
+		"cause_security": "Alert bezpieczeństwa",
+		"effect_no_service": "Brak kursów",
+		"effect_reduced_service": "Ograniczone kursowanie",
+		"effect_significant_delays": "Znaczne opóźnienia",
+		"effect_detour": "Objazd",
+		"effect_additional_service": "Dodatkowe kursy",
+		"effect_modified_service": "Zmienione kursowanie",
+		"effect_other": "Inny skutek",
+		"effect_unknown": "Nieznany skutek",
+		"effect_stop_moved": "Przystanek przeniesiony",
+		"effect_no_effect": "Brak wpływu",
+		"effect_accessibility": "Problem z dostępnością"
+	},
+	"view_stop_information": "Zobacz informacje o przystanku",
+	"stop_details": {
+		"view_details": "Zobacz szczegóły",
+		"stop_info": "O przystanku"
 	},
 	"language_switcher": {
 		"select_language": "Wybierz język: {language}",
 		"available_languages": "Dostępne języki"
 	},
 	"map": {
-		"find_my_location": "Znajdź moją lokalizację"
+		"find_my_location": "Znajdź moją lokalizację",
+		"routes_shown": "Wyświetlane trasy",
+		"live_vehicle_count": "{count} na żywo"
 	},
 	"context-menu": {
 		"start_here": "Rozpocznij tutaj",
@@ -182,6 +304,13 @@
 		},
 		"go_home": "Strona główna",
 		"go_back": "Wróć"
+	},
+	"trip_details": {
+		"route": "Trasa",
+		"no_stops": "Brak godzin odjazdów dla tego kursu.",
+		"loading": "Ładowanie szczegółów kursu...",
+		"live_vehicle": "Na żywo · pojazd {vehicleId}",
+		"collapsed_stops": "{count, plural, one {# przystanek} few {# przystanki} many {# przystanków} other {# przystanka}}"
 	},
 	"skip_to_main_content": "Przejdź do głównej treści"
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "Itinerários de Viagem",
 		"show_steps": "Mostrar passos",
 		"hide_steps": "Ocultar passos",
+		"options": "Opções",
+		"trip_options": "Opções de Viagem",
+		"cancel": "Cancelar",
+		"done": "Concluído",
+		"reset_to_defaults": "Restaurar padrões",
+		"departure_time": "Horário de Partida",
+		"departure_date": "Data de partida",
+		"leave_now": "Partir Agora",
+		"depart_at": "Partir às",
+		"arrive_by": "Chegar até",
+		"wheelchair_accessible": "Acessível para cadeira de rodas",
+		"wheelchair_desc": "Encontrar itinerários adequados para dispositivos de mobilidade e cadeiras de rodas",
+		"wheelchair": "Cadeira de rodas",
+		"route_optimization": "Otimização do Itinerário",
+		"fastest_trip": "Viagem Mais Rápida",
+		"fewest_transfers": "Menos Baldeações",
+		"stay_on_board": "Permaneça a bordo. Esta viagem continua como a Linha {route}.",
+		"walking_distance": "Distância a Pé",
+		"max_walking_distance": "Distância máxima a pé",
 		"distance_unit": "Unidade de distância",
 		"unit_auto": "Detectar automaticamente",
 		"unit_metric": "Métrico (km, m)",
-		"unit_imperial": "Imperial (mi, ft)"
+		"unit_imperial": "Imperial (mi, ft)",
+		"swap_locations": "Trocar os locais de origem e destino",
+		"error_code": "Código do erro",
+		"remove_recent_trip": "Remover viagem recente",
+		"recent_trip": "Usar viagem recente de {from} para {to}",
+		"recent_searches": "Buscas Recentes",
+		"recents": "Recentes",
+		"clear_all": "Limpar Tudo",
+		"request_failed": "Não foi possível conectar ao serviço de planejamento de viagens. Tente novamente.",
+		"invalid_shared_link": "Este link de viagem compartilhado parece inválido. Tente planejar a viagem novamente."
 	},
 	"tabs": {
 		"stops-and-stations": "Paradas e Estações",
 		"plan_trip": "Planejar uma Viagem"
+	},
+	"favorites": {
+		"title": "Favoritos",
+		"add": "Adicionar aos favoritos",
+		"remove": "Remover dos favoritos",
+		"clear_all": "Limpar Tudo",
+		"open_panel": "Abrir favoritos",
+		"close_panel": "Fechar favoritos",
+		"empty": "Nenhum favorito ainda. Toque na estrela de uma parada ou linha para salvá-la aqui.",
+		"stop_code": "Código",
+		"open_item": "Abrir {name}",
+		"remove_item": "Remover {name} dos favoritos"
 	},
 	"search": {
 		"placeholder": "Buscar paradas, linhas e locais",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "para ver a lista de linhas disponíveis",
 		"search_for_routes": "Buscar linhas...",
 		"no_routes_found": "Nenhuma linha encontrada",
-		"all_routes": "Todas as Linhas"
+		"all_routes": "Todas as Linhas",
+		"clear": "Limpar",
+		"collapse": "Recolher busca"
+	},
+	"sheet": {
+		"close": "Fechar",
+		"resize_handle": "Redimensionar painel",
+		"snap_full": "Altura total",
+		"snap_half": "Meia altura",
+		"snap_peek": "Recolhido"
+	},
+	"survey": {
+		"required_question": "Pergunta obrigatória",
+		"required_answer": "Esta pergunta é obrigatória.",
+		"expand": "Mostrar pergunta",
+		"collapse": "Ocultar pergunta",
+		"dismiss": "Dispensar pesquisa",
+		"submit": "Enviar",
+		"next": "Avançar",
+		"submit_failed": "Não foi possível enviar sua resposta. Tente novamente."
 	},
 	"header": {
 		"home": "Início",
@@ -88,13 +147,26 @@
 		"close": "Fechar"
 	},
 	"arrivals_and_departures": "Chegadas e partidas",
+	"show_more": "Mostrar mais",
+	"show_less": "Mostrar menos",
 	"load_more_arrivals": "Carregar mais chegadas",
+	"refresh": "Atualizar",
 	"no_arrivals_found_in_next_minutes": "Nenhuma chegada encontrada nos próximos {minutes} minutos",
 	"no_more_arrivals_in_next_minutes": "Nenhuma chegada adicional nos próximos {minutes} minutos",
 	"stop": "Parada",
+	"direction_bound": "Sentido {direction}",
 	"routes": "Linhas",
 	"route": "linha",
 	"route_modal_title": "Linha {name}",
+	"notifications": {
+		"route_load_failed": "Não foi possível carregar esta linha.",
+		"route_shape_failed": "Não foi possível desenhar esta linha no mapa.",
+		"route_shape_partial": "Não foi possível desenhar parte desta linha. Pode faltar um trecho no mapa.",
+		"favorite_saved": "Salvo nos favoritos.",
+		"favorite_removed": "Removido dos favoritos.",
+		"tap_to_retry": "Toque para tentar novamente.",
+		"dismiss": "Dispensar"
+	},
 	"loading": "Carregando",
 	"arrives": "chega",
 	"NA": "N/D",
@@ -105,13 +177,16 @@
 		"secs": "segs",
 		"min": "min",
 		"mins": "mins",
-		"minutes": "minutos"
+		"minutes": "minutos",
+		"min_compact": "{n} min"
 	},
 	"vehicle": {
 		"number": "Veículo nº",
 		"data_updated": "Dados atualizados",
 		"no_real_time_data": "Não temos dados em tempo real para este veículo no momento.",
-		"next_stop": "Próxima parada:"
+		"next_stop": "Próxima parada:",
+		"label": "Veículo",
+		"to_headsign": "Veículo com destino a {headsign}"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "Chegadas e Partidas"
@@ -150,18 +225,61 @@
 		"no_description": "Nenhuma descrição detalhada disponível para este alerta",
 		"page": "Página",
 		"show": "Mostrar",
-		"hide": "Ocultar"
+		"hide": "Ocultar",
+		"open_alert": "Abrir detalhes do alerta de serviço ({severity}): {summary}",
+		"affects_this_stop": "Afeta esta parada",
+		"other_alerts": "Outros alertas",
+		"severity_severe": "Grave",
+		"severity_warning": "Atenção",
+		"severity_info": "Info",
+		"cause": "Causa",
+		"effect": "Efeito",
+		"active": "Ativo",
+		"active_until": "Até {date}",
+		"active_from": "A partir de {date}",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "Desconhecida",
+		"cause_other": "Outra",
+		"cause_technical": "Problema técnico",
+		"cause_strike": "Greve",
+		"cause_demonstration": "Manifestação",
+		"cause_accident": "Acidente",
+		"cause_holiday": "Feriado",
+		"cause_weather": "Condições climáticas",
+		"cause_maintenance": "Manutenção",
+		"cause_construction": "Obras",
+		"cause_police": "Ação policial",
+		"cause_medical": "Emergência médica",
+		"cause_equipment": "Problema de equipamento",
+		"cause_environment": "Condições ambientais",
+		"cause_personnel": "Problema de pessoal",
+		"cause_miscellaneous": "Motivos diversos",
+		"cause_security": "Alerta de segurança",
+		"effect_no_service": "Sem serviço",
+		"effect_reduced_service": "Serviço reduzido",
+		"effect_significant_delays": "Atrasos significativos",
+		"effect_detour": "Desvio",
+		"effect_additional_service": "Serviço adicional",
+		"effect_modified_service": "Serviço modificado",
+		"effect_other": "Outro efeito",
+		"effect_unknown": "Efeito desconhecido",
+		"effect_stop_moved": "Parada transferida",
+		"effect_no_effect": "Sem efeito",
+		"effect_accessibility": "Problema de acessibilidade"
 	},
 	"view_stop_information": "Ver Informações da Parada",
 	"stop_details": {
-		"view_details": "Ver Detalhes"
+		"view_details": "Ver Detalhes",
+		"stop_info": "Informações da Parada"
 	},
 	"language_switcher": {
 		"select_language": "Selecionar idioma: {language}",
 		"available_languages": "Idiomas disponíveis"
 	},
 	"map": {
-		"find_my_location": "Encontrar minha localização"
+		"find_my_location": "Encontrar minha localização",
+		"routes_shown": "Linhas exibidas",
+		"live_vehicle_count": "{count} em tempo real"
 	},
 	"context-menu": {
 		"start_here": "Começar aqui",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "Ir para o início",
 		"go_back": "Voltar"
+	},
+	"trip_details": {
+		"route": "Linha",
+		"no_stops": "Nenhum horário de parada disponível para esta viagem.",
+		"loading": "Carregando detalhes da viagem...",
+		"live_vehicle": "Em tempo real · veículo {vehicleId}",
+		"collapsed_stops": "{count, plural, one {# parada} other {# paradas}}"
 	},
 	"skip_to_main_content": "Pular para o conteúdo principal"
 }

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "Варианты маршрута",
 		"show_steps": "Показать шаги",
 		"hide_steps": "Скрыть шаги",
+		"options": "Параметры",
+		"trip_options": "Параметры поездки",
+		"cancel": "Отмена",
+		"done": "Готово",
+		"reset_to_defaults": "Сбросить настройки",
+		"departure_time": "Время отправления",
+		"departure_date": "Дата отправления",
+		"leave_now": "Отправиться сейчас",
+		"depart_at": "Отправиться в указанное время",
+		"arrive_by": "Прибыть к указанному времени",
+		"wheelchair_accessible": "Доступно для инвалидных колясок",
+		"wheelchair_desc": "Искать маршруты, подходящие для инвалидных колясок и других средств передвижения",
+		"wheelchair": "Коляска",
+		"route_optimization": "Оптимизация маршрута",
+		"fastest_trip": "Самая быстрая поездка",
+		"fewest_transfers": "Минимум пересадок",
+		"stay_on_board": "Оставайтесь в салоне. Этот рейс продолжается как маршрут {route}.",
+		"walking_distance": "Расстояние пешком",
+		"max_walking_distance": "Максимальное расстояние пешком",
 		"distance_unit": "Единица измерения расстояния",
 		"unit_auto": "Определить автоматически",
 		"unit_metric": "Метрическая (км, м)",
-		"unit_imperial": "Имперская (mi, ft)"
+		"unit_imperial": "Имперская (mi, ft)",
+		"swap_locations": "Поменять местами «Откуда» и «Куда»",
+		"error_code": "Код ошибки",
+		"remove_recent_trip": "Удалить недавнюю поездку",
+		"recent_trip": "Использовать недавнюю поездку из «{from}» в «{to}»",
+		"recent_searches": "Недавние запросы",
+		"recents": "Недавние",
+		"clear_all": "Очистить всё",
+		"request_failed": "Не удалось связаться со службой планирования поездок. Пожалуйста, попробуйте ещё раз.",
+		"invalid_shared_link": "Похоже, эта ссылка на поездку повреждена. Попробуйте спланировать поездку заново."
 	},
 	"tabs": {
 		"stops-and-stations": "Остановки и станции",
 		"plan_trip": "Спланировать поездку"
+	},
+	"favorites": {
+		"title": "Избранное",
+		"add": "Добавить в избранное",
+		"remove": "Удалить из избранного",
+		"clear_all": "Очистить всё",
+		"open_panel": "Открыть избранное",
+		"close_panel": "Закрыть избранное",
+		"empty": "В избранном пока пусто. Нажмите на звёздочку у остановки или маршрута, чтобы добавить их сюда.",
+		"stop_code": "Код",
+		"open_item": "Открыть «{name}»",
+		"remove_item": "Удалить «{name}» из избранного"
 	},
 	"search": {
 		"placeholder": "Поиск остановок, маршрутов и мест",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "для списка доступных маршрутов",
 		"search_for_routes": "Поиск маршрутов...",
 		"no_routes_found": "Маршруты не найдены",
-		"all_routes": "Все маршруты"
+		"all_routes": "Все маршруты",
+		"clear": "Очистить",
+		"collapse": "Свернуть поиск"
+	},
+	"sheet": {
+		"close": "Закрыть",
+		"resize_handle": "Изменить размер панели",
+		"snap_full": "Полная высота",
+		"snap_half": "Половина высоты",
+		"snap_peek": "Свёрнуто"
+	},
+	"survey": {
+		"required_question": "Обязательный вопрос",
+		"required_answer": "Ответ на этот вопрос обязателен.",
+		"expand": "Показать вопрос",
+		"collapse": "Скрыть вопрос",
+		"dismiss": "Закрыть опрос",
+		"submit": "Отправить",
+		"next": "Далее",
+		"submit_failed": "Не удалось отправить ответ. Пожалуйста, попробуйте ещё раз."
 	},
 	"header": {
 		"home": "Главная",
@@ -88,13 +147,26 @@
 		"close": "Закрыть"
 	},
 	"arrivals_and_departures": "Прибытие и отправление",
+	"show_more": "Показать больше",
+	"show_less": "Показать меньше",
 	"load_more_arrivals": "Загрузить больше прибытий",
+	"refresh": "Обновить",
 	"no_arrivals_found_in_next_minutes": "Нет прибытий в ближайшие {minutes} минут",
 	"no_more_arrivals_in_next_minutes": "Нет больше прибытий в ближайшие {minutes} минут",
 	"stop": "Остановка",
+	"direction_bound": "Направление {direction}",
 	"routes": "Маршруты",
 	"route": "маршрут",
 	"route_modal_title": "Маршрут {name}",
+	"notifications": {
+		"route_load_failed": "Не удалось загрузить маршрут.",
+		"route_shape_failed": "Не удалось отобразить маршрут на карте.",
+		"route_shape_partial": "Часть маршрута не удалось отобразить. На карте может не хватать участка.",
+		"favorite_saved": "Добавлено в избранное.",
+		"favorite_removed": "Удалено из избранного.",
+		"tap_to_retry": "Нажмите, чтобы повторить.",
+		"dismiss": "Закрыть"
+	},
 	"loading": "Загрузка",
 	"arrives": "прибывает",
 	"NA": "Н/Д",
@@ -105,13 +177,16 @@
 		"secs": "сек",
 		"min": "мин",
 		"mins": "мин",
-		"minutes": "минут"
+		"minutes": "минут",
+		"min_compact": "{n} мин"
 	},
 	"vehicle": {
 		"number": "Транспорт №",
 		"data_updated": "Данные обновлены",
 		"no_real_time_data": "Данные в реальном времени для этого транспорта сейчас недоступны.",
-		"next_stop": "Следующая остановка:"
+		"next_stop": "Следующая остановка:",
+		"label": "Транспорт",
+		"to_headsign": "Транспорт до «{headsign}»"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "Прибытие и отправление"
@@ -150,18 +225,61 @@
 		"no_description": "Подробное описание для этого оповещения недоступно",
 		"page": "Страница",
 		"show": "Показать",
-		"hide": "Скрыть"
+		"hide": "Скрыть",
+		"open_alert": "Открыть подробности оповещения ({severity}): {summary}",
+		"affects_this_stop": "Касается этой остановки",
+		"other_alerts": "Другие оповещения",
+		"severity_severe": "Серьёзное",
+		"severity_warning": "Предупреждение",
+		"severity_info": "Информация",
+		"cause": "Причина",
+		"effect": "Последствие",
+		"active": "Действует",
+		"active_until": "До {date}",
+		"active_from": "С {date}",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "Неизвестно",
+		"cause_other": "Другое",
+		"cause_technical": "Техническая проблема",
+		"cause_strike": "Забастовка",
+		"cause_demonstration": "Демонстрация",
+		"cause_accident": "Авария",
+		"cause_holiday": "Праздник",
+		"cause_weather": "Погода",
+		"cause_maintenance": "Техобслуживание",
+		"cause_construction": "Строительные работы",
+		"cause_police": "Действия полиции",
+		"cause_medical": "Неотложная медицинская помощь",
+		"cause_equipment": "Оборудование",
+		"cause_environment": "Окружающая среда",
+		"cause_personnel": "Персонал",
+		"cause_miscellaneous": "Прочее",
+		"cause_security": "Угроза безопасности",
+		"effect_no_service": "Нет движения",
+		"effect_reduced_service": "Сокращённое движение",
+		"effect_significant_delays": "Значительные задержки",
+		"effect_detour": "Объезд",
+		"effect_additional_service": "Дополнительные рейсы",
+		"effect_modified_service": "Изменённое движение",
+		"effect_other": "Другое последствие",
+		"effect_unknown": "Неизвестное последствие",
+		"effect_stop_moved": "Остановка перенесена",
+		"effect_no_effect": "Без последствий",
+		"effect_accessibility": "Проблема с доступностью"
 	},
 	"view_stop_information": "Информация об остановке",
 	"stop_details": {
-		"view_details": "Подробнее"
+		"view_details": "Подробнее",
+		"stop_info": "Об остановке"
 	},
 	"language_switcher": {
 		"select_language": "Выберите язык: {language}",
 		"available_languages": "Доступные языки"
 	},
 	"map": {
-		"find_my_location": "Найти моё местоположение"
+		"find_my_location": "Найти моё местоположение",
+		"routes_shown": "Маршруты на карте",
+		"live_vehicle_count": "{count} онлайн"
 	},
 	"context-menu": {
 		"start_here": "Начать отсюда",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "На главную",
 		"go_back": "Назад"
+	},
+	"trip_details": {
+		"route": "Маршрут",
+		"no_stops": "Для этого рейса нет расписания по остановкам.",
+		"loading": "Загрузка информации о рейсе...",
+		"live_vehicle": "Онлайн · транспорт №{vehicleId}",
+		"collapsed_stops": "{count, plural, one {# остановка} few {# остановки} many {# остановок} other {# остановки}}"
 	},
 	"skip_to_main_content": "Перейти к основному содержимому"
 }

--- a/src/locales/sm.json
+++ b/src/locales/sm.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "Lisi o Malaga",
 		"show_steps": "Faʻaali laasaga",
 		"hide_steps": "Natia laasaga",
+		"options": "Filifiliga",
+		"trip_options": "Filifiliga o le Malaga",
+		"cancel": "Toe foʻi",
+		"done": "Maeʻa",
+		"reset_to_defaults": "Toe faʻafoʻi i tulaga masani",
+		"departure_time": "Taimi e Alu Ese ai",
+		"departure_date": "Aso e alu ese ai",
+		"leave_now": "Alu Ese Nei",
+		"depart_at": "Alu Ese i le Taimi",
+		"arrive_by": "Taunuʻu i le Taimi",
+		"wheelchair_accessible": "Avanoa mo nofoa faʻataʻavalevale",
+		"wheelchair_desc": "Saili auala e talafeagai mo masini fesoasoani i le femalagaaʻi ma nofoa faʻataʻavalevale",
+		"wheelchair": "Nofoa faʻataʻavalevale",
+		"route_optimization": "Filifiliga o le Auala",
+		"fastest_trip": "Malaga Sili ona Vave",
+		"fewest_transfers": "Suiga Sili ona Itiiti",
+		"stay_on_board": "Nofo pea i luga o le taʻavale. E faʻaauau lenei malaga o le Auala {route}.",
+		"walking_distance": "Mamao e Savali ai",
+		"max_walking_distance": "Mamao sili e savali ai",
 		"distance_unit": "Iunite o le Mamao",
 		"unit_auto": "Otometi su'esu'e",
 		"unit_metric": "Metiriki (km, m)",
-		"unit_imperial": "Emepaea (mi, ft)"
+		"unit_imperial": "Emepaea (mi, ft)",
+		"swap_locations": "Fesuiaʻi le nofoaga amata ma le nofoaga faʻaiʻu",
+		"error_code": "Numera o le mea sese",
+		"remove_recent_trip": "Aveʻese le malaga talu ai nei",
+		"recent_trip": "Faʻaaoga le malaga talu ai nei mai {from} i {to}",
+		"recent_searches": "Sailiga Talu Ai Nei",
+		"recents": "Talu Ai Nei",
+		"clear_all": "Tapeʻe Uma",
+		"request_failed": "E leʻi mafai ona faʻafesoʻotaʻi le auaunaga fuafua malaga. Faʻamolemole toe taumafai.",
+		"invalid_shared_link": "E foliga mai ua leaga lenei soʻotaga malaga na faʻasoa mai. Taumafai e toe fuafua le malaga."
 	},
 	"tabs": {
 		"stops-and-stations": "Nofoaga Taofi ma Fale Taʻavale",
 		"plan_trip": "Fuafua se Malaga"
+	},
+	"favorites": {
+		"title": "Mea Pele",
+		"add": "Faʻaopoopo i mea pele",
+		"remove": "Aveʻese mai mea pele",
+		"clear_all": "Tapeʻe Uma",
+		"open_panel": "Tatala mea pele",
+		"close_panel": "Tapuni mea pele",
+		"empty": "E leai lava ni mea pele. Paʻi i le fetu i luga o se nofoaga taofi po o se auala e teu ai iinei.",
+		"stop_code": "Numera",
+		"open_item": "Tatala {name}",
+		"remove_item": "Aveʻese {name} mai mea pele"
 	},
 	"search": {
 		"placeholder": "Saili mo nofoaga taofi, auala, ma nofoaga",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "mo se lisi o auala o loʻo avanoa",
 		"search_for_routes": "Saili mo auala...",
 		"no_routes_found": "E leai ni auala na maua",
-		"all_routes": "Auala Uma"
+		"all_routes": "Auala Uma",
+		"clear": "Tapeʻe",
+		"collapse": "Faʻapuupuu le sailiga"
+	},
+	"sheet": {
+		"close": "Tapuni",
+		"resize_handle": "Suia le tele o le vaega",
+		"snap_full": "Maualuga atoa",
+		"snap_half": "Afa o le maualuga",
+		"snap_peek": "Faʻapuupuuina"
+	},
+	"survey": {
+		"required_question": "Fesili e manaʻomia",
+		"required_answer": "E manaʻomia se tali i lenei fesili.",
+		"expand": "Faʻaali le fesili",
+		"collapse": "Natia le fesili",
+		"dismiss": "Tapuni le suʻesuʻega",
+		"submit": "Lafo",
+		"next": "Sosoo",
+		"submit_failed": "E leʻi mafai ona lafo lau tali. Faʻamolemole toe taumafai."
 	},
 	"header": {
 		"home": "Aiga",
@@ -88,13 +147,26 @@
 		"close": "Tapuni"
 	},
 	"arrivals_and_departures": "Taunuʻuga ma alu atu",
+	"show_more": "Faʻaali atili",
+	"show_less": "Faʻaali itiiti",
 	"load_more_arrivals": "Utaina atili taunuʻuga",
+	"refresh": "Faʻafou",
 	"no_arrivals_found_in_next_minutes": "E leai ni taunuʻuga na maua i le {minutes} minute o loʻo sosoo",
 	"no_more_arrivals_in_next_minutes": "Leai ni taunuʻuga faaopoopo i le {minutes} minute o loʻo sosoo",
 	"stop": "Nofoaga Taofi",
+	"direction_bound": "Agaʻi i {direction}",
 	"routes": "Auala",
 	"route": "auala",
 	"route_modal_title": "Auala {name}",
+	"notifications": {
+		"route_load_failed": "E leʻi mafai ona utaina lenei auala.",
+		"route_shape_failed": "E leʻi mafai ona tusia lenei auala i le faʻafanua.",
+		"route_shape_partial": "E leʻi mafai ona tusia se vaega o lenei auala. Atonu o loʻo misi se vaega i le faʻafanua.",
+		"favorite_saved": "Ua teu i mea pele.",
+		"favorite_removed": "Ua aveʻese mai mea pele.",
+		"tap_to_retry": "Paʻi e toe taumafai.",
+		"dismiss": "Tapuni"
+	},
 	"loading": "O loʻo utaina",
 	"arrives": "taunuʻu",
 	"NA": "Leai",
@@ -105,13 +177,16 @@
 		"secs": "sek",
 		"min": "min",
 		"mins": "min",
-		"minutes": "minute"
+		"minutes": "minute",
+		"min_compact": "{n} min"
 	},
 	"vehicle": {
 		"number": "Taʻavale #",
 		"data_updated": "Faʻamatalaga faʻafouina",
 		"no_real_time_data": "E leai ni faʻamatalaga taimi moni mo lenei taʻavale i le taimi nei.",
-		"next_stop": "Nofoaga taofi e sosoo ai:"
+		"next_stop": "Nofoaga taofi e sosoo ai:",
+		"label": "Taʻavale",
+		"to_headsign": "Taʻavale i {headsign}"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "Taunuʻuga ma Alu Atu"
@@ -150,18 +225,61 @@
 		"no_description": "E leai se faʻamatalaga auiliili o loʻo avanoa mo lenei lapataiga",
 		"page": "Itulau",
 		"show": "Faʻaali",
-		"hide": "Natia"
+		"hide": "Natia",
+		"open_alert": "Tatala auiliiliga o le lapataiga o le auaunaga ({severity}): {summary}",
+		"affects_this_stop": "E aʻafia ai lenei nofoaga taofi",
+		"other_alerts": "Isi lapataiga",
+		"severity_severe": "Ogaoga",
+		"severity_warning": "Faʻaeteete",
+		"severity_info": "Faʻamatalaga",
+		"cause": "Mafuaʻaga",
+		"effect": "Aʻafiaga",
+		"active": "Taimi e aoga ai",
+		"active_until": "Seʻia oʻo i le {date}",
+		"active_from": "Mai le {date}",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "E le iloa",
+		"cause_other": "Isi",
+		"cause_technical": "Faʻafitauli faʻatekinisi",
+		"cause_strike": "Teteʻe a le aufaigaluega",
+		"cause_demonstration": "Faʻaaliga teteʻe",
+		"cause_accident": "Faʻalavelave faʻafuaseʻi",
+		"cause_holiday": "Aso malolo",
+		"cause_weather": "Tau",
+		"cause_maintenance": "Tausiga",
+		"cause_construction": "Fausiaga",
+		"cause_police": "Gaoioiga a leoleo",
+		"cause_medical": "Faʻalavelave faʻafomaʻi",
+		"cause_equipment": "Meafaigaluega",
+		"cause_environment": "Siʻosiʻomaga",
+		"cause_personnel": "Aufaigaluega",
+		"cause_miscellaneous": "Mea eseese",
+		"cause_security": "Lapataiga o le saogalemu",
+		"effect_no_service": "Leai se auaunaga",
+		"effect_reduced_service": "Auaunaga ua faʻaitiitia",
+		"effect_significant_delays": "Tuai tetele",
+		"effect_detour": "Liliuga o le auala",
+		"effect_additional_service": "Auaunaga faʻaopoopo",
+		"effect_modified_service": "Auaunaga ua suia",
+		"effect_other": "Isi aʻafiaga",
+		"effect_unknown": "Aʻafiaga e le iloa",
+		"effect_stop_moved": "Ua siʻitia le nofoaga taofi",
+		"effect_no_effect": "Leai se aʻafiaga",
+		"effect_accessibility": "Faʻafitauli i le avanoa faigofie"
 	},
 	"view_stop_information": "Vaʻai Faʻamatalaga o le Nofoaga Taofi",
 	"stop_details": {
-		"view_details": "Vaʻai Faʻamatalaga"
+		"view_details": "Vaʻai Faʻamatalaga",
+		"stop_info": "Faʻamatalaga o le Nofoaga Taofi"
 	},
 	"language_switcher": {
 		"select_language": "Filifili gagana: {language}",
 		"available_languages": "Gagana avanoa"
 	},
 	"map": {
-		"find_my_location": "Su'e Lo'u Nofoaga"
+		"find_my_location": "Su'e Lo'u Nofoaga",
+		"routes_shown": "Auala o loʻo faʻaalia",
+		"live_vehicle_count": "{count} taʻavale i le taimi moni"
 	},
 	"context-menu": {
 		"start_here": "Amata mai iinei",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "Toe fo'i i le amataga",
 		"go_back": "Toe fo'i i tua"
+	},
+	"trip_details": {
+		"route": "Auala",
+		"no_stops": "E leai ni taimi o nofoaga taofi o loʻo avanoa mo lenei malaga.",
+		"loading": "O loʻo utaina faʻamatalaga o le malaga...",
+		"live_vehicle": "Taimi moni · taʻavale {vehicleId}",
+		"collapsed_stops": "{count, plural, one {# nofoaga taofi} other {# nofoaga taofi}}"
 	},
 	"skip_to_main_content": "Alu i le mea autu"
 }

--- a/src/locales/sm.json
+++ b/src/locales/sm.json
@@ -32,7 +32,7 @@
 		"hide_steps": "Natia laasaga",
 		"options": "Filifiliga",
 		"trip_options": "Filifiliga o le Malaga",
-		"cancel": "Toe foʻi",
+		"cancel": "Faʻaleaoga",
 		"done": "Maeʻa",
 		"reset_to_defaults": "Toe faʻafoʻi i tulaga masani",
 		"departure_time": "Taimi e Alu Ese ai",

--- a/src/locales/so.json
+++ b/src/locales/so.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "Jadwalka safarada",
 		"show_steps": "Muuji tillaabooyinka",
 		"hide_steps": "Qari tillaabooyinka",
+		"options": "Ikhtiyaarada",
+		"trip_options": "Ikhtiyaarada safarka",
+		"cancel": "Jooji",
+		"done": "Dhammee",
+		"reset_to_defaults": "Dib ugu celi sida caadiga ah",
+		"departure_time": "Waqtiga bixitaanka",
+		"departure_date": "Taariikhda bixitaanka",
+		"leave_now": "Hadda bax",
+		"depart_at": "Bax waqtigan",
+		"arrive_by": "Imow ka hor",
+		"wheelchair_accessible": "Ku habboon kursiga naafada",
+		"wheelchair_desc": "Raadi waddooyin ku habboon qalabka caawimaadda socodka iyo kuraasta naafada",
+		"wheelchair": "Kursi naafo",
+		"route_optimization": "Doorbidka waddada",
+		"fastest_trip": "Safarka ugu dhaqsaha badan",
+		"fewest_transfers": "Beddelaadda ugu yar",
+		"stay_on_board": "Gaariga ku sii jir. Safarkan wuxuu ku sii socdaa Waddada {route}.",
+		"walking_distance": "Masaafada socodka",
+		"max_walking_distance": "Masaafada socodka ee ugu badan",
 		"distance_unit": "Halbeegga Masaafada",
 		"unit_auto": "Si toos ah u ogaado",
 		"unit_metric": "Mitrik (km, m)",
-		"unit_imperial": "Imbiriyaal (mi, ft)"
+		"unit_imperial": "Imbiriyaal (mi, ft)",
+		"swap_locations": "Is-weydaarso goobaha laga bilaabo iyo loo socdo",
+		"error_code": "Koodhka qaladka",
+		"remove_recent_trip": "Ka saar safarkii dhowaa",
+		"recent_trip": "Isticmaal safarkii dhowaa ee laga bilaabo {from} ilaa {to}",
+		"recent_searches": "Raadinnadii dhowaa",
+		"recents": "Kuwii dhowaa",
+		"clear_all": "Nadiifi dhammaan",
+		"request_failed": "Lama gaadhi karin adeegga qorshaynta safarka. Fadlan mar kale isku day.",
+		"invalid_shared_link": "Xiriirkan safarka la wadaagay ma shaqaynayo. Isku day inaad safarka mar kale qorshayso."
 	},
 	"tabs": {
 		"stops-and-stations": "Joogsiyada iyo saldhigyada",
 		"plan_trip": "Qorshee safarka"
+	},
+	"favorites": {
+		"title": "Kuwa aad jeceshahay",
+		"add": "Ku dar kuwa aad jeceshahay",
+		"remove": "Ka saar kuwa aad jeceshahay",
+		"clear_all": "Nadiifi dhammaan",
+		"open_panel": "Fur kuwa aad jeceshahay",
+		"close_panel": "Xidh kuwa aad jeceshahay",
+		"empty": "Weli waxba lama kaydin. Taabo xiddigta joogsi ama waddo si aad halkan ugu kaydsato.",
+		"stop_code": "Koodh",
+		"open_item": "Fur {name}",
+		"remove_item": "{name} ka saar kuwa aad jeceshahay"
 	},
 	"search": {
 		"placeholder": "Raadi joogsiyo, wadooyin iyo meelo",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "si aad u aragto liiska waddooyinka la heli karo",
 		"search_for_routes": "Raadi wadooyin...",
 		"no_routes_found": "Wax waddo ah lama helin",
-		"all_routes": "Dhammaan wadooyinka"
+		"all_routes": "Dhammaan wadooyinka",
+		"clear": "Nadiifi",
+		"collapse": "Laabo raadinta"
+	},
+	"sheet": {
+		"close": "Xidh",
+		"resize_handle": "Beddel cabbirka daaqadda",
+		"snap_full": "Dhererka buuxa",
+		"snap_half": "Nuska dhererka",
+		"snap_peek": "La laabay"
+	},
+	"survey": {
+		"required_question": "Su'aal khasab ah",
+		"required_answer": "Su'aashan waa khasab.",
+		"expand": "Muuji su'aasha",
+		"collapse": "Qari su'aasha",
+		"dismiss": "Iska dhaaf sahanka",
+		"submit": "Gudbi",
+		"next": "Xiga",
+		"submit_failed": "Jawaabtaada lama diri karin. Fadlan mar kale isku day."
 	},
 	"header": {
 		"home": "Bogga Hore",
@@ -88,13 +147,26 @@
 		"close": "Xidh"
 	},
 	"arrivals_and_departures": "Imaatinka iyo baxsashada",
+	"show_more": "Muuji wax dheeraad ah",
+	"show_less": "Muuji wax yar",
 	"load_more_arrivals": "Soo rar imaatinno dheeraad ah",
+	"refresh": "Cusbooneysii",
 	"no_arrivals_found_in_next_minutes": "Lama helin soo gaadhis {minutes} daqiiqo ee soo socda",
 	"no_more_arrivals_in_next_minutes": "Ma jiraan soo gaadhis dheeraad ah {minutes} daqiiqo ee soo socda",
 	"stop": "Joogsi",
+	"direction_bound": "Jihada {direction}",
 	"routes": "Jidadka",
 	"route": "Jidka",
 	"route_modal_title": "Jidka {name}",
+	"notifications": {
+		"route_load_failed": "Waddadan lama soo rari karin.",
+		"route_shape_failed": "Waddadan laguma sawiri karin khariidadda.",
+		"route_shape_partial": "Qayb ka mid ah waddadan lama sawiri karin. Khariidadda waxaa laga yaabaa inay qayb ka maqan tahay.",
+		"favorite_saved": "Waxaa lagu kaydiyay kuwa aad jeceshahay.",
+		"favorite_removed": "Waxaa laga saaray kuwa aad jeceshahay.",
+		"tap_to_retry": "Taabo si aad mar kale isugu daydo.",
+		"dismiss": "Iska dhaaf"
+	},
 	"loading": "Shaqeynaya",
 	"arrives": "imaataa",
 	"NA": "M/Q",
@@ -105,13 +177,16 @@
 		"secs": "secs",
 		"min": "min",
 		"mins": "mins",
-		"minutes": "minutes"
+		"minutes": "minutes",
+		"min_compact": "{n} daq"
 	},
 	"vehicle": {
 		"number": "Gaari #",
 		"data_updated": "Xogta waa la cusbooneysiiyay",
 		"no_real_time_data": "Ma hayno xog ku saabsan wakhtiga dhabta ah ee gaarigan hadda.",
-		"next_stop": "Joogsiga xiga:"
+		"next_stop": "Joogsiga xiga:",
+		"label": "Gaari",
+		"to_headsign": "Gaariga u socda {headsign}"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "Imaanshaha iyo Bixitaanka"
@@ -150,18 +225,61 @@
 		"no_description": "Sharax faahfaahsan ma jiro ogeysiiskan",
 		"page": "Bogga",
 		"show": "Muujin",
-		"hide": "Qari"
+		"hide": "Qari",
+		"open_alert": "Fur faahfaahinta ogeysiiska adeegga ee heerka {severity}: {summary}",
+		"affects_this_stop": "Kuwa saameeya joogsigan",
+		"other_alerts": "Ogeysiisyo kale",
+		"severity_severe": "Daran",
+		"severity_warning": "Digniin",
+		"severity_info": "Macluumaad",
+		"cause": "Sababta",
+		"effect": "Saamaynta",
+		"active": "Firfircoon",
+		"active_until": "Ilaa {date}",
+		"active_from": "Laga bilaabo {date}",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "Lama garanayo",
+		"cause_other": "Kale",
+		"cause_technical": "Cillad farsamo",
+		"cause_strike": "Shaqo-joojin",
+		"cause_demonstration": "Bannaanbax",
+		"cause_accident": "Shil",
+		"cause_holiday": "Fasax",
+		"cause_weather": "Cimilo",
+		"cause_maintenance": "Dayactir",
+		"cause_construction": "Dhismo",
+		"cause_police": "Howlgal booliis",
+		"cause_medical": "Xaalad caafimaad oo degdeg ah",
+		"cause_equipment": "Qalab",
+		"cause_environment": "Deegaan",
+		"cause_personnel": "Shaqaale",
+		"cause_miscellaneous": "Kala duwan",
+		"cause_security": "Digniin ammaan",
+		"effect_no_service": "Adeeg ma jiro",
+		"effect_reduced_service": "Adeeg la yareeyay",
+		"effect_significant_delays": "Daahitaan weyn",
+		"effect_detour": "Wareeg",
+		"effect_additional_service": "Adeeg dheeraad ah",
+		"effect_modified_service": "Adeeg la beddelay",
+		"effect_other": "Saamayn kale",
+		"effect_unknown": "Saamayn aan la garanayn",
+		"effect_stop_moved": "Joogsi la wareejiyay",
+		"effect_no_effect": "Saamayn ma leh",
+		"effect_accessibility": "Cillad marin u helidda"
 	},
 	"view_stop_information": "Eeg macluumaadka joogsiga",
 	"stop_details": {
-		"view_details": "Eeg faahfaahinta"
+		"view_details": "Eeg faahfaahinta",
+		"stop_info": "Macluumaadka joogsiga"
 	},
 	"language_switcher": {
 		"select_language": "Dooro luuqadda: {language}",
 		"available_languages": "Luuqadaha la heli karo"
 	},
 	"map": {
-		"find_my_location": "Raadi Goobteeyda"
+		"find_my_location": "Raadi Goobteeyda",
+		"routes_shown": "Waddooyinka la muujiyay",
+		"live_vehicle_count": "{count} toos ah"
 	},
 	"context-menu": {
 		"start_here": "Halkan ka bilow",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "Aad guriga",
 		"go_back": "Ku noqo"
+	},
+	"trip_details": {
+		"route": "Waddo",
+		"no_stops": "Waqtiyo joogsi lama heli karo safarkan.",
+		"loading": "Faahfaahinta safarka waa la soo rarayaa...",
+		"live_vehicle": "Toos ah · gaariga {vehicleId}",
+		"collapsed_stops": "{count, plural, one {# joogsi} other {# joogsi}}"
 	},
 	"skip_to_main_content": "U bood waxa muhiimka ah"
 }

--- a/src/locales/ti.json
+++ b/src/locales/ti.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "መስመራት መገሻ",
 		"show_steps": "ስጉምትታት ኣርኢ",
 		"hide_steps": "ስጉምትታት ሕባእ",
+		"options": "ኣማራጺታት",
+		"trip_options": "ኣማራጺታት መገሻ",
+		"cancel": "ሰርዝ",
+		"done": "ወዲአ",
+		"reset_to_defaults": "ናብ ንቡር ኣቀማምጣ መልስ",
+		"departure_time": "ሰዓት ምብጋስ",
+		"departure_date": "ዕለት ምብጋስ",
+		"leave_now": "ሕጂ ተበገስ",
+		"depart_at": "ኣብዚ ሰዓት ተበገስ",
+		"arrive_by": "ክሳብዚ ሰዓት ብጻሕ",
+		"wheelchair_accessible": "ንዊልቸር ዝምችእ",
+		"wheelchair_desc": "ንመንቀሳቐሲ መሳርሒታትን ዊልቸርን ዝምችኡ መስመራት ድለ",
+		"wheelchair": "ዊልቸር",
+		"route_optimization": "ምርጫ መስመር",
+		"fastest_trip": "ዝቐልጠፈ መገሻ",
+		"fewest_transfers": "ዝወሓደ ምቕያር",
+		"stay_on_board": "ኣብ ውሽጢ ተሽከርካሪ ጽናሕ። እዚ መገሻ ከም መስመር {route} ኮይኑ ይቕጽል።",
+		"walking_distance": "ብእግሪ ዝኽየድ ርሕቀት",
+		"max_walking_distance": "ዝለዓለ ብእግሪ ዝኽየድ ርሕቀት",
 		"distance_unit": "ኣሃዱ ርሕቀት",
 		"unit_auto": "ባዕሉ ይለሊ",
 		"unit_metric": "ሜትሪክ (ኪሜ፣ ሜ)",
-		"unit_imperial": "ኢምፐርያል (ማይል፣ ጫማ)"
+		"unit_imperial": "ኢምፐርያል (ማይል፣ ጫማ)",
+		"swap_locations": "ናይ ካብን ናብን ቦታታት ቀያይር",
+		"error_code": "ኮድ ጌጋ",
+		"remove_recent_trip": "ናይ ቀረባ ግዜ መገሻ ኣወግድ",
+		"recent_trip": "ካብ {from} ናብ {to} ዝነበረ ናይ ቀረባ ግዜ መገሻ ተጠቐም",
+		"recent_searches": "ናይ ቀረባ ግዜ ድልያታት",
+		"recents": "ናይ ቀረባ ግዜ",
+		"clear_all": "ኩሉ ደምስስ",
+		"request_failed": "ናብ ኣገልግሎት ውጥን መገሻ ክንበጽሕ ኣይከኣልናን። በጃኻ ደጊምካ ፈትን።",
+		"invalid_shared_link": "እዚ ዝተማቐለ መላግቦ መገሻ ዝተበላሸወ እዩ ዝመስል። መገሻኻ ደጊምካ ውጠን።"
 	},
 	"tabs": {
 		"stops-and-stations": "መዕረፊታትን መደበራትን",
 		"plan_trip": "መገሻ ውጠን"
+	},
+	"favorites": {
+		"title": "ተፈተውቲ",
+		"add": "ናብ ተፈተውቲ ወስኽ",
+		"remove": "ካብ ተፈተውቲ ኣወግድ",
+		"clear_all": "ኩሉ ደምስስ",
+		"open_panel": "ተፈተውቲ ክፈት",
+		"close_panel": "ተፈተውቲ ዕጸው",
+		"empty": "ገና ተፈተውቲ የለዉን። ኣብ መዕረፊ ወይ መስመር ዘሎ ኮኾብ ጠዊቕካ ኣብዚ ኣቐምጦ።",
+		"stop_code": "ኮድ",
+		"open_item": "{name} ክፈት",
+		"remove_item": "{name} ካብ ተፈተውቲ ኣወግድ"
 	},
 	"search": {
 		"placeholder": "መዕረፊታት፣ መስመራትን ቦታታትን ድለ",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "ዝርዝር ዘለዉ መስመራት ንምርኣይ",
 		"search_for_routes": "መስመራት ድለ...",
 		"no_routes_found": "መስመር ኣይተረኽበን",
-		"all_routes": "ኩሎም መስመራት"
+		"all_routes": "ኩሎም መስመራት",
+		"clear": "ደምስስ",
+		"collapse": "ድልያ ጽመቕ"
+	},
+	"sheet": {
+		"close": "ዕጸው",
+		"resize_handle": "ዓቐን ናይዚ ክፍሊ ቀይር",
+		"snap_full": "ምሉእ ቁመት",
+		"snap_half": "ፍርቂ ቁመት",
+		"snap_peek": "ዝተጸመቐ"
+	},
+	"survey": {
+		"required_question": "ግድን ዝምለስ ሕቶ",
+		"required_answer": "እዚ ሕቶ ግድን ክምለስ ኣለዎ።",
+		"expand": "ሕቶ ኣርኢ",
+		"collapse": "ሕቶ ሕባእ",
+		"dismiss": "መጽናዕቲ ዕጸው",
+		"submit": "ስደድ",
+		"next": "ቀጽል",
+		"submit_failed": "መልስኻ ክስደድ ኣይከኣለን። በጃኻ ደጊምካ ፈትን።"
 	},
 	"header": {
 		"home": "መበገሲ",
@@ -88,13 +147,26 @@
 		"close": "ዕጸው"
 	},
 	"arrivals_and_departures": "ምብጻሕን ምብጋስን",
+	"show_more": "ተወሳኺ ኣርኢ",
+	"show_less": "ውሑድ ኣርኢ",
 	"load_more_arrivals": "ተወሳኺ ምብጻሓት ጽዓን",
+	"refresh": "ኣሓድስ",
 	"no_arrivals_found_in_next_minutes": "ኣብ ዝመጽእ {minutes} ደቓይቕ ዝኾነ ምብጻሕ ኣይተረኽበን",
 	"no_more_arrivals_in_next_minutes": "ኣብ ዝመጽእ {minutes} ደቓይቕ ዝኾነ ተወሳኺ ምብጻሕ የለን",
 	"stop": "መዕረፊ",
+	"direction_bound": "ናብ {direction} ዝኸይድ",
 	"routes": "መስመራት",
 	"route": "መስመር",
 	"route_modal_title": "መስመር {name}",
+	"notifications": {
+		"route_load_failed": "እዚ መስመር ክጽዓን ኣይከኣለን።",
+		"route_shape_failed": "እዚ መስመር ኣብ ካርታ ክስኣል ኣይከኣለን።",
+		"route_shape_partial": "ክፋል እዚ መስመር ክስኣል ኣይከኣለን። ኣብ ካርታ ሓደ ክፋል ጎዲሉ ክኸውን ይኽእል።",
+		"favorite_saved": "ናብ ተፈተውቲ ተቐሚጡ።",
+		"favorite_removed": "ካብ ተፈተውቲ ተኣልዩ።",
+		"tap_to_retry": "ንምድጋም ጠውቕ።",
+		"dismiss": "ዕጸው"
+	},
 	"loading": "ይጽዕን ኣሎ",
 	"arrives": "ይበጽሕ",
 	"NA": "የለን",
@@ -105,13 +177,16 @@
 		"secs": "ካልኢታት",
 		"min": "ደቂቕ",
 		"mins": "ደቃይቕ",
-		"minutes": "ደቃይቕ"
+		"minutes": "ደቃይቕ",
+		"min_compact": "{n} ደቂቕ"
 	},
 	"vehicle": {
 		"number": "ተሽከርካሪ #",
 		"data_updated": "ሓበሬታ ተሓዲሱ",
 		"no_real_time_data": "ብቐጥታ ዝኾነ ሓበሬታ ናይዚ ተሽከርካሪ ሕጂ የብልናን።",
-		"next_stop": "ዝስዕብ መዕረፊ:"
+		"next_stop": "ዝስዕብ መዕረፊ:",
+		"label": "ተሽከርካሪ",
+		"to_headsign": "ናብ {headsign} ዝኸይድ ተሽከርካሪ"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "ምብጻሕን ምብጋስን"
@@ -150,18 +225,61 @@
 		"no_description": "ንዚ ምልክታ ዝርዝር መግለጺ የለን",
 		"page": "ገጽ",
 		"show": "ኣርኢ",
-		"hide": "ሕባእ"
+		"hide": "ሕባእ",
+		"open_alert": "{severity} — ዝርዝር ናይ ኣገልግሎት ምልክታ ክፈት: {summary}",
+		"affects_this_stop": "ነዚ መዕረፊ ይትንክፍ",
+		"other_alerts": "ካልኦት ምልክታታት",
+		"severity_severe": "ከቢድ",
+		"severity_warning": "መጠንቀቕታ",
+		"severity_info": "ሓበሬታ",
+		"cause": "ምኽንያት",
+		"effect": "ሳዕቤን",
+		"active": "ንጡፍ",
+		"active_until": "ክሳብ {date}",
+		"active_from": "ካብ {date}",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "ዘይተፈልጠ",
+		"cause_other": "ካልእ",
+		"cause_technical": "ቴክኒካዊ ጸገም",
+		"cause_strike": "ኣድማ",
+		"cause_demonstration": "ሰላማዊ ሰልፊ",
+		"cause_accident": "ሓደጋ",
+		"cause_holiday": "በዓል",
+		"cause_weather": "ኩነታት ኣየር",
+		"cause_maintenance": "ጽገና",
+		"cause_construction": "ናይ ህንጸት ስራሕ",
+		"cause_police": "ናይ ፖሊስ ንጥፈት",
+		"cause_medical": "ሕክምናዊ ህጹጽ ኩነታት",
+		"cause_equipment": "መሳርሒ",
+		"cause_environment": "ከባቢ",
+		"cause_personnel": "ሰራሕተኛታት",
+		"cause_miscellaneous": "ዝተፈላለየ",
+		"cause_security": "ናይ ጸጥታ ምልክታ",
+		"effect_no_service": "ኣገልግሎት የለን",
+		"effect_reduced_service": "ዝወሓደ ኣገልግሎት",
+		"effect_significant_delays": "ብርቱዕ ምድንጓይ",
+		"effect_detour": "መተካእታ መንገዲ",
+		"effect_additional_service": "ተወሳኺ ኣገልግሎት",
+		"effect_modified_service": "ዝተቐየረ ኣገልግሎት",
+		"effect_other": "ካልእ ሳዕቤን",
+		"effect_unknown": "ዘይተፈልጠ ሳዕቤን",
+		"effect_stop_moved": "መዕረፊ ቦታኡ ተቐይሩ",
+		"effect_no_effect": "ሳዕቤን የለን",
+		"effect_accessibility": "ናይ ተበጻሕነት ጸገም"
 	},
 	"view_stop_information": "ሓበሬታ መዕረፊ ርአ",
 	"stop_details": {
-		"view_details": "ዝርዝር ርአ"
+		"view_details": "ዝርዝር ርአ",
+		"stop_info": "ሓበሬታ መዕረፊ"
 	},
 	"language_switcher": {
 		"select_language": "ቋንቋ ምረጽ: {language}",
 		"available_languages": "ዝርከቡ ቋንቋታት"
 	},
 	"map": {
-		"find_my_location": "ቦታይ ፈልጥ"
+		"find_my_location": "ቦታይ ፈልጥ",
+		"routes_shown": "ዝረኣዩ መስመራት",
+		"live_vehicle_count": "{count} ብቐጥታ"
 	},
 	"context-menu": {
 		"start_here": "ካብዚ ጀምር",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "ናብ መበገሲ",
 		"go_back": "ንድሕሪት ተመለስ"
+	},
+	"trip_details": {
+		"route": "መስመር",
+		"no_stops": "ነዚ መገሻ ናይ መዕረፊ ሰዓታት የለን።",
+		"loading": "ዝርዝር መገሻ ይጽዕን ኣሎ...",
+		"live_vehicle": "ብቐጥታ · ተሽከርካሪ {vehicleId}",
+		"collapsed_stops": "{count, plural, one {# መዕረፊ} other {# መዕረፊታት}}"
 	},
 	"skip_to_main_content": "ናብ ቀንዲ ትሕዝቶ ዝሕለፍ"
 }

--- a/src/locales/tl.json
+++ b/src/locales/tl.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "Mga itineraryo ng biyahe",
 		"show_steps": "Ipakita ang mga hakbang",
 		"hide_steps": "Itago ang mga hakbang",
+		"options": "Mga Opsyon",
+		"trip_options": "Mga Opsyon sa Biyahe",
+		"cancel": "Kanselahin",
+		"done": "Tapos na",
+		"reset_to_defaults": "I-reset sa mga default",
+		"departure_time": "Oras ng Pag-alis",
+		"departure_date": "Petsa ng pag-alis",
+		"leave_now": "Umalis Ngayon",
+		"depart_at": "Umalis sa Piniling Oras",
+		"arrive_by": "Dumating sa Piniling Oras",
+		"wheelchair_accessible": "Accessible sa wheelchair",
+		"wheelchair_desc": "Maghanap ng mga rutang angkop para sa mga mobility device at wheelchair",
+		"wheelchair": "Wheelchair",
+		"route_optimization": "Pag-optimize ng Ruta",
+		"fastest_trip": "Pinakamabilis na Biyahe",
+		"fewest_transfers": "Pinakakaunting Paglipat",
+		"stay_on_board": "Manatili sa sasakyan. Magpapatuloy ang biyaheng ito bilang Ruta {route}.",
+		"walking_distance": "Distansya ng Paglalakad",
+		"max_walking_distance": "Pinakamalayong distansya ng paglalakad",
 		"distance_unit": "Yunit ng Distansya",
 		"unit_auto": "Awtomatikong tukuyin",
 		"unit_metric": "Metriko (km, m)",
-		"unit_imperial": "Imperyalismo (mi, ft)"
+		"unit_imperial": "Imperyalismo (mi, ft)",
+		"swap_locations": "Ipagpalit ang mga lokasyong Mula sa at Patungo sa",
+		"error_code": "Code ng error",
+		"remove_recent_trip": "Alisin ang kamakailang biyahe",
+		"recent_trip": "Gamitin ang kamakailang biyahe mula sa {from} papuntang {to}",
+		"recent_searches": "Mga Kamakailang Paghahanap",
+		"recents": "Kamakailan",
+		"clear_all": "I-clear Lahat",
+		"request_failed": "Hindi namin maabot ang serbisyo sa pagpaplano ng biyahe. Pakisubukang muli.",
+		"invalid_shared_link": "Mukhang sira ang na-share na link ng biyaheng ito. Subukang planuhin muli ang biyahe."
 	},
 	"tabs": {
 		"stops-and-stations": "Mga hintuan at estasyon",
 		"plan_trip": "Planuhin ang biyahe"
+	},
+	"favorites": {
+		"title": "Mga Paborito",
+		"add": "Idagdag sa mga paborito",
+		"remove": "Alisin sa mga paborito",
+		"clear_all": "I-clear Lahat",
+		"open_panel": "Buksan ang mga paborito",
+		"close_panel": "Isara ang mga paborito",
+		"empty": "Wala pang paborito. I-tap ang bituin sa isang hintuan o ruta para i-save ito rito.",
+		"stop_code": "Code",
+		"open_item": "Buksan ang {name}",
+		"remove_item": "Alisin ang {name} sa mga paborito"
 	},
 	"search": {
 		"placeholder": "Maghanap ng mga hintuan, ruta, at lugar",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "para sa listahan ng mga magagamit na ruta",
 		"search_for_routes": "Maghanap ng mga ruta...",
 		"no_routes_found": "Walang nahanap na ruta",
-		"all_routes": "Lahat ng ruta"
+		"all_routes": "Lahat ng ruta",
+		"clear": "I-clear",
+		"collapse": "I-collapse ang paghahanap"
+	},
+	"sheet": {
+		"close": "Isara",
+		"resize_handle": "Baguhin ang laki ng panel",
+		"snap_full": "Buong taas",
+		"snap_half": "Kalahating taas",
+		"snap_peek": "Naka-collapse"
+	},
+	"survey": {
+		"required_question": "Kinakailangang tanong",
+		"required_answer": "Kinakailangan ang tanong na ito.",
+		"expand": "Ipakita ang tanong",
+		"collapse": "Itago ang tanong",
+		"dismiss": "I-dismiss ang survey",
+		"submit": "Isumite",
+		"next": "Susunod",
+		"submit_failed": "Hindi naipadala ang iyong sagot. Pakisubukang muli."
 	},
 	"header": {
 		"home": "Home",
@@ -88,13 +147,26 @@
 		"close": "Isara"
 	},
 	"arrivals_and_departures": "Mga pagdating at pag-alis",
+	"show_more": "Ipakita pa",
+	"show_less": "Ipakita nang mas kaunti",
 	"load_more_arrivals": "Mag-load pa ng mga pagdating",
+	"refresh": "I-refresh",
 	"no_arrivals_found_in_next_minutes": "Walang nahanap na pagdating sa susunod na {minutes} minuto",
 	"no_more_arrivals_in_next_minutes": "Wala nang karagdagang pagdating sa susunod na {minutes} minuto",
 	"stop": "Hintuan",
+	"direction_bound": "Papuntang {direction}",
 	"routes": "Mga ruta",
 	"route": "Ruta",
 	"route_modal_title": "Ruta {name}",
+	"notifications": {
+		"route_load_failed": "Hindi ma-load ang rutang ito.",
+		"route_shape_failed": "Hindi maiguhit ang rutang ito sa mapa.",
+		"route_shape_partial": "May bahagi ng rutang ito na hindi naiguhit. Maaaring may kulang na segment sa mapa.",
+		"favorite_saved": "Na-save sa mga paborito.",
+		"favorite_removed": "Inalis sa mga paborito.",
+		"tap_to_retry": "I-tap para subukang muli.",
+		"dismiss": "I-dismiss"
+	},
 	"loading": "Naglo-load",
 	"arrives": "Dumarating",
 	"NA": "W/A",
@@ -105,13 +177,16 @@
 		"secs": "secs",
 		"min": "min",
 		"mins": "mins",
-		"minutes": "minutes"
+		"minutes": "minutes",
+		"min_compact": "{n} min"
 	},
 	"vehicle": {
 		"number": "Sasakyan #",
 		"data_updated": "Na-update ang data",
 		"no_real_time_data": "Wala kaming real-time na data para sa sasakyang ito ngayon.",
-		"next_stop": "Susunod na hintuan:"
+		"next_stop": "Susunod na hintuan:",
+		"label": "Sasakyan",
+		"to_headsign": "Sasakyang papuntang {headsign}"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "Mga Pagdating at Pag-alis"
@@ -150,18 +225,61 @@
 		"no_description": "Walang detalyadong paglalarawan na available para sa abisong ito",
 		"page": "Pahina",
 		"show": "Ipakita",
-		"hide": "Itago"
+		"hide": "Itago",
+		"open_alert": "Buksan ang mga detalye ng abiso ng serbisyo ({severity}): {summary}",
+		"affects_this_stop": "Nakakaapekto sa hintuang ito",
+		"other_alerts": "Iba pang abiso",
+		"severity_severe": "Malubha",
+		"severity_warning": "Babala",
+		"severity_info": "Impormasyon",
+		"cause": "Sanhi",
+		"effect": "Epekto",
+		"active": "Aktibo",
+		"active_until": "Hanggang {date}",
+		"active_from": "Mula {date}",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "Hindi alam",
+		"cause_other": "Iba pa",
+		"cause_technical": "Teknikal na problema",
+		"cause_strike": "Welga",
+		"cause_demonstration": "Demonstrasyon",
+		"cause_accident": "Aksidente",
+		"cause_holiday": "Pista opisyal",
+		"cause_weather": "Panahon",
+		"cause_maintenance": "Maintenance",
+		"cause_construction": "Konstruksyon",
+		"cause_police": "Aktibidad ng pulisya",
+		"cause_medical": "Medikal na emerhensya",
+		"cause_equipment": "Kagamitan",
+		"cause_environment": "Kapaligiran",
+		"cause_personnel": "Tauhan",
+		"cause_miscellaneous": "Iba't ibang dahilan",
+		"cause_security": "Abiso sa seguridad",
+		"effect_no_service": "Walang serbisyo",
+		"effect_reduced_service": "Nabawasang serbisyo",
+		"effect_significant_delays": "Malaking pagkaantala",
+		"effect_detour": "Detour",
+		"effect_additional_service": "Karagdagang serbisyo",
+		"effect_modified_service": "Binagong serbisyo",
+		"effect_other": "Ibang epekto",
+		"effect_unknown": "Hindi alam na epekto",
+		"effect_stop_moved": "Inilipat ang hintuan",
+		"effect_no_effect": "Walang epekto",
+		"effect_accessibility": "Isyu sa accessibility"
 	},
 	"view_stop_information": "Tingnan ang impormasyon ng hintuan",
 	"stop_details": {
-		"view_details": "Tingnan ang detalye"
+		"view_details": "Tingnan ang detalye",
+		"stop_info": "Impormasyon ng Hintuan"
 	},
 	"language_switcher": {
 		"select_language": "Piliin ang wika: {language}",
 		"available_languages": "Mga available na wika"
 	},
 	"map": {
-		"find_my_location": "Hanapin ang Aking Lokasyon"
+		"find_my_location": "Hanapin ang Aking Lokasyon",
+		"routes_shown": "Mga ipinapakitang ruta",
+		"live_vehicle_count": "{count} live"
 	},
 	"context-menu": {
 		"start_here": "Magsimula dito",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "Pumunta sa home",
 		"go_back": "Bumalik"
+	},
+	"trip_details": {
+		"route": "Ruta",
+		"no_stops": "Walang magagamit na oras ng hintuan para sa biyaheng ito.",
+		"loading": "Naglo-load ng mga detalye ng biyahe...",
+		"live_vehicle": "Live · sasakyan {vehicleId}",
+		"collapsed_stops": "{count, plural, one {# hintuan} other {# na hintuan}}"
 	},
 	"skip_to_main_content": "Lumipat sa pangunahing nilalaman"
 }

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "Варіанти маршруту",
 		"show_steps": "Показати кроки",
 		"hide_steps": "Сховати кроки",
+		"options": "Параметри",
+		"trip_options": "Параметри поїздки",
+		"cancel": "Скасувати",
+		"done": "Готово",
+		"reset_to_defaults": "Скинути налаштування",
+		"departure_time": "Час відправлення",
+		"departure_date": "Дата відправлення",
+		"leave_now": "Вирушити зараз",
+		"depart_at": "Вирушити о",
+		"arrive_by": "Прибути до",
+		"wheelchair_accessible": "Доступно для візків",
+		"wheelchair_desc": "Знаходити маршрути, придатні для візків та інших засобів пересування",
+		"wheelchair": "Візок",
+		"route_optimization": "Оптимізація маршруту",
+		"fastest_trip": "Найшвидша поїздка",
+		"fewest_transfers": "Найменше пересадок",
+		"stay_on_board": "Залишайтеся в салоні. Цей рейс продовжується як маршрут {route}.",
+		"walking_distance": "Відстань пішки",
+		"max_walking_distance": "Максимальна відстань пішки",
 		"distance_unit": "Одиниця вимірювання відстані",
 		"unit_auto": "Визначити автоматично",
 		"unit_metric": "Метрична (км, м)",
-		"unit_imperial": "Імперська (mi, ft)"
+		"unit_imperial": "Імперська (mi, ft)",
+		"swap_locations": "Поміняти місцями «Звідки» і «Куди»",
+		"error_code": "Код помилки",
+		"remove_recent_trip": "Видалити нещодавню поїздку",
+		"recent_trip": "Використати нещодавню поїздку. Звідки: {from}. Куди: {to}",
+		"recent_searches": "Нещодавні пошуки",
+		"recents": "Нещодавні",
+		"clear_all": "Очистити все",
+		"request_failed": "Не вдалося зв'язатися зі службою планування поїздок. Спробуйте ще раз.",
+		"invalid_shared_link": "Схоже, це посилання на поїздку пошкоджене. Спробуйте спланувати поїздку ще раз."
 	},
 	"tabs": {
 		"stops-and-stations": "Зупинки та станції",
 		"plan_trip": "Спланувати поїздку"
+	},
+	"favorites": {
+		"title": "Обране",
+		"add": "Додати до обраного",
+		"remove": "Видалити з обраного",
+		"clear_all": "Очистити все",
+		"open_panel": "Відкрити обране",
+		"close_panel": "Закрити обране",
+		"empty": "Обраного ще немає. Натисніть зірочку на зупинці або маршруті, щоб зберегти їх тут.",
+		"stop_code": "Код",
+		"open_item": "Відкрити: {name}",
+		"remove_item": "Видалити з обраного: {name}"
 	},
 	"search": {
 		"placeholder": "Пошук зупинок, маршрутів та місць",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "для перегляду доступних маршрутів",
 		"search_for_routes": "Пошук маршрутів...",
 		"no_routes_found": "Маршрутів не знайдено",
-		"all_routes": "Усі маршрути"
+		"all_routes": "Усі маршрути",
+		"clear": "Очистити",
+		"collapse": "Згорнути пошук"
+	},
+	"sheet": {
+		"close": "Закрити",
+		"resize_handle": "Змінити розмір панелі",
+		"snap_full": "Повна висота",
+		"snap_half": "Половина висоти",
+		"snap_peek": "Згорнуто"
+	},
+	"survey": {
+		"required_question": "Обов'язкове запитання",
+		"required_answer": "Це запитання обов'язкове.",
+		"expand": "Показати запитання",
+		"collapse": "Сховати запитання",
+		"dismiss": "Закрити опитування",
+		"submit": "Надіслати",
+		"next": "Далі",
+		"submit_failed": "Не вдалося надіслати відповідь. Спробуйте ще раз."
 	},
 	"header": {
 		"home": "Головна",
@@ -88,13 +147,26 @@
 		"close": "Закрити"
 	},
 	"arrivals_and_departures": "Прибуття та відправлення",
+	"show_more": "Показати більше",
+	"show_less": "Показати менше",
 	"load_more_arrivals": "Завантажити більше прибуттів",
+	"refresh": "Оновити",
 	"no_arrivals_found_in_next_minutes": "Немає прибуттів протягом наступних {minutes} хвилин",
 	"no_more_arrivals_in_next_minutes": "Немає більше прибуттів протягом наступних {minutes} хвилин",
 	"stop": "Зупинка",
+	"direction_bound": "Напрямок: {direction}",
 	"routes": "Маршрути",
 	"route": "маршрут",
 	"route_modal_title": "Маршрут {name}",
+	"notifications": {
+		"route_load_failed": "Не вдалося завантажити цей маршрут.",
+		"route_shape_failed": "Не вдалося показати цей маршрут на карті.",
+		"route_shape_partial": "Частину цього маршруту не вдалося показати. На карті може бракувати ділянки.",
+		"favorite_saved": "Збережено в обраному.",
+		"favorite_removed": "Видалено з обраного.",
+		"tap_to_retry": "Натисніть, щоб повторити.",
+		"dismiss": "Закрити"
+	},
 	"loading": "Завантаження",
 	"arrives": "прибуває",
 	"NA": "Н/Д",
@@ -105,13 +177,16 @@
 		"secs": "сек",
 		"min": "хв",
 		"mins": "хв",
-		"minutes": "хвилин"
+		"minutes": "хвилин",
+		"min_compact": "{n} хв"
 	},
 	"vehicle": {
 		"number": "Транспорт №",
 		"data_updated": "Дані оновлено",
 		"no_real_time_data": "Наразі немає даних у реальному часі для цього транспорту.",
-		"next_stop": "Наступна зупинка:"
+		"next_stop": "Наступна зупинка:",
+		"label": "Транспорт",
+		"to_headsign": "Транспорт у напрямку: {headsign}"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "Прибуття та відправлення"
@@ -150,18 +225,61 @@
 		"no_description": "Детальний опис для цього сповіщення недоступний",
 		"page": "Сторінка",
 		"show": "Показати",
-		"hide": "Сховати"
+		"hide": "Сховати",
+		"open_alert": "Відкрити деталі сервісного сповіщення ({severity}): {summary}",
+		"affects_this_stop": "Стосується цієї зупинки",
+		"other_alerts": "Інші сповіщення",
+		"severity_severe": "Критичне",
+		"severity_warning": "Попередження",
+		"severity_info": "Інформація",
+		"cause": "Причина",
+		"effect": "Наслідок",
+		"active": "Діє",
+		"active_until": "До {date}",
+		"active_from": "З {date}",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "Невідома",
+		"cause_other": "Інша",
+		"cause_technical": "Технічна несправність",
+		"cause_strike": "Страйк",
+		"cause_demonstration": "Демонстрація",
+		"cause_accident": "Аварія",
+		"cause_holiday": "Свято",
+		"cause_weather": "Погодні умови",
+		"cause_maintenance": "Технічне обслуговування",
+		"cause_construction": "Будівельні роботи",
+		"cause_police": "Дії поліції",
+		"cause_medical": "Надзвичайна медична ситуація",
+		"cause_equipment": "Проблема з обладнанням",
+		"cause_environment": "Умови довкілля",
+		"cause_personnel": "Проблема з персоналом",
+		"cause_miscellaneous": "Різне",
+		"cause_security": "Загроза безпеці",
+		"effect_no_service": "Рух припинено",
+		"effect_reduced_service": "Скорочений рух",
+		"effect_significant_delays": "Значні затримки",
+		"effect_detour": "Об'їзд",
+		"effect_additional_service": "Додаткові рейси",
+		"effect_modified_service": "Змінений рух",
+		"effect_other": "Інший наслідок",
+		"effect_unknown": "Невідомий наслідок",
+		"effect_stop_moved": "Зупинку перенесено",
+		"effect_no_effect": "Без наслідків",
+		"effect_accessibility": "Проблема з доступністю"
 	},
 	"view_stop_information": "Переглянути інформацію про зупинку",
 	"stop_details": {
-		"view_details": "Детальніше"
+		"view_details": "Детальніше",
+		"stop_info": "Про зупинку"
 	},
 	"language_switcher": {
 		"select_language": "Оберіть мову: {language}",
 		"available_languages": "Доступні мови"
 	},
 	"map": {
-		"find_my_location": "Знайти моє місцезнаходження"
+		"find_my_location": "Знайти моє місцезнаходження",
+		"routes_shown": "Показані маршрути",
+		"live_vehicle_count": "{count} онлайн"
 	},
 	"context-menu": {
 		"start_here": "Почати звідси",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "На головну",
 		"go_back": "Назад"
+	},
+	"trip_details": {
+		"route": "Маршрут",
+		"no_stops": "Немає даних про час зупинок для цього рейсу.",
+		"loading": "Завантаження деталей рейсу...",
+		"live_vehicle": "Онлайн · транспорт {vehicleId}",
+		"collapsed_stops": "{count, plural, one {# зупинка} few {# зупинки} many {# зупинок} other {# зупинки}}"
 	},
 	"skip_to_main_content": "Перейти до основного вмісту"
 }

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "Lịch trình chuyến đi",
 		"show_steps": "Hiện các bước",
 		"hide_steps": "Ẩn các bước",
+		"options": "Tùy chọn",
+		"trip_options": "Tùy chọn chuyến đi",
+		"cancel": "Hủy",
+		"done": "Xong",
+		"reset_to_defaults": "Đặt lại mặc định",
+		"departure_time": "Thời gian khởi hành",
+		"departure_date": "Ngày khởi hành",
+		"leave_now": "Khởi hành ngay",
+		"depart_at": "Khởi hành lúc",
+		"arrive_by": "Đến trước",
+		"wheelchair_accessible": "Hỗ trợ xe lăn",
+		"wheelchair_desc": "Tìm các tuyến đường phù hợp với thiết bị hỗ trợ di chuyển và xe lăn",
+		"wheelchair": "Xe lăn",
+		"route_optimization": "Tối ưu hóa tuyến đường",
+		"fastest_trip": "Chuyến đi nhanh nhất",
+		"fewest_transfers": "Ít lần chuyển tuyến nhất",
+		"stay_on_board": "Tiếp tục ở trên xe. Chuyến đi này tiếp tục với Tuyến đường {route}.",
+		"walking_distance": "Khoảng cách đi bộ",
+		"max_walking_distance": "Khoảng cách đi bộ tối đa",
 		"distance_unit": "Đơn vị khoảng cách",
 		"unit_auto": "Tự động phát hiện",
 		"unit_metric": "Hệ mét (km, m)",
-		"unit_imperial": "Hệ Anh (mi, ft)"
+		"unit_imperial": "Hệ Anh (mi, ft)",
+		"swap_locations": "Hoán đổi địa điểm Từ và Đến",
+		"error_code": "Mã lỗi",
+		"remove_recent_trip": "Xóa chuyến đi gần đây",
+		"recent_trip": "Dùng chuyến đi gần đây từ {from} đến {to}",
+		"recent_searches": "Tìm kiếm gần đây",
+		"recents": "Gần đây",
+		"clear_all": "Xóa tất cả",
+		"request_failed": "Không thể kết nối tới dịch vụ lập kế hoạch chuyến đi. Vui lòng thử lại.",
+		"invalid_shared_link": "Liên kết chuyến đi được chia sẻ này có vẻ bị lỗi. Vui lòng lập kế hoạch lại chuyến đi."
 	},
 	"tabs": {
 		"stops-and-stations": "Trạm dừng và nhà ga",
 		"plan_trip": "Lập kế hoạch chuyến đi"
+	},
+	"favorites": {
+		"title": "Yêu thích",
+		"add": "Thêm vào yêu thích",
+		"remove": "Xóa khỏi yêu thích",
+		"clear_all": "Xóa tất cả",
+		"open_panel": "Mở danh sách yêu thích",
+		"close_panel": "Đóng danh sách yêu thích",
+		"empty": "Chưa có mục yêu thích nào. Nhấn vào biểu tượng ngôi sao trên một trạm dừng hoặc tuyến đường để lưu vào đây.",
+		"stop_code": "Mã",
+		"open_item": "Mở {name}",
+		"remove_item": "Xóa {name} khỏi yêu thích"
 	},
 	"search": {
 		"placeholder": "Tìm kiếm trạm dừng, tuyến đường và địa điểm",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "cho danh sách các tuyến đường có sẵn",
 		"search_for_routes": "Tìm kiếm tuyến đường...",
 		"no_routes_found": "Không tìm thấy tuyến đường",
-		"all_routes": "Tất cả các tuyến đường"
+		"all_routes": "Tất cả các tuyến đường",
+		"clear": "Xóa",
+		"collapse": "Thu gọn tìm kiếm"
+	},
+	"sheet": {
+		"close": "Đóng",
+		"resize_handle": "Thay đổi kích thước bảng",
+		"snap_full": "Toàn màn hình",
+		"snap_half": "Nửa màn hình",
+		"snap_peek": "Thu gọn"
+	},
+	"survey": {
+		"required_question": "Câu hỏi bắt buộc",
+		"required_answer": "Câu hỏi này là bắt buộc.",
+		"expand": "Hiện câu hỏi",
+		"collapse": "Ẩn câu hỏi",
+		"dismiss": "Bỏ qua khảo sát",
+		"submit": "Gửi",
+		"next": "Tiếp theo",
+		"submit_failed": "Không thể gửi câu trả lời. Vui lòng thử lại."
 	},
 	"header": {
 		"home": "Trang chủ",
@@ -88,13 +147,26 @@
 		"close": "Đóng"
 	},
 	"arrivals_and_departures": "Đến và đi",
+	"show_more": "Xem thêm",
+	"show_less": "Ẩn bớt",
 	"load_more_arrivals": "Tải thêm chuyến đến",
+	"refresh": "Làm mới",
 	"no_arrivals_found_in_next_minutes": "Không tìm thấy chuyến đến trong {minutes} phút tới",
 	"no_more_arrivals_in_next_minutes": "Không có thêm chuyến đến trong {minutes} phút tới",
 	"stop": "Trạm dừng",
+	"direction_bound": "Hướng {direction}",
 	"routes": "Tuyến đường",
 	"route": "Tuyến đường",
 	"route_modal_title": "Tuyến đường {name}",
+	"notifications": {
+		"route_load_failed": "Không thể tải tuyến đường này.",
+		"route_shape_failed": "Không thể vẽ tuyến đường này trên bản đồ.",
+		"route_shape_partial": "Không thể vẽ một phần của tuyến đường này. Bản đồ có thể bị thiếu một đoạn.",
+		"favorite_saved": "Đã lưu vào yêu thích.",
+		"favorite_removed": "Đã xóa khỏi yêu thích.",
+		"tap_to_retry": "Nhấn để thử lại.",
+		"dismiss": "Bỏ qua"
+	},
 	"loading": "Đang tải",
 	"arrives": "Đến",
 	"NA": "KAD",
@@ -105,13 +177,16 @@
 		"secs": "secs",
 		"min": "min",
 		"mins": "mins",
-		"minutes": "minutes"
+		"minutes": "minutes",
+		"min_compact": "{n} phút"
 	},
 	"vehicle": {
 		"number": "Xe #",
 		"data_updated": "Dữ liệu đã cập nhật",
 		"no_real_time_data": "Hiện tại không có dữ liệu thời gian thực cho xe này.",
-		"next_stop": "Trạm dừng tiếp theo:"
+		"next_stop": "Trạm dừng tiếp theo:",
+		"label": "Xe",
+		"to_headsign": "Xe đi {headsign}"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "Lịch Đến và Đi"
@@ -150,18 +225,61 @@
 		"no_description": "Không có mô tả chi tiết cho thông báo này",
 		"page": "Trang",
 		"show": "Hiển thị",
-		"hide": "Ẩn"
+		"hide": "Ẩn",
+		"open_alert": "Mở chi tiết thông báo dịch vụ mức {severity}: {summary}",
+		"affects_this_stop": "Ảnh hưởng đến trạm dừng này",
+		"other_alerts": "Thông báo khác",
+		"severity_severe": "Nghiêm trọng",
+		"severity_warning": "Cảnh báo",
+		"severity_info": "Thông tin",
+		"cause": "Nguyên nhân",
+		"effect": "Ảnh hưởng",
+		"active": "Thời gian hiệu lực",
+		"active_until": "Đến {date}",
+		"active_from": "Từ {date}",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "Không xác định",
+		"cause_other": "Khác",
+		"cause_technical": "Sự cố kỹ thuật",
+		"cause_strike": "Đình công",
+		"cause_demonstration": "Biểu tình",
+		"cause_accident": "Tai nạn",
+		"cause_holiday": "Ngày lễ",
+		"cause_weather": "Thời tiết",
+		"cause_maintenance": "Bảo trì",
+		"cause_construction": "Thi công",
+		"cause_police": "Hoạt động của cảnh sát",
+		"cause_medical": "Cấp cứu y tế",
+		"cause_equipment": "Thiết bị",
+		"cause_environment": "Môi trường",
+		"cause_personnel": "Nhân sự",
+		"cause_miscellaneous": "Lý do khác",
+		"cause_security": "Cảnh báo an ninh",
+		"effect_no_service": "Không có dịch vụ",
+		"effect_reduced_service": "Giảm dịch vụ",
+		"effect_significant_delays": "Chậm trễ đáng kể",
+		"effect_detour": "Đổi lộ trình",
+		"effect_additional_service": "Bổ sung dịch vụ",
+		"effect_modified_service": "Thay đổi dịch vụ",
+		"effect_other": "Ảnh hưởng khác",
+		"effect_unknown": "Ảnh hưởng không xác định",
+		"effect_stop_moved": "Trạm dừng đã di dời",
+		"effect_no_effect": "Không ảnh hưởng",
+		"effect_accessibility": "Vấn đề về khả năng tiếp cận"
 	},
 	"view_stop_information": "Xem thông tin trạm dừng",
 	"stop_details": {
-		"view_details": "Xem chi tiết"
+		"view_details": "Xem chi tiết",
+		"stop_info": "Thông tin trạm dừng"
 	},
 	"language_switcher": {
 		"select_language": "Chọn ngôn ngữ: {language}",
 		"available_languages": "Ngôn ngữ có sẵn"
 	},
 	"map": {
-		"find_my_location": "Tìm vị trí của tôi"
+		"find_my_location": "Tìm vị trí của tôi",
+		"routes_shown": "Tuyến đường đang hiển thị",
+		"live_vehicle_count": "{count} xe trực tiếp"
 	},
 	"context-menu": {
 		"start_here": "Bắt đầu từ đây",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "Về trang chủ",
 		"go_back": "Quay lại"
+	},
+	"trip_details": {
+		"route": "Tuyến đường",
+		"no_stops": "Không có giờ dừng nào cho chuyến đi này.",
+		"loading": "Đang tải chi tiết chuyến đi...",
+		"live_vehicle": "Trực tiếp · xe {vehicleId}",
+		"collapsed_stops": "{count, plural, other {# trạm dừng}}"
 	},
 	"skip_to_main_content": "Bỏ qua đến nội dung chính"
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "行程方案",
 		"show_steps": "显示步骤",
 		"hide_steps": "隐藏步骤",
+		"options": "选项",
+		"trip_options": "行程选项",
+		"cancel": "取消",
+		"done": "完成",
+		"reset_to_defaults": "恢复默认设置",
+		"departure_time": "出发时间",
+		"departure_date": "出发日期",
+		"leave_now": "现在出发",
+		"depart_at": "指定出发时间",
+		"arrive_by": "指定到达时间",
+		"wheelchair_accessible": "轮椅无障碍",
+		"wheelchair_desc": "查找适合助行设备和轮椅通行的线路",
+		"wheelchair": "轮椅",
+		"route_optimization": "线路优化",
+		"fastest_trip": "最快行程",
+		"fewest_transfers": "最少换乘",
+		"stay_on_board": "请留在车上。本次行程将以 {route} 线路继续运行。",
+		"walking_distance": "步行距离",
+		"max_walking_distance": "最大步行距离",
 		"distance_unit": "距离单位",
 		"unit_auto": "自动检测",
 		"unit_metric": "公制 (km, m)",
-		"unit_imperial": "英制 (mi, ft)"
+		"unit_imperial": "英制 (mi, ft)",
+		"swap_locations": "交换起点和终点",
+		"error_code": "错误代码",
+		"remove_recent_trip": "删除最近行程",
+		"recent_trip": "使用从 {from} 到 {to} 的最近行程",
+		"recent_searches": "最近搜索",
+		"recents": "最近",
+		"clear_all": "全部清除",
+		"request_failed": "无法连接行程规划服务，请稍后重试。",
+		"invalid_shared_link": "此行程分享链接似乎已失效，请重新规划行程。"
 	},
 	"tabs": {
 		"stops-and-stations": "站点",
 		"plan_trip": "规划行程"
+	},
+	"favorites": {
+		"title": "收藏",
+		"add": "添加到收藏",
+		"remove": "从收藏中移除",
+		"clear_all": "全部清除",
+		"open_panel": "打开收藏",
+		"close_panel": "关闭收藏",
+		"empty": "暂无收藏。点击站点或线路上的星标即可保存到此处。",
+		"stop_code": "编号",
+		"open_item": "打开 {name}",
+		"remove_item": "将 {name} 从收藏中移除"
 	},
 	"search": {
 		"placeholder": "搜索站点、线路和地点",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "查看可用线路列表",
 		"search_for_routes": "搜索线路...",
 		"no_routes_found": "未找到线路",
-		"all_routes": "所有线路"
+		"all_routes": "所有线路",
+		"clear": "清除",
+		"collapse": "收起搜索"
+	},
+	"sheet": {
+		"close": "关闭",
+		"resize_handle": "调整面板大小",
+		"snap_full": "完整高度",
+		"snap_half": "半屏高度",
+		"snap_peek": "最小高度"
+	},
+	"survey": {
+		"required_question": "必答题",
+		"required_answer": "此题为必答题。",
+		"expand": "显示问题",
+		"collapse": "隐藏问题",
+		"dismiss": "关闭问卷",
+		"submit": "提交",
+		"next": "下一题",
+		"submit_failed": "无法提交您的回答，请重试。"
 	},
 	"header": {
 		"home": "首页",
@@ -88,13 +147,26 @@
 		"close": "关闭"
 	},
 	"arrivals_and_departures": "到站与发车",
+	"show_more": "显示更多",
+	"show_less": "收起",
 	"load_more_arrivals": "加载更多到站信息",
+	"refresh": "刷新",
 	"no_arrivals_found_in_next_minutes": "未来{minutes}分钟内无到站信息",
 	"no_more_arrivals_in_next_minutes": "未来{minutes}分钟内无更多到站信息",
 	"stop": "站点",
+	"direction_bound": "{direction} 方向",
 	"routes": "线路",
 	"route": "线路",
 	"route_modal_title": "{name} 线路",
+	"notifications": {
+		"route_load_failed": "无法加载该线路。",
+		"route_shape_failed": "无法在地图上绘制该线路。",
+		"route_shape_partial": "该线路部分路段无法绘制，地图上可能缺少一段。",
+		"favorite_saved": "已添加到收藏。",
+		"favorite_removed": "已从收藏中移除。",
+		"tap_to_retry": "点击重试。",
+		"dismiss": "关闭"
+	},
 	"loading": "加载中",
 	"arrives": "到达",
 	"NA": "暂无",
@@ -105,13 +177,16 @@
 		"secs": "秒",
 		"min": "分钟",
 		"mins": "分钟",
-		"minutes": "分钟"
+		"minutes": "分钟",
+		"min_compact": "{n} 分钟"
 	},
 	"vehicle": {
 		"number": "车辆编号",
 		"data_updated": "数据更新于",
 		"no_real_time_data": "暂无该车辆的实时数据。",
-		"next_stop": "下一站："
+		"next_stop": "下一站：",
+		"label": "车辆",
+		"to_headsign": "开往 {headsign} 的车辆"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "到站与发车"
@@ -150,18 +225,61 @@
 		"no_description": "该通知暂无详细描述",
 		"page": "页",
 		"show": "显示",
-		"hide": "隐藏"
+		"hide": "隐藏",
+		"open_alert": "打开{severity}服务通知详情：{summary}",
+		"affects_this_stop": "影响此站点",
+		"other_alerts": "其他通知",
+		"severity_severe": "严重",
+		"severity_warning": "警告",
+		"severity_info": "提示",
+		"cause": "原因",
+		"effect": "影响",
+		"active": "生效中",
+		"active_until": "截至 {date}",
+		"active_from": "自 {date} 起",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "未知",
+		"cause_other": "其他",
+		"cause_technical": "技术故障",
+		"cause_strike": "罢工",
+		"cause_demonstration": "示威活动",
+		"cause_accident": "事故",
+		"cause_holiday": "节假日",
+		"cause_weather": "天气",
+		"cause_maintenance": "维护作业",
+		"cause_construction": "施工",
+		"cause_police": "警务活动",
+		"cause_medical": "医疗紧急情况",
+		"cause_equipment": "设备问题",
+		"cause_environment": "环境因素",
+		"cause_personnel": "人员问题",
+		"cause_miscellaneous": "其他情况",
+		"cause_security": "安全警报",
+		"effect_no_service": "停止服务",
+		"effect_reduced_service": "服务缩减",
+		"effect_significant_delays": "严重延误",
+		"effect_detour": "绕行",
+		"effect_additional_service": "增加服务",
+		"effect_modified_service": "服务调整",
+		"effect_other": "其他影响",
+		"effect_unknown": "未知影响",
+		"effect_stop_moved": "站点迁移",
+		"effect_no_effect": "无影响",
+		"effect_accessibility": "无障碍问题"
 	},
 	"view_stop_information": "查看站点信息",
 	"stop_details": {
-		"view_details": "查看详情"
+		"view_details": "查看详情",
+		"stop_info": "站点信息"
 	},
 	"language_switcher": {
 		"select_language": "选择语言: {language}",
 		"available_languages": "可用语言"
 	},
 	"map": {
-		"find_my_location": "查找我的位置"
+		"find_my_location": "查找我的位置",
+		"routes_shown": "显示的线路",
+		"live_vehicle_count": "实时 {count} 辆"
 	},
 	"context-menu": {
 		"start_here": "从这里出发",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "返回首页",
 		"go_back": "返回"
+	},
+	"trip_details": {
+		"route": "线路",
+		"no_stops": "本次行程暂无站点时刻信息。",
+		"loading": "正在加载行程详情...",
+		"live_vehicle": "实时 · 车辆 {vehicleId}",
+		"collapsed_stops": "{count, plural, other {# 个站点}}"
 	},
 	"skip_to_main_content": "跳转至主要内容"
 }

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -30,14 +30,54 @@
 		"trip_itineraries": "行程方案",
 		"show_steps": "顯示步驟",
 		"hide_steps": "隱藏步驟",
+		"options": "選項",
+		"trip_options": "行程選項",
+		"cancel": "取消",
+		"done": "完成",
+		"reset_to_defaults": "重設為預設值",
+		"departure_time": "出發時間",
+		"departure_date": "出發日期",
+		"leave_now": "立即出發",
+		"depart_at": "指定出發時間",
+		"arrive_by": "指定抵達時間",
+		"wheelchair_accessible": "無障礙路線",
+		"wheelchair_desc": "尋找適合行動輔具與輪椅使用的路線",
+		"wheelchair": "無障礙",
+		"route_optimization": "路線最佳化",
+		"fastest_trip": "最快行程",
+		"fewest_transfers": "最少轉乘",
+		"stay_on_board": "請留在車上。本班車將以路線 {route} 繼續行駛。",
+		"walking_distance": "步行距離",
+		"max_walking_distance": "最長步行距離",
 		"distance_unit": "距離單位",
 		"unit_auto": "自動偵測",
 		"unit_metric": "公制 (km, m)",
-		"unit_imperial": "英制 (mi, ft)"
+		"unit_imperial": "英制 (mi, ft)",
+		"swap_locations": "交換起點與終點",
+		"error_code": "錯誤代碼",
+		"remove_recent_trip": "移除最近的行程",
+		"recent_trip": "使用最近的行程：從 {from} 到 {to}",
+		"recent_searches": "最近搜尋",
+		"recents": "最近紀錄",
+		"clear_all": "全部清除",
+		"request_failed": "無法連線至行程規劃服務。請再試一次。",
+		"invalid_shared_link": "此行程分享連結似乎已失效。請重新規劃行程。"
 	},
 	"tabs": {
 		"stops-and-stations": "站牌與車站",
 		"plan_trip": "規劃行程"
+	},
+	"favorites": {
+		"title": "我的最愛",
+		"add": "加入我的最愛",
+		"remove": "從我的最愛移除",
+		"clear_all": "全部清除",
+		"open_panel": "開啟我的最愛",
+		"close_panel": "關閉我的最愛",
+		"empty": "尚未加入我的最愛。點選站牌或路線上的星號即可儲存於此。",
+		"stop_code": "編號",
+		"open_item": "開啟 {name}",
+		"remove_item": "將 {name} 從我的最愛移除"
 	},
 	"search": {
 		"placeholder": "搜尋站牌、路線和地點",
@@ -48,7 +88,26 @@
 		"for_a_list_of_available_routes": "查看可用路線列表",
 		"search_for_routes": "搜尋路線...",
 		"no_routes_found": "找不到路線",
-		"all_routes": "所有路線"
+		"all_routes": "所有路線",
+		"clear": "清除",
+		"collapse": "收合搜尋"
+	},
+	"sheet": {
+		"close": "關閉",
+		"resize_handle": "調整面板大小",
+		"snap_full": "完整高度",
+		"snap_half": "一半高度",
+		"snap_peek": "已收合"
+	},
+	"survey": {
+		"required_question": "必答題",
+		"required_answer": "此題為必答。",
+		"expand": "顯示問題",
+		"collapse": "隱藏問題",
+		"dismiss": "關閉問卷",
+		"submit": "送出",
+		"next": "下一題",
+		"submit_failed": "無法送出您的回答。請再試一次。"
 	},
 	"header": {
 		"home": "首頁",
@@ -88,13 +147,26 @@
 		"close": "關閉"
 	},
 	"arrivals_and_departures": "到站與發車",
+	"show_more": "顯示更多",
+	"show_less": "顯示較少",
 	"load_more_arrivals": "載入更多到站班次",
+	"refresh": "重新整理",
 	"no_arrivals_found_in_next_minutes": "未來 {minutes} 分鐘內沒有到站班次",
 	"no_more_arrivals_in_next_minutes": "未來{minutes}分鐘內沒有更多到站班次",
 	"stop": "站牌",
+	"direction_bound": "往 {direction}",
 	"routes": "路線",
 	"route": "路線",
 	"route_modal_title": "路線 {name}",
+	"notifications": {
+		"route_load_failed": "無法載入此路線。",
+		"route_shape_failed": "無法在地圖上繪製此路線。",
+		"route_shape_partial": "此路線有部分無法繪製，地圖上可能缺少部分路段。",
+		"favorite_saved": "已加入我的最愛。",
+		"favorite_removed": "已從我的最愛移除。",
+		"tap_to_retry": "點選以重試。",
+		"dismiss": "關閉"
+	},
 	"loading": "載入中",
 	"arrives": "到達",
 	"NA": "無資料",
@@ -105,13 +177,16 @@
 		"secs": "秒",
 		"min": "分鐘",
 		"mins": "分鐘",
-		"minutes": "分鐘"
+		"minutes": "分鐘",
+		"min_compact": "{n} 分"
 	},
 	"vehicle": {
 		"number": "車輛編號",
 		"data_updated": "資料更新時間",
 		"no_real_time_data": "目前沒有此車輛的即時資料。",
-		"next_stop": "下一站："
+		"next_stop": "下一站：",
+		"label": "車輛",
+		"to_headsign": "開往 {headsign} 的車輛"
 	},
 	"arrivals_and_departures_for_stop": {
 		"title": "到站與發車"
@@ -150,18 +225,61 @@
 		"no_description": "此公告無詳細說明",
 		"page": "頁",
 		"show": "顯示",
-		"hide": "隱藏"
+		"hide": "隱藏",
+		"open_alert": "開啟服務公告詳細資訊（{severity}）：{summary}",
+		"affects_this_stop": "影響此站牌",
+		"other_alerts": "其他公告",
+		"severity_severe": "嚴重",
+		"severity_warning": "警告",
+		"severity_info": "資訊",
+		"cause": "原因",
+		"effect": "影響",
+		"active": "生效中",
+		"active_until": "至 {date} 止",
+		"active_from": "自 {date} 起",
+		"active_range": "{from} – {to}",
+		"cause_unknown": "不明",
+		"cause_other": "其他",
+		"cause_technical": "技術問題",
+		"cause_strike": "罷工",
+		"cause_demonstration": "示威活動",
+		"cause_accident": "事故",
+		"cause_holiday": "假日",
+		"cause_weather": "天候因素",
+		"cause_maintenance": "維修",
+		"cause_construction": "施工",
+		"cause_police": "警方執勤",
+		"cause_medical": "緊急醫療事件",
+		"cause_equipment": "設備問題",
+		"cause_environment": "環境因素",
+		"cause_personnel": "人力因素",
+		"cause_miscellaneous": "其他因素",
+		"cause_security": "安全警示",
+		"effect_no_service": "停駛",
+		"effect_reduced_service": "減班",
+		"effect_significant_delays": "嚴重延誤",
+		"effect_detour": "改道行駛",
+		"effect_additional_service": "加開班次",
+		"effect_modified_service": "服務異動",
+		"effect_other": "其他影響",
+		"effect_unknown": "影響不明",
+		"effect_stop_moved": "站牌遷移",
+		"effect_no_effect": "無影響",
+		"effect_accessibility": "無障礙設施問題"
 	},
 	"view_stop_information": "查看站牌資訊",
 	"stop_details": {
-		"view_details": "查看詳情"
+		"view_details": "查看詳情",
+		"stop_info": "站牌資訊"
 	},
 	"language_switcher": {
 		"select_language": "選擇語言: {language}",
 		"available_languages": "可用語言"
 	},
 	"map": {
-		"find_my_location": "尋找我的位置"
+		"find_my_location": "尋找我的位置",
+		"routes_shown": "顯示中的路線",
+		"live_vehicle_count": "即時 {count} 輛"
 	},
 	"context-menu": {
 		"start_here": "從這裡出發",
@@ -186,6 +304,13 @@
 		},
 		"go_home": "回首頁",
 		"go_back": "返回"
+	},
+	"trip_details": {
+		"route": "路線",
+		"no_stops": "此班次沒有停靠站時刻資料。",
+		"loading": "正在載入班次詳細資訊...",
+		"live_vehicle": "即時 · 車輛 {vehicleId}",
+		"collapsed_stops": "{count, plural, other {# 站}}"
 	},
 	"skip_to_main_content": "跳至主要內容"
 }


### PR DESCRIPTION
## Summary

- Fills the **115-key gap** (117 for `es`/`pl`) that every non-English locale had accumulated — features that shipped English-only: `service_alerts` (40), `trip-planner` (28), `favorites` (10), `survey` (8), `notifications` (7), plus `trip_details`, `map`, `sheet`. All 24 locales now sit at 258/258 with `en`.
- **Purely additive.** 3,428 pre-existing translations are preserved byte-for-byte; 2,764 added. The only `-` lines in the diff are a previously-last entry gaining a trailing comma. `en.json` is untouched.
- Each locale was translated twice independently, then adjudicated against that file's own established glossary and register, so new strings inherit the terminology already in use instead of competing with it.

## Test plan

- [x] Key parity: all 24 locales 258/258 vs `en`, no extra or missing keys
- [x] Placeholder integrity: 0 lost across 6,450 strings; en-dash (U+2013) preserved in `active_range`
- [x] ICU: every string parses under the repo's own `intl-messageformat`; plural categories correct per language (`ar` zero/one/two/few/many/other, `pl`/`ru`/`uk` one/few/many/other, CJK/vi/km/lo other-only)
- [x] No mutation: scripted diff against `develop` confirms 0 pre-existing keys changed or lost
- [x] Browser: dev server, switched to `es` / `ar` / `ht`, walked the trip planner and Options modal — all new keys render, no raw keys leak, RTL applies (computed `direction: rtl`)
- [x] `prettier --check` clean; `vitest run` 110 files / 1891 tests pass

## Review notes

Non-blocking, and **not fixed here** because the root causes live in `en.json`/components which this branch deliberately doesn't touch:

- **`direction_bound` renders an untranslated compass code.** `StopBottomSheet.svelte:53` passes the raw `stop.direction` ("SW") into `{direction}`, bypassing the fully-translated `direction.*` block every locale ships. `FavoritesList.svelte:43` and `SearchPane.svelte:434` already do this correctly. One-line fix, improves all 24 locales at once.
- **`SearchPane.svelte:434` hardcodes an English `Code:` literal** shown to every locale, even though all 24 just translated `favorites.stop_code` for that concept.
- **`serviceAlertsHelper.js:279`** passes `undefined` to `Intl.DateTimeFormat`, so alert dates use the *browser's* locale inside translated strings.
- **`service_alerts.active`** renders as a `<dt>` label before a date window, but "Active" reads as an adjective — locales split 7 noun / 4 verb / 13 adjective. Renaming it in `en.json` (e.g. `active_period`) before the next translation pass would avoid re-translating these.
- **`time.min_compact` = `{n}m` collides with `units.meters` = `"m"`.** Every translator independently refused the bare abbreviation; 18 of 24 locales now render it identically to `time.min`, so "compact" is achieved only in English.
- **`map.live_vehicle_count` = `{count} live`** elides the counted noun; languages with numeral agreement or classifiers must invent it. `trip_details.live_vehicle` states "vehicle" for the same concept.
- **Hardcoded colons** in `ServiceAlerts.svelte` / `FavoritesList.svelte` leave CJK with a halfwidth `:` and French without its required space.
- **Pre-existing translation errors found but left alone:** `am.json` renders `stop` as ቆሻሻ (*garbage*) and `vehicle.no_real_time_data` is garbled; `tl.json` `unit_imperial` = "Imperyalismo" (*imperialism*); `fa.json` same key = *empire*; `so.json` uses two different words for "route".

Two deliberate choices a reviewer might otherwise "fix":

- **`tl` `collapsed_stops` uses `one {# hintuan} other {# na hintuan}`.** CLDR `fil`'s `other` is a *linker* category, not a plural one — it fires for 4/6/9-ending numerals whose Filipino names end in a consonant and take `na`. Verified in the formatter: "3 hintuan" / "4 na hintuan".
- **`ht` and `sm` have no ICU plural data** and fall back to `en-US`; both correctly use identical branches since neither inflects after a numeral.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Localization**
  - Expanded translations across supported languages for trip planning, favorites, search, surveys, notifications, service alerts, stop details, maps, vehicles, and trip details.
  - Added localized labels for accessibility options, route preferences, departure and arrival controls, recent trips, errors, alert causes and effects, live vehicle counts, and compact time displays.
  - Improved language coverage for new and existing interface controls, including map, notification, and trip-detail states.
  - Corrected a Samoan trip-planner label while preserving existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->