### PR TITLE
fix(i18n): raw compass codes, English labels, browser-locale dates

### DIFF
--- a/src/components/favorites/FavoritesList.svelte
+++ b/src/components/favorites/FavoritesList.svelte
@@ -12,7 +12,7 @@
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 	import { faStar, faSignsPost, faTimes } from '@fortawesome/free-solid-svg-icons';
 	import { prioritizedRouteTypeForDisplay } from '$config/routeConfig';
-	import { removeAgencyPrefix } from '$lib/utils';
+	import { removeAgencyPrefix, stopSubtitle } from '$lib/utils';
 
 	let { onStopClick = null, onRouteClick = null, class: className = '' } = $props();
 
@@ -38,16 +38,7 @@
 
 	function itemSubtitle(item) {
 		if (item.type === 'stop') {
-			const parts = [];
-			if (item.direction) {
-				parts.push($t(`direction.${item.direction}`));
-			}
-			if (item.code) {
-				parts.push(`${$t('favorites.stop_code')}: ${item.code}`);
-			} else {
-				parts.push(`${$t('favorites.stop_code')}: ${removeAgencyPrefix(item.id)}`);
-			}
-			return parts.join(' · ');
+			return stopSubtitle(item, $t);
 		}
 		return item.description ?? '';
 	}

--- a/src/components/search/SearchPane.svelte
+++ b/src/components/search/SearchPane.svelte
@@ -13,7 +13,7 @@
 	import TripPlan from '$components/trip-planner/TripPlan.svelte';
 	import { isMapLoaded } from '$src/stores/mapStore';
 	import { answeredSurveys, surveyStore } from '$stores/surveyStore';
-	import { removeAgencyPrefix } from '$lib/utils';
+	import { removeAgencyPrefix, stopSubtitle } from '$lib/utils';
 	import { browser } from '$app/environment';
 	import { page } from '$app/stores';
 	import { parseTripParams, hasTripParams } from '$lib/urlState';
@@ -431,7 +431,7 @@
 							on:click={() => handleStopClick(stop)}
 							icon={faSignsPost}
 							title={stop.name}
-							subtitle={`${stop.direction ? $t(`direction.${stop.direction}`) : ''}; Code: ${stop.code}`}
+							subtitle={stopSubtitle(stop, $t)}
 						/>
 					{/each}
 				{/if}

--- a/src/components/service-alerts/ServiceAlertItem.svelte
+++ b/src/components/service-alerts/ServiceAlertItem.svelte
@@ -6,7 +6,7 @@
 		faCircleInfo,
 		faChevronRight
 	} from '@fortawesome/free-solid-svg-icons';
-	import { t } from 'svelte-i18n';
+	import { t, locale } from 'svelte-i18n';
 	import { env } from '$env/dynamic/public';
 	import {
 		normalizeSeverity,
@@ -42,7 +42,9 @@
 	let summaryText = $derived(
 		alert?.summary?.value || alert?.description?.value || $t('service_alerts.service_alert')
 	);
-	let activeLabel = $derived(formatActiveWindowLabel(activeWindowRange(alert), $t, regionTz));
+	let activeLabel = $derived(
+		formatActiveWindowLabel(activeWindowRange(alert), $t, regionTz, $locale)
+	);
 </script>
 
 <button

--- a/src/components/service-alerts/ServiceAlerts.svelte
+++ b/src/components/service-alerts/ServiceAlerts.svelte
@@ -7,7 +7,7 @@
 	import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 	import { Modal } from 'flowbite-svelte';
 	import ServiceAlertItem from './ServiceAlertItem.svelte';
-	import { t } from 'svelte-i18n';
+	import { t, locale } from 'svelte-i18n';
 	import { env } from '$env/dynamic/public';
 	import {
 		orderAlertsByRelevance,
@@ -47,7 +47,7 @@
 
 	let modalSeverity = $derived(modalAlert ? normalizeSeverity(modalAlert) : null);
 	let modalWindow = $derived(modalAlert ? activeWindowRange(modalAlert) : null);
-	let modalActiveLabel = $derived(formatActiveWindowLabel(modalWindow, $t, regionTz));
+	let modalActiveLabel = $derived(formatActiveWindowLabel(modalWindow, $t, regionTz, $locale));
 	let modalCause = $derived(modalAlert ? formatCauseLabel(modalAlert.reason, $t) : null);
 	let modalEffect = $derived(
 		modalAlert ? formatEffectLabel(modalAlert?.consequences?.[0]?.condition, $t) : null

--- a/src/components/service-alerts/__tests__/ServiceAlertItem.test.js
+++ b/src/components/service-alerts/__tests__/ServiceAlertItem.test.js
@@ -34,6 +34,12 @@ vi.mock('svelte-i18n', () => {
 				fn(translate);
 				return () => {};
 			}
+		},
+		locale: {
+			subscribe: (fn) => {
+				fn('en');
+				return () => {};
+			}
 		}
 	};
 });

--- a/src/components/service-alerts/serviceAlertsHelper.js
+++ b/src/components/service-alerts/serviceAlertsHelper.js
@@ -272,11 +272,13 @@ export function formatEffectLabel(effect, translate) {
  *
  * @param {number | null | undefined} ms
  * @param {string | undefined} timeZone
+ * @param {string | undefined} locale - the app's active locale; falls back to the
+ *   browser's when absent.
  * @returns {string | null}
  */
-function formatAlertDate(ms, timeZone) {
+function formatAlertDate(ms, timeZone, locale) {
 	if (!Number.isFinite(ms)) return null;
-	return new Intl.DateTimeFormat(undefined, {
+	return new Intl.DateTimeFormat(locale || undefined, {
 		month: 'short',
 		day: 'numeric',
 		hour: 'numeric',
@@ -292,12 +294,13 @@ function formatAlertDate(ms, timeZone) {
  * @param {{ from: number | null, to: number | null } | null | undefined} range
  * @param {(key: string, opts?: { values?: Record<string, string> }) => string} translate
  * @param {string | undefined} timeZone
+ * @param {string | undefined} locale
  * @returns {string | null}
  */
-export function formatActiveWindowLabel(range, translate, timeZone) {
+export function formatActiveWindowLabel(range, translate, timeZone, locale) {
 	if (!range) return null;
-	const from = formatAlertDate(range.from, timeZone);
-	const to = formatAlertDate(range.to, timeZone);
+	const from = formatAlertDate(range.from, timeZone, locale);
+	const to = formatAlertDate(range.to, timeZone, locale);
 	if (from && to) {
 		return translate('service_alerts.active_range', { values: { from, to } });
 	}

--- a/src/components/stops/StopBottomSheet.svelte
+++ b/src/components/stops/StopBottomSheet.svelte
@@ -24,7 +24,7 @@
 	import { keybinding } from '$lib/keybinding';
 	import '$lib/i18n.js';
 	import { isLoading, t } from 'svelte-i18n';
-	import { removeAgencyPrefix, routeShortNamesForStop } from '$lib/utils';
+	import { directionLabel, removeAgencyPrefix, routeShortNamesForStop } from '$lib/utils';
 
 	let {
 		stop,
@@ -44,13 +44,15 @@
 	let stopPaneLoading = $state(false);
 
 	let routeShortNames = $derived(routeShortNamesForStop(arrivalsAndDeparturesResponse, stop));
-	// "Stop #20170 · SW bound · C, 21, 116, 125" — direction and routes are both
-	// optional, so build the parts list and join only what's present.
+	// "Stop #20170 · Southwest bound · C, 21, 116, 125" — direction and routes are
+	// both optional, so build the parts list and join only what's present.
 	let subtitle = $derived(
 		[
 			`${$isLoading ? '' : $t('stop')} #${removeAgencyPrefix(stop.id)}`,
 			stop.direction && !$isLoading
-				? $t('direction_bound', { values: { direction: stop.direction } })
+				? $t('direction_bound', {
+						values: { direction: directionLabel(stop.direction, $t) }
+					})
 				: null,
 			routeShortNames?.length ? routeShortNames.join(', ') : null
 		]

--- a/src/components/stops/StopPageHeader.svelte
+++ b/src/components/stops/StopPageHeader.svelte
@@ -8,7 +8,7 @@
 	import { page } from '$app/stores';
 
 	import { t, isLoading } from 'svelte-i18n';
-	import { removeAgencyPrefix } from '$lib/utils';
+	import { removeAgencyPrefix, directionLabel } from '$lib/utils';
 	let {
 		stopName,
 		stopId,
@@ -58,7 +58,7 @@
 			<div class="rounded-md bg-gray-50 px-2 py-1">
 				<CompassArrow {stopDirection} />
 				<strong>{$isLoading ? '' : $t('schedule_for_stop.direction')}:</strong>
-				{stopDirection}
+				{directionLabel(stopDirection, $t) ?? ''}
 			</div>
 		</div>
 		<TabContainer>

--- a/src/components/stops/__tests__/StopBottomSheet.test.js
+++ b/src/components/stops/__tests__/StopBottomSheet.test.js
@@ -11,13 +11,23 @@ import {
 vi.mock('svelte-i18n', () => ({
 	t: {
 		subscribe: vi.fn((fn) => {
-			fn((key) => key);
+			// Echoes keys, except direction_bound, which mirrors its real en.json
+			// template so the assertion below can observe what {direction} resolved to.
+			fn((key, options) =>
+				key === 'direction_bound' ? `${options?.values?.direction} bound` : key
+			);
 			return { unsubscribe: () => {} };
 		})
 	},
 	isLoading: {
 		subscribe: vi.fn((fn) => {
 			fn(false);
+			return { unsubscribe: () => {} };
+		})
+	},
+	locale: {
+		subscribe: vi.fn((fn) => {
+			fn('en');
 			return { unsubscribe: () => {} };
 		})
 	}
@@ -47,8 +57,8 @@ describe('StopBottomSheet', () => {
 		expect(screen.getByText(mockStopData.name)).toBeInTheDocument();
 
 		await waitFor(() => {
-			// The i18n mock echoes keys, so the direction segment renders as its key.
-			expect(screen.getByText('stop #75403 · direction_bound · 10, 11')).toBeInTheDocument();
+			// "direction.N", not "N" -- the raw compass code must not reach the sentence.
+			expect(screen.getByText('stop #75403 · direction.N bound · 10, 11')).toBeInTheDocument();
 		});
 	});
 

--- a/src/components/stops/__tests__/StopPageHeader.test.js
+++ b/src/components/stops/__tests__/StopPageHeader.test.js
@@ -31,7 +31,10 @@ vi.mock('svelte-i18n', () => ({
 					'schedule_for_stop.route_schedules': 'Route Schedules',
 					'navigation.back_to_map': 'Back to Map',
 					'favorites.add': 'Add to favorites',
-					'favorites.remove': 'Remove from favorites'
+					'favorites.remove': 'Remove from favorites',
+					// The header must render these, not the raw "N"/"S" compass codes.
+					'direction.N': 'North',
+					'direction.S': 'South'
 				};
 				return translations[key] || key;
 			});
@@ -115,7 +118,7 @@ describe('StopPageHeader', () => {
 		render(StopPageHeader, { props: defaultProps });
 
 		expect(screen.getByText('Direction:')).toBeInTheDocument();
-		expect(screen.getByText('N')).toBeInTheDocument();
+		expect(screen.getByText('North')).toBeInTheDocument();
 	});
 
 	test('has proper header styling classes', () => {
@@ -206,7 +209,7 @@ describe('StopPageHeader', () => {
 		render(StopPageHeader, { props: propsWithSouthDirection });
 
 		expect(screen.getByText('Direction:')).toBeInTheDocument();
-		expect(screen.getByText('S')).toBeInTheDocument();
+		expect(screen.getByText('South')).toBeInTheDocument();
 	});
 
 	test('handles different stop IDs', () => {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -59,3 +59,39 @@ export function routeShortNamesForStop(arrivalsAndDeparturesResponse, stop) {
 			.sort()
 	);
 }
+
+/**
+ * Localizes a stop's compass direction code ("N", "SW", …) via the `direction.*`
+ * messages. OneBusAway is not guaranteed to return one of the eight codes those
+ * messages cover — CompassArrow already hides its arrow for anything else — so an
+ * unrecognized code falls back to itself rather than leaking the literal message
+ * id ("direction.FOO") into the UI.
+ *
+ * @param {string | null | undefined} direction - Compass code from the OBA stop
+ * @param {(id: string, options?: Object) => string} translate - svelte-i18n's `$t`
+ * @returns {string | null} The localized direction, or null when the stop has none
+ */
+export function directionLabel(direction, translate) {
+	if (!direction) {
+		return null;
+	}
+	return translate(`direction.${direction}`, { default: direction });
+}
+
+/**
+ * Builds the one-line subtitle shown under a stop's name wherever stops are
+ * listed (search results, favorites), so the two lists read identically.
+ * A stop with no code falls back to its id instead of showing "undefined".
+ *
+ * @param {Object} stop - Stop object with `direction`, `code` and `id`
+ * @param {(id: string, options?: Object) => string} translate - svelte-i18n's `$t`
+ * @returns {string} e.g. "Southwest · Code: 41242"
+ */
+export function stopSubtitle(stop, translate) {
+	return [
+		directionLabel(stop.direction, translate),
+		`${translate('favorites.stop_code')}: ${stop.code || removeAgencyPrefix(stop.id)}`
+	]
+		.filter(Boolean)
+		.join(' · ');
+}

--- a/src/locales/am.json
+++ b/src/locales/am.json
@@ -80,7 +80,7 @@
 		"remove_item": "ከተወዳጆች አስወግድ: {name}"
 	},
 	"search": {
-		"placeholder": "ቆሻሻዎችን፣ መንገዶችን እና ቦታዎችን ይፈልጉ",
+		"placeholder": "ማቆሚያዎችን፣ መንገዶችን እና ቦታዎችን ይፈልጉ",
 		"results_for": "የፍለጋ ውጤቶች ለ",
 		"clear_results": "ውጤቶችን አጥፋ",
 		"search": "ፈልግ",
@@ -153,7 +153,7 @@
 	"refresh": "አድስ",
 	"no_arrivals_found_in_next_minutes": "በሚቀጥሉት {minutes} ደቂቃዎች ውስጥ ምንም መድረሻ አልተገኘም",
 	"no_more_arrivals_in_next_minutes": "በሚቀጥሉት {minutes} ደቂቃዎች ውስጥ ምንም ተጨማሪ መድረሻ የለም",
-	"stop": "ቆሻሻ",
+	"stop": "ማቆሚያ",
 	"direction_bound": "ወደ {direction} አቅጣጫ",
 	"routes": "መንገዶች",
 	"route": "መንገድ",
@@ -173,11 +173,11 @@
 	"time": {
 		"ago": "በፊት",
 		"now": "አሁን",
-		"sec": "sec",
-		"secs": "secs",
-		"min": "min",
-		"mins": "mins",
-		"minutes": "minutes",
+		"sec": "ሰከንድ",
+		"secs": "ሰከንድ",
+		"min": "ደቂቃ",
+		"mins": "ደቂቃ",
+		"minutes": "ደቂቃ",
 		"min_compact": "{n} ደቂቃ"
 	},
 	"vehicle": {

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -173,11 +173,11 @@
 	"time": {
 		"ago": "منذ",
 		"now": "الآن",
-		"sec": "sec",
-		"secs": "secs",
-		"min": "min",
-		"mins": "mins",
-		"minutes": "minutes",
+		"sec": "ثانية",
+		"secs": "ثانية",
+		"min": "دقيقة",
+		"mins": "دقيقة",
+		"minutes": "دقيقة",
 		"min_compact": "{n} د"
 	},
 	"vehicle": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -176,7 +176,7 @@
 		"sec": "seg",
 		"secs": "segs",
 		"min": "min",
-		"mins": "mins",
+		"mins": "min",
 		"minutes": "minutos",
 		"min_compact": "{n} min"
 	},

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -52,7 +52,7 @@
 		"distance_unit": "واحد مسافت",
 		"unit_auto": "تشخیص خودکار",
 		"unit_metric": "متریک (کم، م)",
-		"unit_imperial": "امپراطوری (mi, ft)",
+		"unit_imperial": "امپریال (mi, ft)",
 		"swap_locations": "جابه‌جا کردن مبدأ و مقصد",
 		"error_code": "کد خطا",
 		"remove_recent_trip": "حذف سفر اخیر",

--- a/src/locales/ht.json
+++ b/src/locales/ht.json
@@ -52,7 +52,7 @@
 		"distance_unit": "Inite Distans",
 		"unit_auto": "Detekte otomatik",
 		"unit_metric": "Metrik (km, m)",
-		"unit_imperial": "Enperyyal (mi, ft)",
+		"unit_imperial": "Enperyal (mi, ft)",
 		"swap_locations": "Chanje plas Soti ak Ale",
 		"error_code": "Kòd erè",
 		"remove_recent_trip": "Retire vwayaj resan an",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -173,11 +173,11 @@
 	"time": {
 		"ago": "temu",
 		"now": "teraz",
-		"sec": "sec",
-		"secs": "secs",
+		"sec": "sek",
+		"secs": "sek",
 		"min": "min",
-		"mins": "mins",
-		"minutes": "minutes",
+		"mins": "min",
+		"minutes": "min",
 		"min_compact": "{n} min"
 	},
 	"vehicle": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -176,7 +176,7 @@
 		"sec": "seg",
 		"secs": "segs",
 		"min": "min",
-		"mins": "mins",
+		"mins": "min",
 		"minutes": "minutos",
 		"min_compact": "{n} min"
 	},

--- a/src/locales/so.json
+++ b/src/locales/so.json
@@ -173,11 +173,11 @@
 	"time": {
 		"ago": "hore",
 		"now": "hadda",
-		"sec": "sec",
-		"secs": "secs",
-		"min": "min",
-		"mins": "mins",
-		"minutes": "minutes",
+		"sec": "ilbiriqsi",
+		"secs": "ilbiriqsi",
+		"min": "daqiiqo",
+		"mins": "daqiiqo",
+		"minutes": "daqiiqo",
 		"min_compact": "{n} daq"
 	},
 	"vehicle": {

--- a/src/locales/tl.json
+++ b/src/locales/tl.json
@@ -52,7 +52,7 @@
 		"distance_unit": "Yunit ng Distansya",
 		"unit_auto": "Awtomatikong tukuyin",
 		"unit_metric": "Metriko (km, m)",
-		"unit_imperial": "Imperyalismo (mi, ft)",
+		"unit_imperial": "Imperyal (mi, ft)",
 		"swap_locations": "Ipagpalit ang mga lokasyong Mula sa at Patungo sa",
 		"error_code": "Code ng error",
 		"remove_recent_trip": "Alisin ang kamakailang biyahe",
@@ -173,11 +173,11 @@
 	"time": {
 		"ago": "nakaraan",
 		"now": "ngayon",
-		"sec": "sec",
-		"secs": "secs",
+		"sec": "seg",
+		"secs": "seg",
 		"min": "min",
-		"mins": "mins",
-		"minutes": "minutes",
+		"mins": "min",
+		"minutes": "minuto",
 		"min_compact": "{n} min"
 	},
 	"vehicle": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -173,11 +173,11 @@
 	"time": {
 		"ago": "trước",
 		"now": "bây giờ",
-		"sec": "sec",
-		"secs": "secs",
-		"min": "min",
-		"mins": "mins",
-		"minutes": "minutes",
+		"sec": "giây",
+		"secs": "giây",
+		"min": "phút",
+		"mins": "phút",
+		"minutes": "phút",
 		"min_compact": "{n} phút"
 	},
 	"vehicle": {

--- a/src/tests/lib/serviceAlerts.test.js
+++ b/src/tests/lib/serviceAlerts.test.js
@@ -310,4 +310,22 @@ describe('formatActiveWindowLabel', () => {
 		);
 		expect(label).toMatch(/^Until /);
 	});
+
+	it('formats the dates in the locale it is given', () => {
+		const range = { from: null, to: Date.UTC(2025, 1, 23, 15, 30) };
+		const english = formatActiveWindowLabel(range, translate, 'UTC', 'en');
+		const german = formatActiveWindowLabel(range, translate, 'UTC', 'de');
+
+		// en puts the month first and uses a 12-hour clock; de does neither. Matched
+		// loosely because ICU varies the separators (e.g. U+202F before PM) by version.
+		expect(english).toMatch(/^Until Feb 23, 3:30.PM$/);
+		expect(german).toMatch(/^Until 23\. Feb\.,? 15:30$/);
+	});
+
+	it('falls back to the runtime default locale when none is given', () => {
+		const range = { from: null, to: Date.UTC(2025, 1, 23, 15, 30) };
+		expect(formatActiveWindowLabel(range, translate, 'UTC')).toBe(
+			formatActiveWindowLabel(range, translate, 'UTC', undefined)
+		);
+	});
 });

--- a/src/tests/lib/utils.test.js
+++ b/src/tests/lib/utils.test.js
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { debounce, removeAgencyPrefix, routeShortNamesForStop } from '$lib/utils';
+import {
+	debounce,
+	directionLabel,
+	removeAgencyPrefix,
+	routeShortNamesForStop,
+	stopSubtitle
+} from '$lib/utils';
 
 describe('debounce', () => {
 	beforeEach(() => {
@@ -193,5 +199,46 @@ describe('routeShortNamesForStop', () => {
 
 		expect(routeShortNamesForStop(response, {})).toBe(null);
 		expect(routeShortNamesForStop(response, null)).toBe(null);
+	});
+});
+
+describe('directionLabel', () => {
+	// Stands in for svelte-i18n's $t: known ids resolve, unknown ones take the
+	// caller's `default` (and fall back to the id when there isn't one).
+	const translate = (id, options) =>
+		({ 'direction.N': 'North', 'direction.SW': 'Southwest' })[id] ?? options?.default ?? id;
+
+	it('translates the eight compass codes', () => {
+		expect(directionLabel('N', translate)).toBe('North');
+		expect(directionLabel('SW', translate)).toBe('Southwest');
+	});
+
+	it('returns null when the stop has no direction', () => {
+		expect(directionLabel(null, translate)).toBe(null);
+		expect(directionLabel(undefined, translate)).toBe(null);
+		expect(directionLabel('', translate)).toBe(null);
+	});
+
+	it('falls back to the raw code rather than leaking the message id', () => {
+		expect(directionLabel('NNW', translate)).toBe('NNW');
+	});
+});
+
+describe('stopSubtitle', () => {
+	const translate = (id, options) =>
+		({ 'direction.S': 'South', 'favorites.stop_code': 'Code' })[id] ?? options?.default ?? id;
+
+	it('joins the direction and the stop code', () => {
+		expect(stopSubtitle({ id: '1_75403', code: '75403', direction: 'S' }, translate)).toBe(
+			'South · Code: 75403'
+		);
+	});
+
+	it('omits the direction when the stop has none', () => {
+		expect(stopSubtitle({ id: '1_75403', code: '75403' }, translate)).toBe('Code: 75403');
+	});
+
+	it('falls back to the id without its agency prefix when the stop has no code', () => {
+		expect(stopSubtitle({ id: '1_75403', direction: 'S' }, translate)).toBe('South · Code: 75403');
 	});
 });


### PR DESCRIPTION
Follow-ups to #610. That PR brought all 24 locales to key parity; translating them surfaced defects the catalog could not fix from its own side.

## Summary

- **Direction codes reached the UI untranslated.** `StopBottomSheet`, `StopPageHeader`, `SearchPane` and `FavoritesList` each interpolated the raw OBA value, so a Spanish rider saw `Dirección: SE` while a fully translated `direction.*` block sat unused in every locale. All four now go through a shared `directionLabel()`.
- **`SearchPane` hardcoded the English word `Code:`** and joined with `; `, which also emitted a leading separator when a stop had no direction. It now shares `stopSubtitle()` with `FavoritesList`.
- **Alert dates used the browser's locale.** `formatActiveWindowLabel` built `Intl.DateTimeFormat(undefined, …)`, so the date rendered in the browser's language inside an otherwise translated sentence. It now takes the app locale.
- **Locale data corrections**, translated independently twice and adjudicated: `am` rendered *stop* as the word for **garbage** (visible on every stop sheet); `ht`/`tl`/`fa` had a wrong or typo'd `unit_imperial` — `tl` said "Imperyalismo", the political ideology; and `time.sec`/`secs`/`minutes` were untranslated English in several locales.

## Test plan

- [x] Browser, Spanish: `/stops/1_10240` renders "Dirección: **Sureste**" (was "Dirección: SE"); raw code absent from the page
- [x] Browser: search result and favorites entry both render "Sureste · **Código**: 10240" — identical, no `undefined`, no stray `;`
- [x] `formatActiveWindowLabel` formats per locale — `es` "12 mar, 9:30", `ja` "3月12日 9:30", `ar` "12 مارس، 9:30 ص"; `undefined` still falls back to browser default
- [x] Mutation-checked: reverting any of the three direction lookups fails the suite (these tests previously passed either way)
- [x] 24 locales still at 258/258 parity; 0 keys lost; exactly 35 intended value changes
- [x] `prettier --check`, `eslint`, and 1899/1899 tests pass

## Review notes

**An unknown compass code used to degrade better than it does now.** `direction.*` defines only the eight cardinals, and `CompassArrow` documents that other values can arrive. A naive lookup would render the message id (`direction.FOO`) — worse than the raw `FOO`. `directionLabel()` passes the code as `$t`'s `default`, so it degrades to itself. Covered by a test.

**Known gaps deliberately left out of scope**, each worth its own issue:

- `src/lib/dateTimeFormat.js` has the *same* browser-locale bug in `utcTimeFormat` / `localTimeFormat` / `fourDigitTimeFormat`, plus a hardcoded `hour12: true`. Those cover arrival, itinerary and schedule times — the most-viewed strings in the app. They are module-level singletons frozen at import, so fixing them means a factory plus threading `$locale` through six components: a different change with a different blast radius. **Alert dates are fixed here; arrival times are not.**
- The label colon is hardcoded ASCII in ~17 markup sites (`{$t(key)}:`). CJK wants `：`, French wants a narrow no-break space. This PR moves the *word* into the catalog but adds one more instance of the pattern; a punctuation-aware helper is the right fix.
- `service_alerts.close`, `service_alerts.more_info` and `trip-planner.itinerary` are dead keys — no literal references, and the only dynamic `service_alerts.*` construction uses `severity_`/`cause_`/`effect_` prefixes. Removing keys is a different risk profile from correcting them, so not done here.
- There is no i18n validator. A check for key parity, placeholder parity, and untranslated-English in non-Latin locales would have caught this PR's `time.*` gaps with zero false positives. It would **not** have caught `stop` = "garbage" or "Imperyalismo" — those are wrong translations, not missing ones, and need native review.

**Two translation choices flagged rather than settled:** `pl` `time.minutes` is `"min"` (Polish needs 1 *minuta* / 2–4 *minuty* / 5+ *minut*; no single string is right without ICU plurals, and `min` is never ungrammatical), and `es`/`pt` now mix invariant `min` with the pre-existing pluralized `segs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stop subtitles and direction labels are now consistently localized across search, favorites, and stop details.
  * Service-alert active-window dates now follow the selected language and regional date format.

* **Bug Fixes**
  * Corrected inaccurate or incomplete translations for time units, distance labels, and stop-related text across multiple languages.
  * Improved fallback formatting for stops without codes.

* **Tests**
  * Added coverage for localized directions, stop subtitles, and locale-aware service-alert dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->