### PR TITLE
test: pin the vitest locale to en-US

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -40,7 +40,8 @@ export default defineConfig({
 		},
 		environment: 'jsdom',
 		env: {
-			TZ: 'UTC'
+			TZ: 'UTC',
+			LC_ALL: 'en_US.UTF-8'
 		},
 		setupFiles: ['./vitest-setup.js'],
 		globals: true


### PR DESCRIPTION
Closes #242

I kept running into this locally because my machine is on en_IN. The time formatters in dateTimeFormat.js create Intl.DateTimeFormat with an undefined locale, so they pick up whatever locale the machine has. On en_IN, 15 tests in dateTimeFormat.test.js fail with things like "9:15 am" instead of "9:15 AM". On en_US they all pass.

On #241 you said the fix should be in the test and not in the app code, so this only touches the vitest config. It sets LC_ALL to en_US.UTF-8 next to the TZ: 'UTC' that's already there. Vitest passes test.env to the forked workers when it starts them, so the locale is set before anything formats a time.

I ran the full suite (1899 tests) with LANG=en_IN, LC_ALL=en_IN, en_US and C.UTF-8, and it passes on all four. On develop the en_IN run fails 15.

convertUnixToTime from the issue isn't in the code anymore. I think it's the same am/pm failure though, it just shows up in these tests now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized the test environment’s locale to ensure consistent, reproducible test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->