### PR TITLE
fix(stops-for-location): send the longitude span as lonSpan

### DIFF
--- a/src/routes/api/oba/stops-for-location/+server.js
+++ b/src/routes/api/oba/stops-for-location/+server.js
@@ -13,7 +13,7 @@ export async function GET({ url }) {
 		lat: lat,
 		lon: lng,
 		latSpan: latSpan,
-		lngSpan: lngSpan,
+		lonSpan: lngSpan,
 		radius: radius
 	};
 

--- a/src/tests/api/stops-for-location.test.js
+++ b/src/tests/api/stops-for-location.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const listMock = vi.hoisted(() => vi.fn());
+
+vi.mock('$lib/obaSdk', () => ({
+	default: { stopsForLocation: { list: listMock } },
+	handleOBAResponse: (response) => new Response(JSON.stringify(response))
+}));
+
+vi.mock('$lib/agencyFilter.js', () => ({
+	getAgencyFilter: () => null,
+	filterStops: (stops) => stops
+}));
+
+import { GET } from '../../routes/api/oba/stops-for-location/+server.js';
+
+describe('GET /api/oba/stops-for-location', () => {
+	beforeEach(() => {
+		listMock.mockReset();
+		listMock.mockResolvedValue({ code: 200, data: { list: [] } });
+	});
+
+	// MapView sends lngSpan; the SDK's parameter is lonSpan, so forwarding the
+	// client's name unchanged drops the longitude span silently.
+	it('forwards the client lngSpan as the SDK lonSpan', async () => {
+		const url = new URL(
+			'http://localhost/api/oba/stops-for-location?lat=47.6&lng=-122.3&latSpan=0.02&lngSpan=0.05&radius=1500'
+		);
+
+		await GET({ url });
+
+		expect(listMock).toHaveBeenCalledTimes(1);
+		const params = listMock.mock.calls[0][0];
+		expect(params.lonSpan).toBe(0.05);
+		expect(params.lngSpan).toBeUndefined();
+	});
+});


### PR DESCRIPTION
### What this fixes

`/api/oba/stops-for-location` forwards the client's `lngSpan` straight through to the SDK ([+server.js#L8-L18](https://github.com/OneBusAway/wayfinder/blob/6c5adb0b8f04305cf209fcf2e6ea6a9dd36b4a52/src/routes/api/oba/stops-for-location/%2Bserver.js#L8-L18)):

```js
const lngSpan = +url.searchParams.get('lngSpan');
const queryParams = { lat, lon: lng, latSpan, lngSpan, radius };
```

The SDK's parameter is `lonSpan`, declared in `onebusaway-sdk/resources/stops-for-location.d.ts`:

```ts
latSpan?: number;
...
lonSpan?: number;
```

`lngSpan` is not a parameter it knows, so the longitude span was dropped and the request fell back to the default window.

### How it shows up

`MapView` sends a real span computed from the visible bounding box ([MapView.svelte#L192](https://github.com/OneBusAway/wayfinder/blob/6c5adb0b8f04305cf209fcf2e6ea6a9dd36b4a52/src/components/map/MapView.svelte#L192)):

```js
`/api/oba/stops-for-location?lat=${lat}&lng=${lng}&latSpan=${boundingBox.north - boundingBox.south}&lngSpan=${boundingBox.east - boundingBox.west}&radius=1500`
```

So on a wide viewport the east-west extent the user can see is wider than the window actually queried, and stops near the left and right edges are missing from the map.

The rest of the codebase already uses `lonSpan` (`serverCache.test.js`, `mathUtils.test.js`), which is what makes this one the outlier.

### Change

One line, keeping the existing `lng` to `lon` mapping style in the same object:

```js
lonSpan: lngSpan,
```

The client keeps sending `lngSpan`; only the name handed to the SDK changes.

### Test

New `src/tests/api/stops-for-location.test.js` asserts the SDK receives `lonSpan`. On unmodified develop:

```
× forwards the client lngSpan as the SDK lonSpan
  → expected undefined to be 0.05
```

Passes with the change. Prettier clean.

Unrelated note: `src/tests/lib/dateTimeFormat.test.js` fails locally for me on develop too, expecting `9:15 AM` where an `en-IN` locale renders `9:15 am`. Not touched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected location-based transit stop searches so longitude span parameters are properly handled, improving result accuracy.

- **Tests**
  - Added coverage to verify that longitude span requests are forwarded correctly to the transit service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->