### PR TITLE
feat(a11y): implement the combobox pattern on the trip-planner autocomplete

### DIFF
--- a/src/components/trip-planner/TripPlanSearchField.svelte
+++ b/src/components/trip-planner/TripPlanSearchField.svelte
@@ -24,16 +24,60 @@
 		onSelect
 	} = $props();
 
+	const listboxId = `${inputId}-listbox`;
+	const optionId = (index) => `${inputId}-option-${index}`;
+
+	// Which option aria-activedescendant points at. -1 means the user is on the
+	// input itself and Enter should submit whatever they typed.
+	let activeIndex = $state(-1);
+	// Escape hides the list without clearing the query. Typing brings it back.
+	let dismissed = $state(false);
+
+	let isOpen = $derived(!isLoading && !dismissed && results?.length > 0);
+	// The parent owns `results`, so it can shrink underneath a stale activeIndex.
+	let activeOption = $derived(isOpen && activeIndex < results.length ? activeIndex : -1);
+
 	function handleInput(event) {
+		activeIndex = -1;
+		dismissed = false;
 		onInput(event.target.value);
 	}
 
 	function handleClear() {
+		activeIndex = -1;
+		dismissed = false;
 		onClear();
 	}
 
 	function handleSelect(result) {
+		activeIndex = -1;
+		dismissed = false;
 		onSelect(result);
+	}
+
+	function handleKeydown(event) {
+		if (event.key === 'Escape') {
+			if (isOpen) {
+				event.preventDefault();
+				dismissed = true;
+				activeIndex = -1;
+			}
+			return;
+		}
+
+		if (!isOpen) return;
+
+		const last = results.length - 1;
+		if (event.key === 'ArrowDown') {
+			event.preventDefault();
+			activeIndex = activeOption >= last ? 0 : activeOption + 1;
+		} else if (event.key === 'ArrowUp') {
+			event.preventDefault();
+			activeIndex = activeOption <= 0 ? last : activeOption - 1;
+		} else if (event.key === 'Enter' && activeOption >= 0) {
+			event.preventDefault();
+			handleSelect(results[activeOption]);
+		}
 	}
 </script>
 
@@ -41,8 +85,14 @@
 	<input
 		id={inputId}
 		type="text"
+		role="combobox"
+		aria-expanded={isOpen}
+		aria-controls={isOpen ? listboxId : undefined}
+		aria-activedescendant={activeOption >= 0 ? optionId(activeOption) : undefined}
+		aria-autocomplete="list"
 		bind:value={place}
 		oninput={handleInput}
+		onkeydown={handleKeydown}
 		placeholder="{$t('trip-planner.search_for_a_place')}..."
 		class="block w-full rounded-md border-gray-300 pr-10 text-sm text-black shadow-sm focus:border-blue-500 focus:ring-blue-500"
 	/>
@@ -62,19 +112,28 @@
 		>
 			{$t('trip-planner.loading')}...
 		</p>
-	{:else if results && results.length > 0}
+	{:else if isOpen}
 		<ul
+			id={listboxId}
+			role="listbox"
 			class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md border border-gray-300 bg-white shadow-lg"
 		>
-			{#each results as result}
-				<li>
-					<button
-						class="flex w-full cursor-pointer items-center px-4 py-2 text-left hover:bg-gray-100 dark:text-black"
-						onclick={() => handleSelect(result)}
-					>
-						<FontAwesomeIcon icon={faMapMarkerAlt} class="mr-2 text-gray-400  " />
-						{result.displayText}
-					</button>
+			{#each results as result, index}
+				<!-- Options are deliberately not tab stops. In the combobox pattern focus
+				     stays on the input and the selection moves via aria-activedescendant,
+				     so the keyboard path lives in handleKeydown, not on each option. -->
+				<!-- svelte-ignore a11y_click_events_have_key_events -->
+				<li
+					id={optionId(index)}
+					role="option"
+					aria-selected={index === activeOption}
+					class="flex w-full cursor-pointer items-center px-4 py-2 text-left dark:text-black"
+					class:bg-gray-100={index === activeOption}
+					onclick={() => handleSelect(result)}
+					onmousemove={() => (activeIndex = index)}
+				>
+					<FontAwesomeIcon icon={faMapMarkerAlt} class="mr-2 text-gray-400" />
+					{result.displayText}
 				</li>
 			{/each}
 		</ul>

--- a/src/components/trip-planner/__tests__/TripPlanSearchField.test.js
+++ b/src/components/trip-planner/__tests__/TripPlanSearchField.test.js
@@ -149,7 +149,7 @@ describe('TripPlanSearchField', () => {
 			expect(mockOnSelect).toHaveBeenCalledWith(result);
 		});
 
-		it('result buttons are focusable', async () => {
+		it('keeps focus on the input while arrowing through options', async () => {
 			const results = [
 				{ displayText: 'Capitol Hill, Seattle, WA, USA', name: 'Capitol Hill' },
 				{ displayText: 'University District, Seattle, WA, USA', name: 'University District' }
@@ -157,22 +157,57 @@ describe('TripPlanSearchField', () => {
 			const props = { ...defaultProps, results };
 			render(TripPlanSearchField, { props });
 
-			const firstResult = screen.getByText('Capitol Hill, Seattle, WA, USA');
-			const secondResult = screen.getByText('University District, Seattle, WA, USA');
+			const input = screen.getByRole('combobox');
+			input.focus();
+			await user.keyboard('{ArrowDown}');
 
-			// Results should be focusable
-			expect(firstResult).toBeInTheDocument();
-			expect(secondResult).toBeInTheDocument();
+			// The combobox pattern moves the selection with aria-activedescendant
+			// rather than moving focus, so the input keeps it throughout.
+			expect(input).toHaveFocus();
+			expect(input).toHaveAttribute('aria-activedescendant', 'from-location-input-option-0');
 
-			// Should be able to focus on results
-			firstResult.focus();
-			expect(firstResult).toHaveFocus();
-
-			secondResult.focus();
-			expect(secondResult).toHaveFocus();
+			await user.keyboard('{ArrowDown}');
+			expect(input).toHaveFocus();
+			expect(input).toHaveAttribute('aria-activedescendant', 'from-location-input-option-1');
 		});
 
-		it('selects result with Enter key', async () => {
+		it('wraps around at both ends of the list', async () => {
+			const results = [
+				{ displayText: 'Capitol Hill, Seattle, WA, USA', name: 'Capitol Hill' },
+				{ displayText: 'University District, Seattle, WA, USA', name: 'University District' }
+			];
+			const props = { ...defaultProps, results };
+			render(TripPlanSearchField, { props });
+
+			const input = screen.getByRole('combobox');
+			input.focus();
+
+			// ArrowUp from the input jumps to the last option.
+			await user.keyboard('{ArrowUp}');
+			expect(input).toHaveAttribute('aria-activedescendant', 'from-location-input-option-1');
+
+			// And past the end it wraps back to the first.
+			await user.keyboard('{ArrowDown}');
+			expect(input).toHaveAttribute('aria-activedescendant', 'from-location-input-option-0');
+		});
+
+		it('closes the list on Escape without clearing the query', async () => {
+			const results = [{ displayText: 'Capitol Hill, Seattle, WA, USA', name: 'Capitol Hill' }];
+			const props = { ...defaultProps, place: 'Capitol', results };
+			render(TripPlanSearchField, { props });
+
+			const input = screen.getByRole('combobox');
+			expect(input).toHaveAttribute('aria-expanded', 'true');
+
+			input.focus();
+			await user.keyboard('{Escape}');
+
+			expect(input).toHaveAttribute('aria-expanded', 'false');
+			expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+			expect(input).toHaveValue('Capitol');
+		});
+
+		it('selects the active option with Enter key', async () => {
 			const result = {
 				displayText: 'Capitol Hill, Seattle, WA, USA',
 				name: 'Capitol Hill'
@@ -180,11 +215,27 @@ describe('TripPlanSearchField', () => {
 			const props = { ...defaultProps, results: [result] };
 			render(TripPlanSearchField, { props });
 
-			const resultButton = screen.getByText('Capitol Hill, Seattle, WA, USA');
-			resultButton.focus();
-			await user.keyboard('{Enter}');
+			const input = screen.getByRole('combobox');
+			input.focus();
+			await user.keyboard('{ArrowDown}{Enter}');
 
 			expect(mockOnSelect).toHaveBeenCalledWith(result);
+		});
+
+		it('does not select on Enter when no option is active', async () => {
+			const result = {
+				displayText: 'Capitol Hill, Seattle, WA, USA',
+				name: 'Capitol Hill'
+			};
+			const props = { ...defaultProps, results: [result] };
+			render(TripPlanSearchField, { props });
+
+			const input = screen.getByRole('combobox');
+			input.focus();
+			await user.keyboard('{Enter}');
+
+			// Enter belongs to the form until the user has arrowed into the list.
+			expect(mockOnSelect).not.toHaveBeenCalled();
 		});
 	});
 
@@ -207,13 +258,58 @@ describe('TripPlanSearchField', () => {
 			expect(clearButton).toHaveAttribute('type', 'button');
 		});
 
-		it('autocomplete results are keyboard accessible', () => {
+		it('options are not tab stops', () => {
 			const results = [{ displayText: 'Capitol Hill, Seattle, WA, USA', name: 'Capitol Hill' }];
 			const props = { ...defaultProps, results };
 			render(TripPlanSearchField, { props });
 
-			const resultButton = screen.getByText('Capitol Hill, Seattle, WA, USA');
-			expect(a11yHelpers.isFocusable(resultButton)).toBe(true);
+			// Options must stay out of the tab sequence: the combobox owns the
+			// keyboard and points at them with aria-activedescendant instead.
+			const option = screen.getByRole('option');
+			expect(option).not.toHaveAttribute('tabindex');
+			expect(a11yHelpers.isFocusable(option)).toBe(false);
+		});
+
+		it('wires the combobox to its listbox', async () => {
+			const results = [
+				{ displayText: 'Capitol Hill, Seattle, WA, USA', name: 'Capitol Hill' },
+				{ displayText: 'University District, Seattle, WA, USA', name: 'University District' }
+			];
+			const props = { ...defaultProps, results };
+			render(TripPlanSearchField, { props });
+
+			const input = screen.getByRole('combobox');
+			const listbox = screen.getByRole('listbox');
+
+			expect(input).toHaveAttribute('aria-autocomplete', 'list');
+			expect(input).toHaveAttribute('aria-expanded', 'true');
+			expect(input).toHaveAttribute('aria-controls', listbox.id);
+			expect(listbox.id).toBe('from-location-input-listbox');
+		});
+
+		it('reports collapsed state when there are no results', () => {
+			render(TripPlanSearchField, { props: defaultProps });
+
+			const input = screen.getByRole('combobox');
+			expect(input).toHaveAttribute('aria-expanded', 'false');
+			expect(input).not.toHaveAttribute('aria-activedescendant');
+		});
+
+		it('marks only the active option as selected', async () => {
+			const results = [
+				{ displayText: 'Capitol Hill, Seattle, WA, USA', name: 'Capitol Hill' },
+				{ displayText: 'University District, Seattle, WA, USA', name: 'University District' }
+			];
+			const props = { ...defaultProps, results };
+			render(TripPlanSearchField, { props });
+
+			const input = screen.getByRole('combobox');
+			input.focus();
+			await user.keyboard('{ArrowDown}');
+
+			const options = screen.getAllByRole('option');
+			expect(options[0]).toHaveAttribute('aria-selected', 'true');
+			expect(options[1]).toHaveAttribute('aria-selected', 'false');
 		});
 
 		it('has proper semantic structure', () => {
@@ -224,13 +320,12 @@ describe('TripPlanSearchField', () => {
 			const props = { ...defaultProps, results };
 			render(TripPlanSearchField, { props });
 
-			// Results should be in a list
-			const resultsList = screen.getByRole('list', { hidden: true });
-			expect(resultsList).toBeInTheDocument();
+			// Results live in a listbox, one option per result.
+			const listbox = screen.getByRole('listbox');
+			expect(listbox).toBeInTheDocument();
 
-			// Each result should be a button within the list
-			const resultButtons = screen.getAllByRole('button');
-			expect(resultButtons).toHaveLength(2); // Excluding clear button which is conditional
+			const options = screen.getAllByRole('option');
+			expect(options).toHaveLength(2);
 		});
 
 		it('supports screen readers with proper labeling', () => {
@@ -248,8 +343,7 @@ describe('TripPlanSearchField', () => {
 			const props = { ...defaultProps, results: [] };
 			render(TripPlanSearchField, { props });
 
-			const resultsList = screen.queryByRole('list', { hidden: true });
-			expect(resultsList).not.toBeInTheDocument();
+			expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
 		});
 
 		it('handles null/undefined results', () => {


### PR DESCRIPTION
Closes #527.

Follow-up to #517 / #525. #525 fixed the invalid HTML; this adds the pattern itself.

The location field rendered suggestions as a plain `ul` of buttons. A screen reader got no announcement that a list had appeared, no count and no position in it, and there was no keyboard path through the suggestions at all: reaching them meant tabbing out of the input and through each result in turn.

The input is now the combobox. It carries `aria-expanded`, `aria-controls`, `aria-activedescendant` and `aria-autocomplete="list"`, the `ul` is a `listbox` and each result an `option` with `aria-selected`. Arrow keys move the active option and wrap at both ends, Enter takes the active one, Escape hides the list without discarding what was typed, and hovering syncs the active option so pointer and keyboard agree.

**Four existing tests changed, so it is worth saying why.** They pinned the old behaviour: focus a result, press Enter on it, assert the results are focusable. The combobox pattern deliberately removes that. Options are not tab stops, focus stays on the input, and `aria-activedescendant` carries the position. Keeping those assertions would have meant keeping two competing keyboard models in one widget. Each one is rewritten against the new contract rather than deleted, and six more are added covering the wiring, the wrap-around at both ends, Escape, the collapsed state and `aria-selected`. That file goes from 24 tests to 30, all passing.

No new i18n keys. The listbox is reachable and announced through `aria-controls` from the already-labelled input, so adding a string here would have meant 25 locale files of debt for no behavioural gain.

Verification: `vitest` on the trip-planner suite is 84 passing across 7 files, `svelte-check` reports 0 errors and 0 warnings, and `prettier` plus `eslint` are clean. `src/tests/lib/dateTimeFormat.test.js` has 15 failures on my machine, but they reproduce identically on an unmodified `develop`, so they are pre-existing and timezone-dependent rather than anything here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added keyboard navigation for search suggestions, including arrow-key movement, wrapping, Enter selection, and Escape dismissal.
  - Improved autocomplete accessibility with combobox and listbox semantics.
  - Added active-option highlighting and selection behavior while keeping focus in the search field.

- **Tests**
  - Expanded coverage for keyboard interactions, accessibility attributes, selection behavior, and empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->